### PR TITLE
Make TopoReconcileConfig Defaulting Code Public

### DIFF
--- a/pkg/apis/planetscale/v2/vitesscell_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesscell_defaults.go
@@ -26,7 +26,7 @@ import (
 func DefaultVitessCell(vtc *VitessCell) {
 	DefaultLocalLockserver(&vtc.Spec.Lockserver)
 	DefaultVitessGateway(&vtc.Spec.Gateway)
-	defaultTopoReconcileConfig(&vtc.Spec.TopologyReconciliation)
+	DefaultTopoReconcileConfig(&vtc.Spec.TopologyReconciliation)
 }
 
 func DefaultLocalLockserver(ls *LockserverSpec) {

--- a/pkg/apis/planetscale/v2/vitesscluster_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_defaults.go
@@ -29,7 +29,7 @@ func DefaultVitessCluster(vt *VitessCluster) {
 	DefaultVitessDashboard(&vt.Spec.VitessDashboard)
 	DefaultVitessKeyspaceTemplates(vt.Spec.Keyspaces)
 	defaultClusterBackup(vt.Spec.Backup)
-	defaultTopoReconcileConfig(&vt.Spec.TopologyReconciliation)
+	DefaultTopoReconcileConfig(&vt.Spec.TopologyReconciliation)
 }
 
 func defaultGlobalLockserver(vt *VitessCluster) {
@@ -110,7 +110,7 @@ func defaultClusterBackup(backup *ClusterBackupSpec) {
 	}
 }
 
-func defaultTopoReconcileConfig(confPtr **TopoReconcileConfig) {
+func DefaultTopoReconcileConfig(confPtr **TopoReconcileConfig) {
 	if *confPtr == nil {
 		*confPtr = &TopoReconcileConfig{}
 	}

--- a/pkg/apis/planetscale/v2/vitesskeyspace_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_defaults.go
@@ -21,7 +21,7 @@ package v2
 // and the defaulting code for a parent object may not have been run yet, meaning the values passed down from that parent
 // might not be safe to deref.
 func DefaultVitessKeyspace(dst *VitessKeyspace) {
-	defaultTopoReconcileConfig(&dst.Spec.TopologyReconciliation)
+	DefaultTopoReconcileConfig(&dst.Spec.TopologyReconciliation)
 }
 
 // DefaultVitessKeyspaceImages fills in unspecified keyspace-level images from cluster-level defaults.

--- a/pkg/apis/planetscale/v2/vitessshard_defaults.go
+++ b/pkg/apis/planetscale/v2/vitessshard_defaults.go
@@ -21,5 +21,5 @@ package v2
 // and the defaulting code for a parent object may not have been run yet, meaning the values passed down from that parent
 // might not be safe to deref.
 func DefaultVitessShard(dst *VitessShard) {
-	defaultTopoReconcileConfig(&dst.Spec.TopologyReconciliation)
+	DefaultTopoReconcileConfig(&dst.Spec.TopologyReconciliation)
 }


### PR DESCRIPTION
This PR makes the defaulting code for TopoReconcileConfig public so it can be used by other operators that might use this operator.