### PR TITLE
Make DeleteCells Idempotent

### DIFF
--- a/pkg/operator/vitesstopo/prune_cells.go
+++ b/pkg/operator/vitesstopo/prune_cells.go
@@ -80,7 +80,8 @@ func DeleteCells(ctx context.Context, ts *topo.Server, recorder record.EventReco
 	resultBuilder := &results.Builder{}
 
 	for _, cellName := range cellNames {
-		if err := ts.DeleteCellInfo(ctx, cellName); err != nil {
+		// topo.NoNode is the error type returned if we can't find the cell when deleting. This ensures that this operation is idempotent.
+		if err := ts.DeleteCellInfo(ctx, cellName); err != nil && !topo.IsErrType(err, topo.NoNode) {
 			recorder.Eventf(eventObj, corev1.EventTypeWarning, "TopoCleanupFailed", "unable to remove cell %s from topology: %v", cellName, err)
 			resultBuilder.RequeueAfter(topoRequeueDelay)
 		} else {

--- a/pkg/operator/vitesstopo/prune_cells.go
+++ b/pkg/operator/vitesstopo/prune_cells.go
@@ -84,7 +84,7 @@ func DeleteCells(ctx context.Context, ts *topo.Server, recorder record.EventReco
 		if err := ts.DeleteCellInfo(ctx, cellName); err != nil && !topo.IsErrType(err, topo.NoNode) {
 			recorder.Eventf(eventObj, corev1.EventTypeWarning, "TopoCleanupFailed", "unable to remove cell %s from topology: %v", cellName, err)
 			resultBuilder.RequeueAfter(topoRequeueDelay)
-		} else {
+		} else if err == nil {
 			recorder.Eventf(eventObj, corev1.EventTypeNormal, "TopoCleanup", "removed unwanted cell %s from topology", cellName)
 		}
 	}


### PR DESCRIPTION
Right now DeleteCells is not idempotent because ts.DeleteCellInfo may return a topo.NoNode error type in the case that the cell was not found while attempting to delete it. To ensure DeleteCells is idempotent, we should not treat "Not Found" as an error type, even if Vitess does.