### PR TITLE
Match Vitess's default charset for 8.0-compatible MySQL flavors.

### DIFF
--- a/pkg/operator/vttablet/constants.go
+++ b/pkg/operator/vttablet/constants.go
@@ -68,7 +68,9 @@ const (
 
 	pvcVolumeName = "persistent-volume-claim"
 
-	dbConfigCharset       = "utf8"
+	defaultMySQL56Charset = "utf8"
+	defaultMySQL80Charset = "utf8mb4"
+
 	dbConfigAppUname      = "vt_app"
 	dbConfigDbaUname      = "vt_dba"
 	dbConfigReplUname     = "vt_repl"

--- a/pkg/operator/vttablet/datastore.go
+++ b/pkg/operator/vttablet/datastore.go
@@ -76,7 +76,7 @@ func datastoreFlags(spec *Spec) vitess.Flags {
 
 func localDatastoreFlags(spec *Spec) vitess.Flags {
 	return vitess.Flags{
-		"db_charset":               dbConfigCharset,
+		"db_charset":               spec.dbConfigCharset(),
 		"db-config-app-uname":      dbConfigAppUname,
 		"db-config-dba-uname":      dbConfigDbaUname,
 		"db-config-repl-uname":     dbConfigReplUname,

--- a/pkg/operator/vttablet/flags.go
+++ b/pkg/operator/vttablet/flags.go
@@ -88,7 +88,7 @@ func init() {
 			"tablet_uid":          spec.Alias.Uid,
 			"socket_file":         mysqlctlSocketPath,
 			"db-config-dba-uname": dbConfigDbaUname,
-			"db_charset":          dbConfigCharset,
+			"db_charset":          spec.dbConfigCharset(),
 			"init_db_sql_file":    dbInitScript.FilePath(),
 		}
 	})
@@ -119,7 +119,7 @@ func init() {
 			"init_db_name_override": spec.localDatabaseName(),
 
 			"db-config-dba-uname": dbConfigDbaUname,
-			"db_charset":          dbConfigCharset,
+			"db_charset":          spec.dbConfigCharset(),
 
 			"init_db_sql_file": dbInitScript.FilePath(),
 		}

--- a/pkg/operator/vttablet/spec.go
+++ b/pkg/operator/vttablet/spec.go
@@ -95,3 +95,15 @@ func (spec *Spec) myCnfFilePath() string {
 func (spec *Spec) mysqldUnixSocketPath() string {
 	return spec.tabletDir() + "/mysql.sock"
 }
+
+// dbConfigCharset returns the charset for vttablet's mysql connection pools.
+func (spec *Spec) dbConfigCharset() string {
+	// For flavors that we know are 8.0-compatible, use the new default charset
+	// that Vitess switched to for 8.0+.
+	if spec.Images.Mysqld != nil && spec.Images.Mysqld.Mysql80Compatible != "" {
+		return defaultMySQL80Charset
+	}
+
+	// For all others, use the old default that Vitess had since 5.6 until 8.0.
+	return defaultMySQL56Charset
+}


### PR DESCRIPTION
For 8.0+ flavors, Vitess uses utf8mb4 as the default charset. Previously, we were always using the old default of utf8.