### PR TITLE
Make Conditions Access Safe

### DIFF
--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -363,6 +363,7 @@ func NewVitessShardStatus() VitessShardStatus {
 		HasMaster:        corev1.ConditionUnknown,
 		HasInitialBackup: corev1.ConditionUnknown,
 		Idle:             corev1.ConditionUnknown,
+		Conditions:       make(map[VitessShardConditionType]*VitessShardCondition),
 	}
 }
 

--- a/pkg/controller/vitessshard/vitessshard_controller.go
+++ b/pkg/controller/vitessshard/vitessshard_controller.go
@@ -172,7 +172,12 @@ func (r *ReconcileVitessShard) Reconcile(request reconcile.Request) (reconcile.R
 	oldStatus := vts.Status
 	vts.Status = planetscalev2.NewVitessShardStatus()
 	// Make sure we don't rinse old conditions - these states need to persist. They may have been added by some other controller.
-	vts.Status.Conditions = oldStatus.DeepCopyConditions()
+	// First check if conditions is nil - this would be true on first round, and allocate map if so.
+	if oldStatus.Conditions == nil {
+		vts.Status.Conditions = make(map[planetscalev2.VitessShardConditionType]*planetscalev2.VitessShardCondition)
+	} else {
+		vts.Status.Conditions = oldStatus.DeepCopyConditions()
+	}
 
 	// Create/update desired tablets.
 	tabletResult, err := r.reconcileTablets(ctx, vts)

--- a/pkg/controller/vitessshard/vitessshard_controller.go
+++ b/pkg/controller/vitessshard/vitessshard_controller.go
@@ -172,10 +172,8 @@ func (r *ReconcileVitessShard) Reconcile(request reconcile.Request) (reconcile.R
 	oldStatus := vts.Status
 	vts.Status = planetscalev2.NewVitessShardStatus()
 	// Make sure we don't rinse old conditions - these states need to persist. They may have been added by some other controller.
-	// First check if conditions is nil - this would be true on first round, and allocate map if so.
-	if oldStatus.Conditions == nil {
-		vts.Status.Conditions = make(map[planetscalev2.VitessShardConditionType]*planetscalev2.VitessShardCondition)
-	} else {
+	// Only persist if old condition is not nil, otherwise use the map allocated above when `NewVitessShardStatus()` was called.
+	if oldStatus.Conditions != nil {
 		vts.Status.Conditions = oldStatus.DeepCopyConditions()
 	}
 


### PR DESCRIPTION
I should have already done this in my previous PR where I introduced the `VitessShardCondition` type. We need to allocate a map for the Conditions field in the defaulting code so access is safe.

Note that the intended design is for consumers to be able to use the Conditions field (but no other part of the status object). This means that we might have a race condition where another controller tries to access the conditions before this controller has allocated a map for them.

That means that it's up to a consumer to nil check the conditions field before trying to access or modify conditions.

One idea I have for that, is that in any controller trying to use conditions, they must have a line such as this that happens before attempted access of conditions:

```go
	// Add empty condition map if condition map isn't there already.
	if vts.Status.Conditions == nil {
		vts.Status.Conditions = make(map[v2.VitessShardConditionType]*v2.VitessShardCondition)
	}
```

Thoughts on best practice for handling this in other controllers? Another strategy is that we force consumers to use methods on the status object itself. Those getters/setters could nil check the conditions field and allocate a new map if nil.