### PR TITLE
Add a Dockerfile for building release images.

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -8,7 +8,7 @@ on:
     - master
 jobs:
   build:
-    name: Build
+    name: Unit Test
     runs-on: ubuntu-latest
     steps:
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.PHONY: build generate push-only push
+.PHONY: build release-build generate push-only push
 
-IMAGE_REGISTRY:=us.gcr.io
+IMAGE_REGISTRY:=docker.io
 IMAGE_TAG:=latest
 
-IMAGE:=planetscale-vitess/operator
+IMAGE:=planetscale/vitess-operator
 
 IMAGE_NAME:=$(IMAGE_REGISTRY)/$(IMAGE)
 
@@ -12,8 +12,15 @@ OPERATOR_SDK_VERSION:=v0.10.0
 # Enable Go modules
 export GO111MODULE=on
 
+# Regular operator-sdk build is good for development because it does the actual
+# build outside Docker, so it uses your cached modules.
 build:
 	operator-sdk-$(OPERATOR_SDK_VERSION) build $(IMAGE_NAME):$(IMAGE_TAG) --image-build-args '--no-cache'
+
+# Release build is slow but self-contained (doesn't depend on anything in your
+# local machine). We use this for automated builds that we publish.
+release-build:
+	docker build -f build/Dockerfile.release -t $(IMAGE_NAME):$(IMAGE_TAG) .
 
 generate:
 	operator-sdk-$(OPERATOR_SDK_VERSION) generate k8s

--- a/build/Dockerfile.release
+++ b/build/Dockerfile.release
@@ -1,0 +1,37 @@
+# This is a Dockerfile for building release images.
+#
+# The base Dockerfile is used by operator-sdk, so we can't use that name.
+# That Dockerfile merely copies a binary that has been built outside Docker,
+# which is useful for development work because it means the build shares the Go
+# module cache from your local machine.
+#
+# In contrast, this file builds the binary inside Docker so it's more
+# self-contained and doesn't require operator-sdk or external steps.
+# The downside is that there's no good way to share the local Go module cache
+# without messing up file permissions, since the Docker container doesn't run as
+# your actual user.
+
+FROM golang:1.12 AS build
+
+ENV GO111MODULE=on
+WORKDIR /go/src/planetscale.dev/vitess-operator
+COPY . /go/src/planetscale.dev/vitess-operator
+RUN go install /go/src/planetscale.dev/vitess-operator/cmd/manager
+
+# The rest is meant to mimic the output from operator-sdk's Dockerfile.
+# We just copy the binary we built inside Docker instead of from outside.
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+
+ENV OPERATOR=/usr/local/bin/vitess-operator \
+    USER_UID=1001 \
+    USER_NAME=vitess-operator
+
+# install operator binary
+COPY --from=build /go/bin/manager ${OPERATOR}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}


### PR DESCRIPTION
We can't change the default Dockerfile because operator-sdk expects it
to behave a certain way. Instead, we'll build releases from this new
Dockerfile.release.

This should let us use Docker Hub for #1.