### PR TITLE
Increase tablet Pod termination grace period.

### DIFF
--- a/pkg/operator/vttablet/constants.go
+++ b/pkg/operator/vttablet/constants.go
@@ -47,6 +47,13 @@ const (
 	fsGroup             = 999
 	healthCheckInterval = 5 * time.Second
 
+	// terminationGracePeriodSeconds is how long Kubernetes will wait for the
+	// tablet processes (vttablet, mysqlctld) to terminate gracefully after
+	// sending SIGTERM, before resorting to SIGKILL. We set this fairly high
+	// because mysqld needs time to flush buffers to disk in order to shut down
+	// cleanly.
+	terminationGracePeriodSeconds = 30 * 60 // 30min
+
 	grpcMaxMessageSize = 64 * 1024 * 1024 // 64 MiB
 
 	queryserverConfigMaxResultSize = 100000

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -272,6 +272,8 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 	}
 	obj.Spec.SecurityContext.FSGroup = pointer.Int64Ptr(fsGroup)
 
+	obj.Spec.TerminationGracePeriodSeconds = pointer.Int64Ptr(terminationGracePeriodSeconds)
+
 	// In both the case of the user injecting their own affinity and the default, we
 	// simply override the pod's existing affinity configuration.
 	if spec.Affinity != nil {


### PR DESCRIPTION
The default (30s) is not enough to allow buffers to flush on a real database.