### PR TITLE
Reconcile removed volumes and volume mounts.

### DIFF
--- a/pkg/operator/update/podspec.go
+++ b/pkg/operator/update/podspec.go
@@ -86,9 +86,6 @@ srcLoop:
 // admission webhooks, other controllers, or the API server.
 func Container(dst, src *corev1.Container) {
 	// Save fields that need to be recursively merged.
-	dstVolumeMounts := dst.VolumeMounts
-	VolumeMounts(&dstVolumeMounts, src.VolumeMounts)
-
 	dstResources := dst.Resources
 	ResourceRequirements(&dstResources, &src.Resources)
 
@@ -99,7 +96,6 @@ func Container(dst, src *corev1.Container) {
 	*dst = *src
 
 	// Restore saved fields.
-	dst.VolumeMounts = dstVolumeMounts
 	dst.Resources = dstResources
 	dst.SecurityContext = dstSecurityContext
 }

--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -111,6 +111,9 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 	// Deployment options.
 	obj.Spec.RevisionHistoryLimit = pointer.Int32Ptr(0)
 
+	// Reset the list of volumes in the template so we remove old ones.
+	obj.Spec.Template.Spec.Volumes = nil
+
 	// Apply user-provided flag overrides after generating base flags.
 	flags := spec.flags()
 	for key, value := range spec.ExtraFlags {


### PR DESCRIPTION
This ensures volumes that are moved/removed/renamed get reconciled. Previously, we would leave behind the old volumes/mounts because we thought they might have been placed there by admission controllers.

However, some limits on what changes we have to tolerate from admission controllers mean we can relax our tolerance for unwanted volumes in order to make renaming/removing volumes work properly:

1. We don't need to allow admission controllers to inject volumes into our Pod _templates_ (e.g. in Deployment) - only into actual Pods.
2. We don't need to allow admission controllers to inject volume mounts into our containers - they can only inject additional containers.

This fixes a problem introduced in #18 that would affect the ability to upgrade existing VitessClusters to a newer operator version. New clusters created from scratch after that PR would not be affected. The problem was that I renamed some volumes and moved some mount points, and without the fix in this PR, the old volume mounts were not being removed from existing Deployments like vtgate.