### PR TITLE
Refactor GlobalConnectionParams to Take Shared Types

### DIFF
--- a/pkg/controller/vitesscluster/reconcile_cells.go
+++ b/pkg/controller/vitesscluster/reconcile_cells.go
@@ -125,7 +125,7 @@ func newVitessCell(key client.ObjectKey, vt *planetscalev2.VitessCluster, parent
 		},
 		Spec: planetscalev2.VitessCellSpec{
 			VitessCellTemplate:     *template,
-			GlobalLockserver:       *lockserver.GlobalConnectionParams(vt),
+			GlobalLockserver:       *lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name),
 			AllCells:               allCells,
 			Images:                 images,
 			ExtraVitessFlags:       vt.Spec.ExtraVitessFlags,

--- a/pkg/controller/vitesscluster/reconcile_keyspaces.go
+++ b/pkg/controller/vitesscluster/reconcile_keyspaces.go
@@ -161,7 +161,7 @@ func newVitessKeyspace(key client.ObjectKey, vt *planetscalev2.VitessCluster, pa
 		},
 		Spec: planetscalev2.VitessKeyspaceSpec{
 			VitessKeyspaceTemplate: *template,
-			GlobalLockserver:       *lockserver.GlobalConnectionParams(vt),
+			GlobalLockserver:       *lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name),
 			Images:                 images,
 			ImagePullPolicies:      vt.Spec.ImagePullPolicies,
 			ZoneMap:                vt.Spec.ZoneMap(),

--- a/pkg/controller/vitesscluster/reconcile_topo.go
+++ b/pkg/controller/vitesscluster/reconcile_topo.go
@@ -52,7 +52,7 @@ func (r *ReconcileVitessCluster) reconcileTopology(ctx context.Context, vt *plan
 	defer cancel()
 
 	// Connect to the global lockserver.
-	globalParams := lockserver.GlobalConnectionParams(vt)
+	globalParams := lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name)
 	if globalParams == nil {
 		// This is an invalid config. There's no reason to request a retry. Just wait for the next mutation to trigger us.
 		r.recorder.Event(vt, corev1.EventTypeWarning, "TopoInvalid", "no global lockserver is defined")

--- a/pkg/controller/vitesscluster/reconcile_vtctld.go
+++ b/pkg/controller/vitesscluster/reconcile_vtctld.go
@@ -18,6 +18,7 @@ package vitesscluster
 
 import (
 	"context"
+
 	"planetscale.dev/vitess-operator/pkg/operator/update"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -133,7 +134,7 @@ func (r *ReconcileVitessCluster) vtctldSpecs(vt *planetscalev2.VitessCluster, pa
 		}
 	}
 
-	glsParams := lockserver.GlobalConnectionParams(vt)
+	glsParams := lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name)
 
 	// Make a vtctld Deployment spec for each cell.
 	specs := make([]*vtctld.Spec, 0, len(cells))

--- a/pkg/operator/lockserver/params.go
+++ b/pkg/operator/lockserver/params.go
@@ -33,15 +33,15 @@ const (
 
 // GlobalConnectionParams returns the Vitess connection parameters for a
 // VitessCluster's global lockserver.
-func GlobalConnectionParams(vt *planetscalev2.VitessCluster) *planetscalev2.VitessLockserverParams {
+func GlobalConnectionParams(lockSpec *planetscalev2.LockserverSpec, name string) *planetscalev2.VitessLockserverParams {
 	switch {
-	case vt.Spec.GlobalLockserver.External != nil:
-		return vt.Spec.GlobalLockserver.External
-	case vt.Spec.GlobalLockserver.Etcd != nil:
+	case lockSpec.External != nil:
+		return lockSpec.External
+	case lockSpec.Etcd != nil:
 		return &planetscalev2.VitessLockserverParams{
 			Implementation: VitessEtcdImplementationName,
-			Address:        fmt.Sprintf("%s-client:%d", GlobalEtcdName(vt.Name), EtcdClientPort),
-			RootPath:       fmt.Sprintf("/vitess/%s/global", vt.Name),
+			Address:        fmt.Sprintf("%s-client:%d", GlobalEtcdName(name), EtcdClientPort),
+			RootPath:       fmt.Sprintf("/vitess/%s/global", name),
 		}
 	default:
 		return nil
@@ -67,7 +67,7 @@ func LocalConnectionParams(vt *planetscalev2.VitessCluster, cell *planetscalev2.
 	default:
 		// No local lockserver was specified.
 		// Share the global lockserver with a cell-specific RootPath.
-		globalParams := GlobalConnectionParams(vt)
+		globalParams := GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name)
 		if globalParams == nil {
 			return nil
 		}

--- a/pkg/operator/lockserver/params.go
+++ b/pkg/operator/lockserver/params.go
@@ -33,15 +33,15 @@ const (
 
 // GlobalConnectionParams returns the Vitess connection parameters for a
 // VitessCluster's global lockserver.
-func GlobalConnectionParams(lockSpec *planetscalev2.LockserverSpec, name string) *planetscalev2.VitessLockserverParams {
+func GlobalConnectionParams(lockSpec *planetscalev2.LockserverSpec, clusterName string) *planetscalev2.VitessLockserverParams {
 	switch {
 	case lockSpec.External != nil:
 		return lockSpec.External
 	case lockSpec.Etcd != nil:
 		return &planetscalev2.VitessLockserverParams{
 			Implementation: VitessEtcdImplementationName,
-			Address:        fmt.Sprintf("%s-client:%d", GlobalEtcdName(name), EtcdClientPort),
-			RootPath:       fmt.Sprintf("/vitess/%s/global", name),
+			Address:        fmt.Sprintf("%s-client:%d", GlobalEtcdName(clusterName), EtcdClientPort),
+			RootPath:       fmt.Sprintf("/vitess/%s/global", clusterName),
 		}
 	default:
 		return nil


### PR DESCRIPTION
This PR refactors the `GlobalConnectionParams` function to take shared types. In PlanetScale's proprietary operator we have an analog to `VitessCluster` that extends the functionality of `VitessCluster`. Translating from the native parent type in that operator to a `VitessCluster` type just to use this helper function is expensive. To avoid code duplication I'm adjusting the helper method to take shared types rather than the entire root type of `VitessCluster`.