### PR TITLE
VitessShard Reconcile: Filter Cells by Responsibility.

### DIFF
--- a/pkg/apis/planetscale/v2/vitessshard_methods.go
+++ b/pkg/apis/planetscale/v2/vitessshard_methods.go
@@ -128,7 +128,7 @@ func (s *VitessShardSpec) BackupsEnabled() bool {
 	return false
 }
 
-// GetCells returns a filtered and de-duplicated list of all cells the current shard is responsible for.
+// GetCells returns a set of all cells the current shard is responsible for.
 func (s *VitessShardSpec) GetCells() sets.String {
 	cells := sets.String{}
 

--- a/pkg/apis/planetscale/v2/vitessshard_methods.go
+++ b/pkg/apis/planetscale/v2/vitessshard_methods.go
@@ -18,6 +18,7 @@ package v2
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // IsExternalMaster indicates whether the tablet is in a pool of type "externalmaster".
@@ -125,4 +126,15 @@ func (s *VitessShardSpec) BackupsEnabled() bool {
 		}
 	}
 	return false
+}
+
+// GetCells returns a filtered and de-duplicated list of all cells the current shard is responsible for.
+func (s *VitessShardSpec) GetCells() sets.String {
+	cells := sets.String{}
+
+	for i := range s.TabletPools {
+		cells.Insert(s.TabletPools[i].Cell)
+	}
+
+	return cells
 }

--- a/pkg/apis/planetscale/v2/vitessshard_methods.go
+++ b/pkg/apis/planetscale/v2/vitessshard_methods.go
@@ -128,7 +128,8 @@ func (s *VitessShardSpec) BackupsEnabled() bool {
 	return false
 }
 
-// GetCells returns a set of all cells the current shard is responsible for.
+// GetCells returns the set of all cells used by any tablet pools
+// defined in this VitessShardSpec.
 func (s *VitessShardSpec) GetCells() sets.String {
 	cells := sets.String{}
 

--- a/pkg/controller/vitessshardreplication/reconcile_drain.go
+++ b/pkg/controller/vitessshardreplication/reconcile_drain.go
@@ -117,7 +117,9 @@ func (r *ReconcileVitessShard) reconcileDrain(ctx context.Context, vts *planetsc
 		return resultBuilder.RequeueAfter(replicationRequeueDelay)
 	}
 
-	// Get all the tablet records for the shard.
+	// Get all the tablet records for the shard, in cells to which we deploy.
+	// We ignore tablets in cells we don't deploy, since we assume there's
+	// a separate operator instance handling drains on those tablets.
 	tablets, err := wr.TopoServer().GetTabletMapForShardByCell(ctx, keyspaceName, vts.Spec.Name, vts.Spec.GetCells().UnsortedList())
 	if err != nil {
 		r.recorder.Eventf(vts, corev1.EventTypeWarning, "TopoGetFailed", "failed to get tablet records: %v", err)

--- a/pkg/controller/vitessshardreplication/reconcile_drain.go
+++ b/pkg/controller/vitessshardreplication/reconcile_drain.go
@@ -118,7 +118,7 @@ func (r *ReconcileVitessShard) reconcileDrain(ctx context.Context, vts *planetsc
 	}
 
 	// Get all the tablet records for the shard.
-	tablets, err := wr.TopoServer().GetTabletMapForShard(ctx, keyspaceName, vts.Spec.Name)
+	tablets, err := wr.TopoServer().GetTabletMapForShardByCell(ctx, keyspaceName, vts.Spec.Name, vts.Spec.GetCells().UnsortedList())
 	if err != nil {
 		r.recorder.Eventf(vts, corev1.EventTypeWarning, "TopoGetFailed", "failed to get tablet records: %v", err)
 		return resultBuilder.RequeueAfter(replicationRequeueDelay)


### PR DESCRIPTION
This PR changes how we get a tablet map for a shard, by filtering the request by a list of cells. That list of cells is retrieved directly from the spec. Changing the way we pull for this info is early work in preparation for cross-region support, and ensures that shards only act on tablets they are directly responsible for.