### PR TITLE
Update Vitess version.

### DIFF
--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -88,7 +88,7 @@ const (
 	// DefaultMysqlPortName is the name for the MySQL port.
 	DefaultMysqlPortName = "mysql"
 
-	defaultVitessLiteImage = "us.gcr.io/planetscale-vitess/lite:2019-12-18.5644314d"
+	defaultVitessLiteImage = "us.gcr.io/planetscale-vitess/lite:2020-01-14.6b55d845"
 )
 
 /*

--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -204,9 +204,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 
 func (spec *Spec) flags() vitess.Flags {
 	return vitess.Flags{
-		"cell":     spec.Cell.Name,
-		"web_dir":  webDir,
-		"web_dir2": webDir2,
+		"cell": spec.Cell.Name,
 
 		"port":        planetscalev2.DefaultWebPort,
 		"grpc_port":   planetscalev2.DefaultGrpcPort,


### PR DESCRIPTION
This also stops setting two flags that were removed from upstream Vitess. If we don't stop setting these flags, vtctld crashes.