### PR TITLE
Only prune ShardCells for known/local cells.

### DIFF
--- a/pkg/apis/planetscale/v2/vitessshard_methods.go
+++ b/pkg/apis/planetscale/v2/vitessshard_methods.go
@@ -139,3 +139,15 @@ func (s *VitessShardSpec) GetCells() sets.String {
 
 	return cells
 }
+
+// CellInCluster returns whether the given cell name is defined in the
+// VitessCluster to which this shard ultimately belongs.
+func (s *VitessShardSpec) CellInCluster(cellName string) bool {
+	// The set of cells defined in the VitessCluster is ultimately passed down
+	// to each VitessShard in the form of a map from Vitess cell names to
+	// provider-specific zone names (even if zone names are left empty).
+	// Therefore the key exists in this map if and only if that cell name is
+	// defined in the VitessCluster.
+	_, inZoneMap := s.ZoneMap[cellName]
+	return inZoneMap
+}


### PR DESCRIPTION
This makes it safe to leave ShardCell pruning enabled in the case when multiple vitess-operator instances are combining to manage pieces of a multi-region Vitess cluster.

Each operator instance knows which Cells it should handle, so it can prune ShardCells corresponding to those Cells.