### PR TITLE
Add workaround for init container bug.

### DIFF
--- a/pkg/operator/vttablet/mysqlctld.go
+++ b/pkg/operator/vttablet/mysqlctld.go
@@ -26,9 +26,9 @@ import (
 const (
 	vtRootInitScript = `set -ex
 mkdir -p /mnt/vt/bin
-cp /vt/bin/mysqlctld /mnt/vt/bin/
+cp --no-clobber /vt/bin/mysqlctld /mnt/vt/bin/
 mkdir -p /mnt/vt/config
-cp -R /vt/config/mycnf /mnt/vt/config/
+cp --no-clobber -R /vt/config/mycnf /mnt/vt/config/
 mkdir -p /mnt/vt/vtdataroot
 ln -sf /dev/stderr /mnt/vt/config/stderr.symlink
 echo "log-error = /vt/config/stderr.symlink" > /mnt/vt/config/mycnf/log-error.cnf`

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vttablet
 
 import (
-	"planetscale.dev/vitess-operator/pkg/operator/update"
 	"strconv"
 	"time"
 
@@ -28,18 +27,19 @@ import (
 
 	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
 	"planetscale.dev/vitess-operator/pkg/operator/names"
+	"planetscale.dev/vitess-operator/pkg/operator/update"
 )
 
 const (
 	vtbackupInitScript = `set -ex
 mkdir -p /mnt/vt/bin
-cp /vt/bin/vtbackup /mnt/vt/bin/
+cp --no-clobber /vt/bin/vtbackup /mnt/vt/bin/
 mkdir -p /mnt/vt/config
-cp -R /vt/config/mycnf /mnt/vt/config/
+cp --no-clobber -R /vt/config/mycnf /mnt/vt/config/
 ln -sf /dev/stderr /mnt/vt/config/stderr.symlink
 echo "log-error = /vt/config/stderr.symlink" > /mnt/vt/config/mycnf/log-error.cnf
 mkdir -p /mnt/vt/certs
-cp /etc/ssl/certs/ca-certificates.crt /mnt/vt/certs/`
+cp --no-clobber /etc/ssl/certs/ca-certificates.crt /mnt/vt/certs/`
 )
 
 // BackupSpec is the spec for a Backup Pod.


### PR DESCRIPTION
Init containers should only ever run before the main containers start.
However, Kubernetes relies on terminated Docker containers sticking
around in order to implement this guarantee. If something interferes
at the Docker level, Kubernetes may forget that the init container
already ran, and run it again while the main containers are already
running.

When this happens, our init-vt-root container would fail because it
tries to overwrite the binary of a running process. This adds a
workaround to skip the file copy if the file already exists, rather than
attempting to overwrite it.

This should prevent the vttablet Pod from entering Init:Error or
Init:CrashLoopBackOff after the main containers had already started.
However, unless the underlying Kubernetes bug is mitigated by stopping
whatever is interfering at the Docker level, Pods may still flap between
Running and Init status whenever the bug is triggered.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>