### PR TITLE
Custom Condition Max Durations

### DIFF
--- a/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
@@ -589,6 +589,12 @@ spec:
                 - name
                 type: object
               type: array
+            conditionMaxDurations:
+              additionalProperties:
+                type: string
+              description: ConditionMaxDurations is an optional way to provide maximum
+                acceptable durations for various known VitessShardCondition types.
+              type: object
             extraVitessFlags:
               additionalProperties:
                 type: string

--- a/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
@@ -173,6 +173,11 @@ spec:
                     type: object
                 type: object
               type: array
+            conditionMaxDurations:
+              additionalProperties:
+                type: string
+              description: ConditionMaxDurations is inherited from the parent's VitessClusterSpec.
+              type: object
             extraVitessFlags:
               additionalProperties:
                 type: string

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -176,8 +176,7 @@ spec:
             conditionMaxDurations:
               additionalProperties:
                 type: string
-              description: ConditionMaxDurations is an optional way to provide maximum
-                acceptable durations for various known VitessShardCondition types.
+              description: ConditionMaxDurations is inherited from the parent's VitessClusterSpec.
               type: object
             databaseInitScriptSecret:
               description: DatabaseInitScriptSecret specifies the init_db.sql script

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -173,6 +173,12 @@ spec:
                     type: object
                 type: object
               type: array
+            conditionMaxDurations:
+              additionalProperties:
+                type: string
+              description: ConditionMaxDurations is an optional way to provide maximum
+                acceptable durations for various known VitessShardCondition types.
+              type: object
             databaseInitScriptSecret:
               description: DatabaseInitScriptSecret specifies the init_db.sql script
                 file to use for this shard. This SQL script file is executed immediately
@@ -323,12 +329,6 @@ spec:
                     or equal to Start in lexicographical order to be in the range.
                   pattern: ^([0-9a-f][0-9a-f])*$
                   type: string
-              type: object
-            maxConditionDurations:
-              additionalProperties:
-                type: string
-              description: MaxConditionDurations is an optional way to provide maximum
-                acceptable durations for various known VitessShardCondition types.
               type: object
             name:
               description: Name is the shard name as its known to Vitess.

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -324,6 +324,13 @@ spec:
                   pattern: ^([0-9a-f][0-9a-f])*$
                   type: string
               type: object
+            maxConditionDurations:
+              additionalProperties:
+                format: int64
+                type: integer
+              description: MaxConditionDurations is an optional way to provide maximum
+                acceptable durations for various known VitessShardCondition types.
+              type: object
             name:
               description: Name is the shard name as its known to Vitess.
               type: string

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -326,8 +326,7 @@ spec:
               type: object
             maxConditionDurations:
               additionalProperties:
-                format: int64
-                type: integer
+                type: string
               description: MaxConditionDurations is an optional way to provide maximum
                 acceptable durations for various known VitessShardCondition types.
               type: object

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4765,6 +4765,17 @@ TopoReconcileConfig
 <p>TopologyReconciliation is inherited from the parent&rsquo;s VitessClusterSpec.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>maxConditionDurations</code></br>
+<em>
+map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]time.Duration
+</em>
+</td>
+<td>
+<p>MaxConditionDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -5016,6 +5027,17 @@ TopoReconcileConfig
 </td>
 <td>
 <p>TopologyReconciliation is inherited from the parent&rsquo;s VitessClusterSpec.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxConditionDurations</code></br>
+<em>
+map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]time.Duration
+</em>
+</td>
+<td>
+<p>MaxConditionDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -420,6 +420,19 @@ TopoReconcileConfig
 <p>TopologyReconciliation can be used to enable or disable registration or pruning of various vitess components to and from topo records.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>conditionMaxDurations</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]k8s.io/apimachinery/pkg/apis/meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2883,6 +2896,19 @@ TopoReconcileConfig
 <p>TopologyReconciliation can be used to enable or disable registration or pruning of various vitess components to and from topo records.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>conditionMaxDurations</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]k8s.io/apimachinery/pkg/apis/meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.VitessClusterStatus">VitessClusterStatus
@@ -3779,6 +3805,19 @@ TopoReconcileConfig
 <p>TopologyReconciliation is inherited from the parent&rsquo;s VitessClusterSpec.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>conditionMaxDurations</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]k8s.io/apimachinery/pkg/apis/meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>ConditionMaxDurations is inherited from the parent&rsquo;s VitessClusterSpec.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -4293,6 +4332,19 @@ TopoReconcileConfig
 <p>TopologyReconciliation is inherited from the parent&rsquo;s VitessClusterSpec.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>conditionMaxDurations</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]k8s.io/apimachinery/pkg/apis/meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>ConditionMaxDurations is inherited from the parent&rsquo;s VitessClusterSpec.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.VitessKeyspaceStatus">VitessKeyspaceStatus
@@ -4775,7 +4827,7 @@ map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardCondition
 </em>
 </td>
 <td>
-<p>ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
+<p>ConditionMaxDurations is inherited from the parent&rsquo;s VitessClusterSpec.</p>
 </td>
 </tr>
 </table>
@@ -5041,7 +5093,7 @@ map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardCondition
 </em>
 </td>
 <td>
-<p>ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
+<p>ConditionMaxDurations is inherited from the parent&rsquo;s VitessClusterSpec.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4769,7 +4769,9 @@ TopoReconcileConfig
 <td>
 <code>maxConditionDurations</code></br>
 <em>
-map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]time.Duration
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]k8s.io/apimachinery/pkg/apis/meta/v1.Duration
+</a>
 </em>
 </td>
 <td>
@@ -5033,7 +5035,9 @@ TopoReconcileConfig
 <td>
 <code>maxConditionDurations</code></br>
 <em>
-map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]time.Duration
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]k8s.io/apimachinery/pkg/apis/meta/v1.Duration
+</a>
 </em>
 </td>
 <td>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4767,7 +4767,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>maxConditionDurations</code></br>
+<code>conditionMaxDurations</code></br>
 <em>
 <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
 map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]k8s.io/apimachinery/pkg/apis/meta/v1.Duration
@@ -4775,7 +4775,7 @@ map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardCondition
 </em>
 </td>
 <td>
-<p>MaxConditionDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
+<p>ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
 </td>
 </tr>
 </table>
@@ -5033,7 +5033,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>maxConditionDurations</code></br>
+<code>conditionMaxDurations</code></br>
 <em>
 <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
 map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]k8s.io/apimachinery/pkg/apis/meta/v1.Duration
@@ -5041,7 +5041,7 @@ map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardCondition
 </em>
 </td>
 <td>
-<p>MaxConditionDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
+<p>ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/planetscale/v2/vitesscluster_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_defaults.go
@@ -19,6 +19,7 @@ package v2
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
@@ -30,6 +31,7 @@ func DefaultVitessCluster(vt *VitessCluster) {
 	DefaultVitessKeyspaceTemplates(vt.Spec.Keyspaces)
 	defaultClusterBackup(vt.Spec.Backup)
 	DefaultTopoReconcileConfig(&vt.Spec.TopologyReconciliation)
+	defaultConditionMaxDurations(&vt.Spec)
 }
 
 func defaultGlobalLockserver(vt *VitessCluster) {
@@ -142,5 +144,11 @@ func DefaultTopoReconcileConfig(confPtr **TopoReconcileConfig) {
 	}
 	if conf.PruneSrvKeyspaces == nil {
 		conf.PruneSrvKeyspaces = pointer.BoolPtr(true)
+	}
+}
+
+func defaultConditionMaxDurations(vts *VitessClusterSpec) {
+	if vts.ConditionMaxDurations == nil {
+		vts.ConditionMaxDurations = make(map[VitessShardConditionType]metav1.Duration)
 	}
 }

--- a/pkg/apis/planetscale/v2/vitesscluster_types.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_types.go
@@ -110,6 +110,9 @@ type VitessClusterSpec struct {
 
 	// TopologyReconciliation can be used to enable or disable registration or pruning of various vitess components to and from topo records.
 	TopologyReconciliation *TopoReconcileConfig `json:"topologyReconciliation,omitempty"`
+
+	// ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.
+	ConditionMaxDurations map[VitessShardConditionType]metav1.Duration `json:"conditionMaxDurations,omitempty"`
 }
 
 // TopoReconcileConfig can be used to turn on or off registration or pruning of specific vitess components from topo records.

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -77,6 +77,9 @@ type VitessKeyspaceSpec struct {
 
 	// TopologyReconciliation is inherited from the parent's VitessClusterSpec.
 	TopologyReconciliation *TopoReconcileConfig `json:"topologyReconciliation,omitempty"`
+
+	// ConditionMaxDurations is inherited from the parent's VitessClusterSpec.
+	ConditionMaxDurations map[VitessShardConditionType]metav1.Duration `json:"conditionMaxDurations,omitempty"`
 }
 
 // VitessKeyspaceTemplate contains only the user-specified parts of a VitessKeyspace object.

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -87,7 +87,7 @@ type VitessShardSpec struct {
 	// TopologyReconciliation is inherited from the parent's VitessClusterSpec.
 	TopologyReconciliation *TopoReconcileConfig `json:"topologyReconciliation,omitempty"`
 
-	// ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.
+	// ConditionMaxDurations is inherited from the parent's VitessClusterSpec.
 	ConditionMaxDurations map[VitessShardConditionType]metav1.Duration `json:"conditionMaxDurations,omitempty"`
 }
 

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -341,8 +341,8 @@ type VitessShardStatus struct {
 // VitessShardConditionType and the value is a VitessShardCondition.
 type VitessShardConditionType string
 
-var (
-	ReadOnlyMasterConditionType VitessShardConditionType
+const (
+	ReadOnlyMasterConditionType VitessShardConditionType = "ReadOnlyMasterConditionType"
 )
 
 // VitessShardCondition contains details for the current condition of this VitessShard.

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v2
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -86,6 +88,9 @@ type VitessShardSpec struct {
 
 	// TopologyReconciliation is inherited from the parent's VitessClusterSpec.
 	TopologyReconciliation *TopoReconcileConfig `json:"topologyReconciliation,omitempty"`
+
+	// MaxConditionDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.
+	MaxConditionDurations map[VitessShardConditionType]time.Duration `json:"maxConditionDurations,omitempty"`
 }
 
 // VitessShardTemplate contains only the user-specified parts of a VitessShard object.
@@ -338,6 +343,10 @@ type VitessShardStatus struct {
 // VitessShardConditionType and the value is a VitessShardCondition.
 type VitessShardConditionType string
 
+var (
+	ReadOnlyMasterConditionType VitessShardConditionType
+)
+
 // VitessShardCondition contains details for the current condition of this VitessShard.
 type VitessShardCondition struct {
 	// Status is the status of the condition.
@@ -358,12 +367,13 @@ type VitessShardCondition struct {
 // NewVitessShardStatus creates a new status object with default values.
 func NewVitessShardStatus() VitessShardStatus {
 	return VitessShardStatus{
-		Tablets:          make(map[string]*VitessTabletStatus),
-		OrphanedTablets:  make(map[string]*OrphanStatus),
-		HasMaster:        corev1.ConditionUnknown,
-		HasInitialBackup: corev1.ConditionUnknown,
-		Idle:             corev1.ConditionUnknown,
-		Conditions:       make(map[VitessShardConditionType]*VitessShardCondition),
+		Tablets:            make(map[string]*VitessTabletStatus),
+		OrphanedTablets:    make(map[string]*OrphanStatus),
+		HasMaster:          corev1.ConditionUnknown,
+		HasInitialBackup:   corev1.ConditionUnknown,
+		Idle:               corev1.ConditionUnknown,
+		Conditions:         make(map[VitessShardConditionType]*VitessShardCondition),
+		ConditionDurations: make(map[VitessShardConditionType]time.Duration),
 	}
 }
 

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v2
 
 import (
-	"time"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -367,13 +365,12 @@ type VitessShardCondition struct {
 // NewVitessShardStatus creates a new status object with default values.
 func NewVitessShardStatus() VitessShardStatus {
 	return VitessShardStatus{
-		Tablets:            make(map[string]*VitessTabletStatus),
-		OrphanedTablets:    make(map[string]*OrphanStatus),
-		HasMaster:          corev1.ConditionUnknown,
-		HasInitialBackup:   corev1.ConditionUnknown,
-		Idle:               corev1.ConditionUnknown,
-		Conditions:         make(map[VitessShardConditionType]*VitessShardCondition),
-		ConditionDurations: make(map[VitessShardConditionType]time.Duration),
+		Tablets:          make(map[string]*VitessTabletStatus),
+		OrphanedTablets:  make(map[string]*OrphanStatus),
+		HasMaster:        corev1.ConditionUnknown,
+		HasInitialBackup: corev1.ConditionUnknown,
+		Idle:             corev1.ConditionUnknown,
+		Conditions:       make(map[VitessShardConditionType]*VitessShardCondition),
 	}
 }
 

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -90,7 +90,7 @@ type VitessShardSpec struct {
 	TopologyReconciliation *TopoReconcileConfig `json:"topologyReconciliation,omitempty"`
 
 	// MaxConditionDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.
-	MaxConditionDurations map[VitessShardConditionType]time.Duration `json:"maxConditionDurations,omitempty"`
+	MaxConditionDurations map[VitessShardConditionType]metav1.Duration `json:"maxConditionDurations,omitempty"`
 }
 
 // VitessShardTemplate contains only the user-specified parts of a VitessShard object.

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -87,8 +87,8 @@ type VitessShardSpec struct {
 	// TopologyReconciliation is inherited from the parent's VitessClusterSpec.
 	TopologyReconciliation *TopoReconcileConfig `json:"topologyReconciliation,omitempty"`
 
-	// MaxConditionDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.
-	MaxConditionDurations map[VitessShardConditionType]metav1.Duration `json:"maxConditionDurations,omitempty"`
+	// ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.
+	ConditionMaxDurations map[VitessShardConditionType]metav1.Duration `json:"maxConditionDurations,omitempty"`
 }
 
 // VitessShardTemplate contains only the user-specified parts of a VitessShard object.

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -88,7 +88,7 @@ type VitessShardSpec struct {
 	TopologyReconciliation *TopoReconcileConfig `json:"topologyReconciliation,omitempty"`
 
 	// ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.
-	ConditionMaxDurations map[VitessShardConditionType]metav1.Duration `json:"maxConditionDurations,omitempty"`
+	ConditionMaxDurations map[VitessShardConditionType]metav1.Duration `json:"conditionMaxDurations,omitempty"`
 }
 
 // VitessShardTemplate contains only the user-specified parts of a VitessShard object.

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -5,6 +5,8 @@
 package v2
 
 import (
+	time "time"
+
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -1843,6 +1845,13 @@ func (in *VitessShardSpec) DeepCopyInto(out *VitessShardSpec) {
 		in, out := &in.TopologyReconciliation, &out.TopologyReconciliation
 		*out = new(TopoReconcileConfig)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.MaxConditionDurations != nil {
+		in, out := &in.MaxConditionDurations, &out.MaxConditionDurations
+		*out = make(map[VitessShardConditionType]time.Duration, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	return
 }

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -1845,8 +1845,8 @@ func (in *VitessShardSpec) DeepCopyInto(out *VitessShardSpec) {
 		*out = new(TopoReconcileConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.MaxConditionDurations != nil {
-		in, out := &in.MaxConditionDurations, &out.MaxConditionDurations
+	if in.ConditionMaxDurations != nil {
+		in, out := &in.ConditionMaxDurations, &out.ConditionMaxDurations
 		*out = make(map[VitessShardConditionType]metav1.Duration, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -1068,6 +1068,13 @@ func (in *VitessClusterSpec) DeepCopyInto(out *VitessClusterSpec) {
 		*out = new(TopoReconcileConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ConditionMaxDurations != nil {
+		in, out := &in.ConditionMaxDurations, &out.ConditionMaxDurations
+		*out = make(map[VitessShardConditionType]metav1.Duration, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -1615,6 +1622,13 @@ func (in *VitessKeyspaceSpec) DeepCopyInto(out *VitessKeyspaceSpec) {
 		in, out := &in.TopologyReconciliation, &out.TopologyReconciliation
 		*out = new(TopoReconcileConfig)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.ConditionMaxDurations != nil {
+		in, out := &in.ConditionMaxDurations, &out.ConditionMaxDurations
+		*out = make(map[VitessShardConditionType]metav1.Duration, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	return
 }

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -5,9 +5,8 @@
 package v2
 
 import (
-	time "time"
-
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -1848,7 +1847,7 @@ func (in *VitessShardSpec) DeepCopyInto(out *VitessShardSpec) {
 	}
 	if in.MaxConditionDurations != nil {
 		in, out := &in.MaxConditionDurations, &out.MaxConditionDurations
-		*out = make(map[VitessShardConditionType]time.Duration, len(*in))
+		*out = make(map[VitessShardConditionType]metav1.Duration, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/pkg/apis/planetscale/v2/zz_generated.openapi.go
+++ b/pkg/apis/planetscale/v2/zz_generated.openapi.go
@@ -1260,7 +1260,7 @@ func schema_pkg_apis_planetscale_v2_VitessShardSpec(ref common.ReferenceCallback
 							Ref:         ref("planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig"),
 						},
 					},
-					"maxConditionDurations": {
+					"conditionMaxDurations": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.",
 							Type:        []string{"object"},

--- a/pkg/apis/planetscale/v2/zz_generated.openapi.go
+++ b/pkg/apis/planetscale/v2/zz_generated.openapi.go
@@ -1260,6 +1260,20 @@ func schema_pkg_apis_planetscale_v2_VitessShardSpec(ref common.ReferenceCallback
 							Ref:         ref("planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig"),
 						},
 					},
+					"maxConditionDurations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaxConditionDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"integer"},
+										Format: "int64",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"databaseInitScriptSecret", "name", "zoneMap", "images", "keyRange", "globalLockserver"},
 			},

--- a/pkg/apis/planetscale/v2/zz_generated.openapi.go
+++ b/pkg/apis/planetscale/v2/zz_generated.openapi.go
@@ -778,12 +778,25 @@ func schema_pkg_apis_planetscale_v2_VitessClusterSpec(ref common.ReferenceCallba
 							Ref:         ref("planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig"),
 						},
 					},
+					"conditionMaxDurations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"cells"},
 			},
 		},
 		Dependencies: []string{
-			"planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.ClusterBackupSpec", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.LockserverSpec", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessCellTemplate", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessDashboardSpec", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessImagePullPolicies", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessImages", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspaceTemplate"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.ClusterBackupSpec", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.LockserverSpec", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessCellTemplate", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessDashboardSpec", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessImagePullPolicies", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessImages", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspaceTemplate"},
 	}
 }
 
@@ -1027,12 +1040,25 @@ func schema_pkg_apis_planetscale_v2_VitessKeyspaceSpec(ref common.ReferenceCallb
 							Ref:         ref("planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig"),
 						},
 					},
+					"conditionMaxDurations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ConditionMaxDurations is inherited from the parent's VitessClusterSpec.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"name", "partitionings", "globalLockserver", "zoneMap"},
 			},
 		},
 		Dependencies: []string{
-			"planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessBackupLocation", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessImagePullPolicies", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspaceImages", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspacePartitioning", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessLockserverParams"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessBackupLocation", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessImagePullPolicies", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspaceImages", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspacePartitioning", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessLockserverParams"},
 	}
 }
 
@@ -1262,7 +1288,7 @@ func schema_pkg_apis_planetscale_v2_VitessShardSpec(ref common.ReferenceCallback
 					},
 					"conditionMaxDurations": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.",
+							Description: "ConditionMaxDurations is inherited from the parent's VitessClusterSpec.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{

--- a/pkg/apis/planetscale/v2/zz_generated.openapi.go
+++ b/pkg/apis/planetscale/v2/zz_generated.openapi.go
@@ -1267,8 +1267,7 @@ func schema_pkg_apis_planetscale_v2_VitessShardSpec(ref common.ReferenceCallback
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"integer"},
-										Format: "int64",
+										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 									},
 								},
 							},
@@ -1279,7 +1278,7 @@ func schema_pkg_apis_planetscale_v2_VitessShardSpec(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.SecretSource", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessBackupLocation", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessImagePullPolicies", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyRange", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspaceImages", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessLockserverParams", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessReplicationSpec", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardTabletPool"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.SecretSource", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.TopoReconcileConfig", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessBackupLocation", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessImagePullPolicies", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyRange", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspaceImages", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessLockserverParams", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessReplicationSpec", "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardTabletPool"},
 	}
 }
 

--- a/pkg/apis/planetscale/v2/zz_generated.openapi.go
+++ b/pkg/apis/planetscale/v2/zz_generated.openapi.go
@@ -1262,7 +1262,7 @@ func schema_pkg_apis_planetscale_v2_VitessShardSpec(ref common.ReferenceCallback
 					},
 					"maxConditionDurations": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxConditionDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.",
+							Description: "ConditionMaxDurations is an optional way to provide maximum acceptable durations for various known VitessShardCondition types.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{

--- a/pkg/controller/vitesscluster/reconcile_keyspaces.go
+++ b/pkg/controller/vitesscluster/reconcile_keyspaces.go
@@ -169,6 +169,7 @@ func newVitessKeyspace(key client.ObjectKey, vt *planetscalev2.VitessCluster, pa
 			BackupEngine:           backupEngine,
 			ExtraVitessFlags:       vt.Spec.ExtraVitessFlags,
 			TopologyReconciliation: vt.Spec.TopologyReconciliation,
+			ConditionMaxDurations:  vt.Spec.ConditionMaxDurations,
 		},
 	}
 }

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -141,7 +141,7 @@ func newVitessShard(key client.ObjectKey, vtk *planetscalev2.VitessKeyspace, par
 			BackupEngine:           vtk.Spec.BackupEngine,
 			ExtraVitessFlags:       vtk.Spec.ExtraVitessFlags,
 			TopologyReconciliation: vtk.Spec.TopologyReconciliation,
-			MaxConditionDurations:  make(map[planetscalev2.VitessShardConditionType]metav1.Duration),
+			ConditionMaxDurations:  make(map[planetscalev2.VitessShardConditionType]metav1.Duration),
 		},
 	}
 }

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -141,6 +141,7 @@ func newVitessShard(key client.ObjectKey, vtk *planetscalev2.VitessKeyspace, par
 			BackupEngine:           vtk.Spec.BackupEngine,
 			ExtraVitessFlags:       vtk.Spec.ExtraVitessFlags,
 			TopologyReconciliation: vtk.Spec.TopologyReconciliation,
+			MaxConditionDurations:  make(map[planetscalev2.VitessShardConditionType]metav1.Duration),
 		},
 	}
 }

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -141,7 +141,7 @@ func newVitessShard(key client.ObjectKey, vtk *planetscalev2.VitessKeyspace, par
 			BackupEngine:           vtk.Spec.BackupEngine,
 			ExtraVitessFlags:       vtk.Spec.ExtraVitessFlags,
 			TopologyReconciliation: vtk.Spec.TopologyReconciliation,
-			ConditionMaxDurations:  make(map[planetscalev2.VitessShardConditionType]metav1.Duration),
+			ConditionMaxDurations:  vtk.Spec.ConditionMaxDurations,
 		},
 	}
 }

--- a/pkg/controller/vitessshard/vitessshard_controller.go
+++ b/pkg/controller/vitessshard/vitessshard_controller.go
@@ -177,6 +177,8 @@ func (r *ReconcileVitessShard) Reconcile(request reconcile.Request) (reconcile.R
 		vts.Status.Conditions = oldStatus.DeepCopyConditions()
 	}
 
+	log.Infof("Conditions: %+v", vts.Status.Conditions)
+
 	// Create/update desired tablets.
 	tabletResult, err := r.reconcileTablets(ctx, vts)
 	resultBuilder.Merge(tabletResult, err)

--- a/pkg/controller/vitessshardreplication/repair_replication.go
+++ b/pkg/controller/vitessshardreplication/repair_replication.go
@@ -193,7 +193,7 @@ func (r *ReconcileVitessShard) canRepairReplication(ctx context.Context, vts *pl
 
 func masterRdOnlyShouldBeFixed(vts *planetscalev2.VitessShard) bool {
 	if maxDuration, exists := vts.Spec.MaxConditionDurations[planetscalev2.ReadOnlyMasterConditionType]; exists {
-		if vts.Status.Conditions[planetscalev2.ReadOnlyMasterConditionType].StatusDuration() < maxDuration {
+		if vts.Status.Conditions[planetscalev2.ReadOnlyMasterConditionType].StatusDuration() < maxDuration.Duration {
 			return false
 		}
 	}

--- a/pkg/controller/vitessshardreplication/repair_replication.go
+++ b/pkg/controller/vitessshardreplication/repair_replication.go
@@ -194,8 +194,8 @@ func (r *ReconcileVitessShard) canRepairReplication(ctx context.Context, vts *pl
 }
 
 func masterRdOnlyShouldBeFixed(vts *planetscalev2.VitessShard) bool {
-	rdOnlyCondition := vts.Status.Conditions[planetscalev2.ReadOnlyMasterConditionType]
-	if rdOnlyCondition.Status != corev1.ConditionTrue {
+	rdOnlyCondition, exists := vts.Status.Conditions[planetscalev2.ReadOnlyMasterConditionType]
+	if !exists || rdOnlyCondition.Status != corev1.ConditionTrue {
 		return false
 	}
 

--- a/pkg/controller/vitessshardreplication/repair_replication.go
+++ b/pkg/controller/vitessshardreplication/repair_replication.go
@@ -199,7 +199,7 @@ func masterRdOnlyShouldBeFixed(vts *planetscalev2.VitessShard) bool {
 		return false
 	}
 
-	if maxDuration, exists := vts.Spec.MaxConditionDurations[planetscalev2.ReadOnlyMasterConditionType]; exists {
+	if maxDuration, exists := vts.Spec.ConditionMaxDurations[planetscalev2.ReadOnlyMasterConditionType]; exists {
 		if rdOnlyCondition.StatusDuration() < maxDuration.Duration {
 			return false
 		}

--- a/pkg/controller/vitessshardreplication/repair_replication.go
+++ b/pkg/controller/vitessshardreplication/repair_replication.go
@@ -200,7 +200,6 @@ func masterRdOnlyShouldBeFixed(vts *planetscalev2.VitessShard) bool {
 	}
 
 	if maxDuration, exists := vts.Spec.MaxConditionDurations[planetscalev2.ReadOnlyMasterConditionType]; exists {
-		rdOnlyCondition := vts.Status.Conditions[planetscalev2.ReadOnlyMasterConditionType]
 		if rdOnlyCondition.StatusDuration() < maxDuration.Duration {
 			return false
 		}

--- a/pkg/controller/vitessshardreplication/repair_replication.go
+++ b/pkg/controller/vitessshardreplication/repair_replication.go
@@ -201,7 +201,7 @@ func masterRdOnlyShouldBeFixed(vts *planetscalev2.VitessShard) bool {
 
 	if maxDuration, exists := vts.Spec.MaxConditionDurations[planetscalev2.ReadOnlyMasterConditionType]; exists {
 		rdOnlyCondition := vts.Status.Conditions[planetscalev2.ReadOnlyMasterConditionType]
-		if rdOnlyCondition.Status != corev1.ConditionTrue || rdOnlyCondition.StatusDuration() < maxDuration.Duration {
+		if rdOnlyCondition.StatusDuration() < maxDuration.Duration {
 			return false
 		}
 	}


### PR DESCRIPTION
This PR adds an optional field for consumers to provide max durations for known `VitessShardConditionType`s. An example has been shown of checking for the existence of a max duration. The logic is that if there doesn't exist a max duration for a condition type, then we assume there is no max duration and we should always act immediately on repair. If a max duration is found, then we check that the conditions duration has exceeded the max duration before attempting to repair.