### PR TITLE
Increase default mysqld wait time.

### DIFF
--- a/pkg/operator/vttablet/constants.go
+++ b/pkg/operator/vttablet/constants.go
@@ -105,6 +105,12 @@ const (
 	xtrabackupStreamMode  = "xbstream"
 	xtrabackupStripeCount = 8
 	xtrabackupUser        = "vt_dba"
+
+	// mysqlctlWaitTime is how long mysqlctld will wait for mysqld to start up
+	// before assuming it's stuck and trying to restart it. We set this fairly
+	// high because it can take a while to do crash recovery and it's rarely
+	// productive to restart automatically.
+	mysqlctlWaitTime = 2 * time.Hour
 )
 
 var (

--- a/pkg/operator/vttablet/flags.go
+++ b/pkg/operator/vttablet/flags.go
@@ -90,6 +90,7 @@ func init() {
 			"db-config-dba-uname": dbConfigDbaUname,
 			"db_charset":          spec.dbConfigCharset(),
 			"init_db_sql_file":    dbInitScript.FilePath(),
+			"wait_time":           mysqlctlWaitTime,
 		}
 	})
 


### PR DESCRIPTION
The built-in default (5min) is not enough to do crash recovery on a real database.