### PR TITLE
Made LocalConnectionParams Independent

### DIFF
--- a/pkg/controller/vitesscluster/reconcile_topo.go
+++ b/pkg/controller/vitesscluster/reconcile_topo.go
@@ -144,7 +144,7 @@ func (r *ReconcileVitessCluster) registerCells(ctx context.Context, vt *planetsc
 
 	// Create or update cell info for cells that should exist.
 	for name, cell := range desiredCells {
-		params := lockserver.LocalConnectionParams(cell, &vt.Spec.GlobalLockserver, vt.Name)
+		params := lockserver.LocalConnectionParams(&vt.Spec.GlobalLockserver, &cell.Lockserver, vt.Name, cell.Name)
 		if params == nil {
 			r.recorder.Eventf(vt, corev1.EventTypeWarning, "TopoInvalid", "no local lockserver is defined for cell %v", name)
 			continue

--- a/pkg/controller/vitesscluster/reconcile_topo.go
+++ b/pkg/controller/vitesscluster/reconcile_topo.go
@@ -144,7 +144,7 @@ func (r *ReconcileVitessCluster) registerCells(ctx context.Context, vt *planetsc
 
 	// Create or update cell info for cells that should exist.
 	for name, cell := range desiredCells {
-		params := lockserver.LocalConnectionParams(vt, cell)
+		params := lockserver.LocalConnectionParams(cell, &vt.Spec.GlobalLockserver, vt.Name)
 		if params == nil {
 			r.recorder.Eventf(vt, corev1.EventTypeWarning, "TopoInvalid", "no local lockserver is defined for cell %v", name)
 			continue

--- a/pkg/operator/lockserver/params.go
+++ b/pkg/operator/lockserver/params.go
@@ -50,9 +50,9 @@ func GlobalConnectionParams(lockSpec *planetscalev2.LockserverSpec, clusterName 
 
 // LocalConnectionParams returns the Vitess connection parameters for a
 // VitessCluster cell's local lockserver.
-func LocalConnectionParams(vt *planetscalev2.VitessCluster, cell *planetscalev2.VitessCellTemplate) *planetscalev2.VitessLockserverParams {
+func LocalConnectionParams(cell *planetscalev2.VitessCellTemplate, lockSpec *planetscalev2.LockserverSpec, clusterName string) *planetscalev2.VitessLockserverParams {
 	// The addition of "/local/" is important in case the cell name happens to be "global".
-	rootPath := fmt.Sprintf("/vitess/%s/local/%s", vt.Name, cell.Name)
+	rootPath := fmt.Sprintf("/vitess/%s/local/%s", clusterName, cell.Name)
 
 	switch {
 	case cell.Lockserver.External != nil:
@@ -61,13 +61,13 @@ func LocalConnectionParams(vt *planetscalev2.VitessCluster, cell *planetscalev2.
 		// Point to the client Service created by the local EtcdCluster.
 		return &planetscalev2.VitessLockserverParams{
 			Implementation: VitessEtcdImplementationName,
-			Address:        fmt.Sprintf("%s-client:%d", LocalEtcdName(vt.Name, cell.Name), EtcdClientPort),
+			Address:        fmt.Sprintf("%s-client:%d", LocalEtcdName(clusterName, cell.Name), EtcdClientPort),
 			RootPath:       rootPath,
 		}
 	default:
 		// No local lockserver was specified.
 		// Share the global lockserver with a cell-specific RootPath.
-		globalParams := GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name)
+		globalParams := GlobalConnectionParams(lockSpec, clusterName)
 		if globalParams == nil {
 			return nil
 		}

--- a/pkg/operator/lockserver/params.go
+++ b/pkg/operator/lockserver/params.go
@@ -50,24 +50,24 @@ func GlobalConnectionParams(lockSpec *planetscalev2.LockserverSpec, clusterName 
 
 // LocalConnectionParams returns the Vitess connection parameters for a
 // VitessCluster cell's local lockserver.
-func LocalConnectionParams(cell *planetscalev2.VitessCellTemplate, lockSpec *planetscalev2.LockserverSpec, clusterName string) *planetscalev2.VitessLockserverParams {
+func LocalConnectionParams(globalLockserverSpec, cellLockserverSpec *planetscalev2.LockserverSpec, clusterName, cellName string) *planetscalev2.VitessLockserverParams {
 	// The addition of "/local/" is important in case the cell name happens to be "global".
-	rootPath := fmt.Sprintf("/vitess/%s/local/%s", clusterName, cell.Name)
+	rootPath := fmt.Sprintf("/vitess/%s/local/%s", clusterName, cellName)
 
 	switch {
-	case cell.Lockserver.External != nil:
-		return cell.Lockserver.External
-	case cell.Lockserver.Etcd != nil:
+	case cellLockserverSpec.External != nil:
+		return cellLockserverSpec.External
+	case cellLockserverSpec.Etcd != nil:
 		// Point to the client Service created by the local EtcdCluster.
 		return &planetscalev2.VitessLockserverParams{
 			Implementation: VitessEtcdImplementationName,
-			Address:        fmt.Sprintf("%s-client:%d", LocalEtcdName(clusterName, cell.Name), EtcdClientPort),
+			Address:        fmt.Sprintf("%s-client:%d", LocalEtcdName(clusterName, cellName), EtcdClientPort),
 			RootPath:       rootPath,
 		}
 	default:
 		// No local lockserver was specified.
 		// Share the global lockserver with a cell-specific RootPath.
-		globalParams := GlobalConnectionParams(lockSpec, clusterName)
+		globalParams := GlobalConnectionParams(globalLockserverSpec, clusterName)
 		if globalParams == nil {
 			return nil
 		}


### PR DESCRIPTION
LocalConnectionParams was dependent on VT which made it difficult for other consumers to use this. This PR updates the input arguments to take commonly shared types so it's more usable by consumers.