### PR TITLE
etcdls: Add fields to help run etcd across Kubernetes clusters.

### DIFF
--- a/deploy/crds/planetscale_v2_etcdlockserver_crd.yaml
+++ b/deploy/crds/planetscale_v2_etcdlockserver_crd.yaml
@@ -31,6 +31,17 @@ spec:
           type: object
         spec:
           properties:
+            advertisePeerURLs:
+              description: 'AdvertisePeerURLs can optionally be used to override the
+                URLs that etcd members use to find each other for peer-to-peer connections.  If
+                specified, the list must contain exactly 3 entries, one for each etcd
+                member index (1,2,3) respectively.  Default: Build peer URLs automatically
+                based on Kubernetes built-in DNS.'
+              items:
+                type: string
+              maxItems: 3
+              minItems: 3
+              type: array
             affinity:
               description: 'Affinity allows you to set rules that constrain the scheduling
                 of your Etcd pods. WARNING: These affinity rules will override all
@@ -43,6 +54,21 @@ spec:
               description: Annotations can optionally be used to attach custom annotations
                 to Pods created for this component.
               type: object
+            createClientService:
+              description: 'CreateClientService sets whether to create a Service for
+                the client port of etcd member Pods.  Note: Disabling this will NOT
+                delete a Service that was previously created.  Default: true'
+              type: boolean
+            createPDB:
+              description: 'CreatePDB sets whether to create a PodDisruptionBudget
+                (PDB) for etcd member Pods.  Note: Disabling this will NOT delete
+                a PDB that was previously created.  Default: true'
+              type: boolean
+            createPeerService:
+              description: 'CreatePeerService sets whether to create a Service for
+                the peer port of etcd member Pods.  Note: Disabling this will NOT
+                delete a Service that was previously created.  Default: true'
+              type: boolean
             dataVolumeClaimTemplate:
               description: 'DataVolumeClaimTemplate configures the PersistentVolumeClaims
                 that will be created for each etcd instance to store its data files.
@@ -102,6 +128,17 @@ spec:
               items:
                 type: object
               type: array
+            localMemberIndex:
+              description: 'LocalMemberIndex can optionally be used to specify that
+                only one etcd member should actually be deployed. This can be used
+                to spread members across multiple Kubernetes clusters by configuring
+                the EtcdLockserver CRD in each cluster to deploy a different member
+                index. If specified, the index must be 1, 2, or 3.  Default: Deploy
+                all etcd members locally.'
+              format: int32
+              maximum: 3
+              minimum: 1
+              type: integer
             resources:
               description: 'Resources specify the compute resources to allocate for
                 each etcd member. Default: Let the operator choose.'

--- a/deploy/crds/planetscale_v2_vitesscell_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesscell_crd.yaml
@@ -347,6 +347,18 @@ spec:
                 etcd:
                   description: Etcd deploys our own etcd cluster as a lockserver.
                   properties:
+                    advertisePeerURLs:
+                      description: 'AdvertisePeerURLs can optionally be used to override
+                        the URLs that etcd members use to find each other for peer-to-peer
+                        connections.  If specified, the list must contain exactly
+                        3 entries, one for each etcd member index (1,2,3) respectively.  Default:
+                        Build peer URLs automatically based on Kubernetes built-in
+                        DNS.'
+                      items:
+                        type: string
+                      maxItems: 3
+                      minItems: 3
+                      type: array
                     affinity:
                       description: 'Affinity allows you to set rules that constrain
                         the scheduling of your Etcd pods. WARNING: These affinity
@@ -360,6 +372,23 @@ spec:
                       description: Annotations can optionally be used to attach custom
                         annotations to Pods created for this component.
                       type: object
+                    createClientService:
+                      description: 'CreateClientService sets whether to create a Service
+                        for the client port of etcd member Pods.  Note: Disabling
+                        this will NOT delete a Service that was previously created.  Default:
+                        true'
+                      type: boolean
+                    createPDB:
+                      description: 'CreatePDB sets whether to create a PodDisruptionBudget
+                        (PDB) for etcd member Pods.  Note: Disabling this will NOT
+                        delete a PDB that was previously created.  Default: true'
+                      type: boolean
+                    createPeerService:
+                      description: 'CreatePeerService sets whether to create a Service
+                        for the peer port of etcd member Pods.  Note: Disabling this
+                        will NOT delete a Service that was previously created.  Default:
+                        true'
+                      type: boolean
                     dataVolumeClaimTemplate:
                       description: 'DataVolumeClaimTemplate configures the PersistentVolumeClaims
                         that will be created for each etcd instance to store its data
@@ -424,6 +453,17 @@ spec:
                       items:
                         type: object
                       type: array
+                    localMemberIndex:
+                      description: 'LocalMemberIndex can optionally be used to specify
+                        that only one etcd member should actually be deployed. This
+                        can be used to spread members across multiple Kubernetes clusters
+                        by configuring the EtcdLockserver CRD in each cluster to deploy
+                        a different member index. If specified, the index must be
+                        1, 2, or 3.  Default: Deploy all etcd members locally.'
+                      format: int32
+                      maximum: 3
+                      minimum: 1
+                      type: integer
                     resources:
                       description: 'Resources specify the compute resources to allocate
                         for each etcd member. Default: Let the operator choose.'

--- a/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
@@ -537,6 +537,18 @@ spec:
                       etcd:
                         description: Etcd deploys our own etcd cluster as a lockserver.
                         properties:
+                          advertisePeerURLs:
+                            description: 'AdvertisePeerURLs can optionally be used
+                              to override the URLs that etcd members use to find each
+                              other for peer-to-peer connections.  If specified, the
+                              list must contain exactly 3 entries, one for each etcd
+                              member index (1,2,3) respectively.  Default: Build peer
+                              URLs automatically based on Kubernetes built-in DNS.'
+                            items:
+                              type: string
+                            maxItems: 3
+                            minItems: 3
+                            type: array
                           affinity:
                             description: 'Affinity allows you to set rules that constrain
                               the scheduling of your Etcd pods. WARNING: These affinity
@@ -550,6 +562,24 @@ spec:
                             description: Annotations can optionally be used to attach
                               custom annotations to Pods created for this component.
                             type: object
+                          createClientService:
+                            description: 'CreateClientService sets whether to create
+                              a Service for the client port of etcd member Pods.  Note:
+                              Disabling this will NOT delete a Service that was previously
+                              created.  Default: true'
+                            type: boolean
+                          createPDB:
+                            description: 'CreatePDB sets whether to create a PodDisruptionBudget
+                              (PDB) for etcd member Pods.  Note: Disabling this will
+                              NOT delete a PDB that was previously created.  Default:
+                              true'
+                            type: boolean
+                          createPeerService:
+                            description: 'CreatePeerService sets whether to create
+                              a Service for the peer port of etcd member Pods.  Note:
+                              Disabling this will NOT delete a Service that was previously
+                              created.  Default: true'
+                            type: boolean
                           dataVolumeClaimTemplate:
                             description: 'DataVolumeClaimTemplate configures the PersistentVolumeClaims
                               that will be created for each etcd instance to store
@@ -616,6 +646,18 @@ spec:
                             items:
                               type: object
                             type: array
+                          localMemberIndex:
+                            description: 'LocalMemberIndex can optionally be used
+                              to specify that only one etcd member should actually
+                              be deployed. This can be used to spread members across
+                              multiple Kubernetes clusters by configuring the EtcdLockserver
+                              CRD in each cluster to deploy a different member index.
+                              If specified, the index must be 1, 2, or 3.  Default:
+                              Deploy all etcd members locally.'
+                            format: int32
+                            maximum: 3
+                            minimum: 1
+                            type: integer
                           resources:
                             description: 'Resources specify the compute resources
                               to allocate for each etcd member. Default: Let the operator
@@ -685,6 +727,18 @@ spec:
                 etcd:
                   description: Etcd deploys our own etcd cluster as a lockserver.
                   properties:
+                    advertisePeerURLs:
+                      description: 'AdvertisePeerURLs can optionally be used to override
+                        the URLs that etcd members use to find each other for peer-to-peer
+                        connections.  If specified, the list must contain exactly
+                        3 entries, one for each etcd member index (1,2,3) respectively.  Default:
+                        Build peer URLs automatically based on Kubernetes built-in
+                        DNS.'
+                      items:
+                        type: string
+                      maxItems: 3
+                      minItems: 3
+                      type: array
                     affinity:
                       description: 'Affinity allows you to set rules that constrain
                         the scheduling of your Etcd pods. WARNING: These affinity
@@ -698,6 +752,23 @@ spec:
                       description: Annotations can optionally be used to attach custom
                         annotations to Pods created for this component.
                       type: object
+                    createClientService:
+                      description: 'CreateClientService sets whether to create a Service
+                        for the client port of etcd member Pods.  Note: Disabling
+                        this will NOT delete a Service that was previously created.  Default:
+                        true'
+                      type: boolean
+                    createPDB:
+                      description: 'CreatePDB sets whether to create a PodDisruptionBudget
+                        (PDB) for etcd member Pods.  Note: Disabling this will NOT
+                        delete a PDB that was previously created.  Default: true'
+                      type: boolean
+                    createPeerService:
+                      description: 'CreatePeerService sets whether to create a Service
+                        for the peer port of etcd member Pods.  Note: Disabling this
+                        will NOT delete a Service that was previously created.  Default:
+                        true'
+                      type: boolean
                     dataVolumeClaimTemplate:
                       description: 'DataVolumeClaimTemplate configures the PersistentVolumeClaims
                         that will be created for each etcd instance to store its data
@@ -762,6 +833,17 @@ spec:
                       items:
                         type: object
                       type: array
+                    localMemberIndex:
+                      description: 'LocalMemberIndex can optionally be used to specify
+                        that only one etcd member should actually be deployed. This
+                        can be used to spread members across multiple Kubernetes clusters
+                        by configuring the EtcdLockserver CRD in each cluster to deploy
+                        a different member index. If specified, the index must be
+                        1, 2, or 3.  Default: Deploy all etcd members locally.'
+                      format: int32
+                      maximum: 3
+                      minimum: 1
+                      type: integer
                     resources:
                       description: 'Resources specify the compute resources to allocate
                         for each etcd member. Default: Let the operator choose.'

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -862,6 +862,79 @@ map[string]string
 created for this component.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>createPDB</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>CreatePDB sets whether to create a PodDisruptionBudget (PDB) for etcd
+member Pods.</p>
+<p>Note: Disabling this will NOT delete a PDB that was previously created.</p>
+<p>Default: true</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>createClientService</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>CreateClientService sets whether to create a Service for the client port
+of etcd member Pods.</p>
+<p>Note: Disabling this will NOT delete a Service that was previously created.</p>
+<p>Default: true</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>createPeerService</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>CreatePeerService sets whether to create a Service for the peer port
+of etcd member Pods.</p>
+<p>Note: Disabling this will NOT delete a Service that was previously created.</p>
+<p>Default: true</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>advertisePeerURLs</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>AdvertisePeerURLs can optionally be used to override the URLs that etcd
+members use to find each other for peer-to-peer connections.</p>
+<p>If specified, the list must contain exactly 3 entries, one for each etcd
+member index (1,2,3) respectively.</p>
+<p>Default: Build peer URLs automatically based on Kubernetes built-in DNS.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>localMemberIndex</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>LocalMemberIndex can optionally be used to specify that only one etcd
+member should actually be deployed. This can be used to spread members
+across multiple Kubernetes clusters by configuring the EtcdLockserver CRD
+in each cluster to deploy a different member index. If specified, the
+index must be 1, 2, or 3.</p>
+<p>Default: Deploy all etcd members locally.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.ExternalDatastore">ExternalDatastore

--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -60,6 +60,9 @@ const (
 	defaultEtcdStorageRequestBytes = 1 * Gi
 	defaultEtcdCPUMillis           = 100
 	defaultEtcdMemoryBytes         = 256 * Mi
+	defaultEtcdCreatePDB           = true
+	defaultEtcdCreateClientService = true
+	defaultEtcdCreatePeerService   = true
 
 	defaultVtctldReplicas    = 1
 	defaultVtctldCPUMillis   = 100

--- a/pkg/apis/planetscale/v2/etcdlockserver_defaults.go
+++ b/pkg/apis/planetscale/v2/etcdlockserver_defaults.go
@@ -19,32 +19,50 @@ package v2
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/pointer"
 )
 
-func DefaultEtcdLockserverTemplate(etcd *EtcdLockserverTemplate) {
-	if etcd.Image == "" {
-		etcd.Image = defaultEtcdImage
+func DefaultEtcdLockserver(ls *EtcdLockserver) {
+	DefaultEtcdLockserverSpec(&ls.Spec)
+}
+
+func DefaultEtcdLockserverSpec(ls *EtcdLockserverSpec) {
+	DefaultEtcdLockserverTemplate(&ls.EtcdLockserverTemplate)
+}
+
+func DefaultEtcdLockserverTemplate(ls *EtcdLockserverTemplate) {
+	if ls.Image == "" {
+		ls.Image = defaultEtcdImage
 	}
-	if len(etcd.DataVolumeClaimTemplate.AccessModes) == 0 {
-		etcd.DataVolumeClaimTemplate.AccessModes = []corev1.PersistentVolumeAccessMode{
+	if len(ls.DataVolumeClaimTemplate.AccessModes) == 0 {
+		ls.DataVolumeClaimTemplate.AccessModes = []corev1.PersistentVolumeAccessMode{
 			corev1.ReadWriteOnce,
 		}
 	}
-	if _, isSet := etcd.DataVolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage]; !isSet {
-		if etcd.DataVolumeClaimTemplate.Resources.Requests == nil {
-			etcd.DataVolumeClaimTemplate.Resources.Requests = make(corev1.ResourceList)
+	if _, isSet := ls.DataVolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage]; !isSet {
+		if ls.DataVolumeClaimTemplate.Resources.Requests == nil {
+			ls.DataVolumeClaimTemplate.Resources.Requests = make(corev1.ResourceList)
 		}
-		etcd.DataVolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage] = *resource.NewQuantity(defaultEtcdStorageRequestBytes, resource.BinarySI)
+		ls.DataVolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage] = *resource.NewQuantity(defaultEtcdStorageRequestBytes, resource.BinarySI)
 	}
-	if len(etcd.Resources.Requests) == 0 {
-		etcd.Resources.Requests = corev1.ResourceList{
+	if len(ls.Resources.Requests) == 0 {
+		ls.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    *resource.NewMilliQuantity(defaultEtcdCPUMillis, resource.DecimalSI),
 			corev1.ResourceMemory: *resource.NewQuantity(defaultEtcdMemoryBytes, resource.BinarySI),
 		}
 	}
-	if len(etcd.Resources.Limits) == 0 {
-		etcd.Resources.Limits = corev1.ResourceList{
+	if len(ls.Resources.Limits) == 0 {
+		ls.Resources.Limits = corev1.ResourceList{
 			corev1.ResourceMemory: *resource.NewQuantity(defaultEtcdMemoryBytes, resource.BinarySI),
 		}
+	}
+	if ls.CreatePDB == nil {
+		ls.CreatePDB = pointer.BoolPtr(defaultEtcdCreatePDB)
+	}
+	if ls.CreateClientService == nil {
+		ls.CreateClientService = pointer.BoolPtr(defaultEtcdCreateClientService)
+	}
+	if ls.CreatePeerService == nil {
+		ls.CreatePeerService = pointer.BoolPtr(defaultEtcdCreatePeerService)
 	}
 }

--- a/pkg/apis/planetscale/v2/etcdlockserver_types.go
+++ b/pkg/apis/planetscale/v2/etcdlockserver_types.go
@@ -126,6 +126,52 @@ type EtcdLockserverTemplate struct {
 	// ExtraLabels can optionally be used to attach custom labels to Pods
 	// created for this component.
 	ExtraLabels map[string]string `json:"extraLabels,omitempty"`
+
+	// CreatePDB sets whether to create a PodDisruptionBudget (PDB) for etcd
+	// member Pods.
+	//
+	// Note: Disabling this will NOT delete a PDB that was previously created.
+	//
+	// Default: true
+	CreatePDB *bool `json:"createPDB,omitempty"`
+
+	// CreateClientService sets whether to create a Service for the client port
+	// of etcd member Pods.
+	//
+	// Note: Disabling this will NOT delete a Service that was previously created.
+	//
+	// Default: true
+	CreateClientService *bool `json:"createClientService,omitempty"`
+
+	// CreatePeerService sets whether to create a Service for the peer port
+	// of etcd member Pods.
+	//
+	// Note: Disabling this will NOT delete a Service that was previously created.
+	//
+	// Default: true
+	CreatePeerService *bool `json:"createPeerService,omitempty"`
+
+	// AdvertisePeerURLs can optionally be used to override the URLs that etcd
+	// members use to find each other for peer-to-peer connections.
+	//
+	// If specified, the list must contain exactly 3 entries, one for each etcd
+	// member index (1,2,3) respectively.
+	//
+	// Default: Build peer URLs automatically based on Kubernetes built-in DNS.
+	// +kubebuilder:validation:MinItems=3
+	// +kubebuilder:validation:MaxItems=3
+	AdvertisePeerURLs []string `json:"advertisePeerURLs,omitempty"`
+
+	// LocalMemberIndex can optionally be used to specify that only one etcd
+	// member should actually be deployed. This can be used to spread members
+	// across multiple Kubernetes clusters by configuring the EtcdLockserver CRD
+	// in each cluster to deploy a different member index. If specified, the
+	// index must be 1, 2, or 3.
+	//
+	// Default: Deploy all etcd members locally.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=3
+	LocalMemberIndex *int32 `json:"localMemberIndex,omitempty"`
 }
 
 // EtcdLockserverStatus defines the observed state of an EtcdLockserver.

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -202,6 +202,31 @@ func (in *EtcdLockserverTemplate) DeepCopyInto(out *EtcdLockserverTemplate) {
 			(*out)[key] = val
 		}
 	}
+	if in.CreatePDB != nil {
+		in, out := &in.CreatePDB, &out.CreatePDB
+		*out = new(bool)
+		**out = **in
+	}
+	if in.CreateClientService != nil {
+		in, out := &in.CreateClientService, &out.CreateClientService
+		*out = new(bool)
+		**out = **in
+	}
+	if in.CreatePeerService != nil {
+		in, out := &in.CreatePeerService, &out.CreatePeerService
+		*out = new(bool)
+		**out = **in
+	}
+	if in.AdvertisePeerURLs != nil {
+		in, out := &in.AdvertisePeerURLs, &out.AdvertisePeerURLs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.LocalMemberIndex != nil {
+		in, out := &in.LocalMemberIndex, &out.LocalMemberIndex
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/planetscale/v2/zz_generated.openapi.go
+++ b/pkg/apis/planetscale/v2/zz_generated.openapi.go
@@ -210,6 +210,48 @@ func schema_pkg_apis_planetscale_v2_EtcdLockserverSpec(ref common.ReferenceCallb
 							},
 						},
 					},
+					"createPDB": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CreatePDB sets whether to create a PodDisruptionBudget (PDB) for etcd member Pods.\n\nNote: Disabling this will NOT delete a PDB that was previously created.\n\nDefault: true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"createClientService": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CreateClientService sets whether to create a Service for the client port of etcd member Pods.\n\nNote: Disabling this will NOT delete a Service that was previously created.\n\nDefault: true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"createPeerService": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CreatePeerService sets whether to create a Service for the peer port of etcd member Pods.\n\nNote: Disabling this will NOT delete a Service that was previously created.\n\nDefault: true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"advertisePeerURLs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AdvertisePeerURLs can optionally be used to override the URLs that etcd members use to find each other for peer-to-peer connections.\n\nIf specified, the list must contain exactly 3 entries, one for each etcd member index (1,2,3) respectively.\n\nDefault: Build peer URLs automatically based on Kubernetes built-in DNS.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"localMemberIndex": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LocalMemberIndex can optionally be used to specify that only one etcd member should actually be deployed. This can be used to spread members across multiple Kubernetes clusters by configuring the EtcdLockserver CRD in each cluster to deploy a different member index. If specified, the index must be 1, 2, or 3.\n\nDefault: Deploy all etcd members locally.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"zone": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Zone is the name of the Availability Zone that this lockserver should run in. This value should match the value of the \"failure-domain.beta.kubernetes.io/zone\" label on the Kubernetes Nodes in that AZ. If the Kubernetes Nodes don't have such a label, leave this empty.",

--- a/pkg/controller/etcdlockserver/etcdlockserver_controller.go
+++ b/pkg/controller/etcdlockserver/etcdlockserver_controller.go
@@ -146,6 +146,9 @@ func (r *ReconcileEtcdLockserver) Reconcile(request reconcile.Request) (reconcil
 		return resultBuilder.Error(err)
 	}
 
+	// Materialize defaults.
+	planetscalev2.DefaultEtcdLockserver(ls)
+
 	// Reset status, since that's all out of date info that we will recompute now.
 	oldStatus := ls.Status
 	ls.Status = *planetscalev2.NewEtcdLockserverStatus()

--- a/pkg/controller/etcdlockserver/reconcile_pdb.go
+++ b/pkg/controller/etcdlockserver/reconcile_pdb.go
@@ -32,6 +32,11 @@ import (
 
 func (r *ReconcileEtcdLockserver) reconcilePodDisruptionBudget(ctx context.Context, ls *planetscalev2.EtcdLockserver) (reconcile.Result, error) {
 	resultBuilder := &results.Builder{}
+
+	if !*ls.Spec.CreatePDB {
+		return resultBuilder.Result()
+	}
+
 	lockserverName := ls.Name
 
 	labels := map[string]string{

--- a/pkg/controller/etcdlockserver/reconcile_services.go
+++ b/pkg/controller/etcdlockserver/reconcile_services.go
@@ -39,43 +39,47 @@ func (r *ReconcileEtcdLockserver) reconcileServices(ctx context.Context, ls *pla
 	}
 
 	// Reconcile the client Service.
-	clientSvcKey := client.ObjectKey{
-		Namespace: ls.Namespace,
-		Name:      etcd.ClientServiceName(lockserverName),
-	}
-	err := r.reconciler.ReconcileObject(ctx, ls, clientSvcKey, labels, true, reconciler.Strategy{
-		Kind: &corev1.Service{},
+	if *ls.Spec.CreateClientService {
+		clientSvcKey := client.ObjectKey{
+			Namespace: ls.Namespace,
+			Name:      etcd.ClientServiceName(lockserverName),
+		}
+		err := r.reconciler.ReconcileObject(ctx, ls, clientSvcKey, labels, true, reconciler.Strategy{
+			Kind: &corev1.Service{},
 
-		New: func(key client.ObjectKey) runtime.Object {
-			return etcd.NewClientService(key, labels)
-		},
-		UpdateInPlace: func(key client.ObjectKey, obj runtime.Object) {
-			curObj := obj.(*corev1.Service)
-			etcd.UpdateClientService(curObj, labels)
-		},
-	})
-	if err != nil {
-		resultBuilder.Error(err)
+			New: func(key client.ObjectKey) runtime.Object {
+				return etcd.NewClientService(key, labels)
+			},
+			UpdateInPlace: func(key client.ObjectKey, obj runtime.Object) {
+				curObj := obj.(*corev1.Service)
+				etcd.UpdateClientService(curObj, labels)
+			},
+		})
+		if err != nil {
+			resultBuilder.Error(err)
+		}
 	}
 
 	// Reconcile the peer Service.
-	peerSvcKey := client.ObjectKey{
-		Namespace: ls.Namespace,
-		Name:      etcd.PeerServiceName(lockserverName),
-	}
-	err = r.reconciler.ReconcileObject(ctx, ls, peerSvcKey, labels, true, reconciler.Strategy{
-		Kind: &corev1.Service{},
+	if *ls.Spec.CreatePeerService {
+		peerSvcKey := client.ObjectKey{
+			Namespace: ls.Namespace,
+			Name:      etcd.PeerServiceName(lockserverName),
+		}
+		err := r.reconciler.ReconcileObject(ctx, ls, peerSvcKey, labels, true, reconciler.Strategy{
+			Kind: &corev1.Service{},
 
-		New: func(key client.ObjectKey) runtime.Object {
-			return etcd.NewPeerService(key, labels)
-		},
-		UpdateInPlace: func(key client.ObjectKey, obj runtime.Object) {
-			curObj := obj.(*corev1.Service)
-			etcd.UpdatePeerService(curObj, labels)
-		},
-	})
-	if err != nil {
-		resultBuilder.Error(err)
+			New: func(key client.ObjectKey) runtime.Object {
+				return etcd.NewPeerService(key, labels)
+			},
+			UpdateInPlace: func(key client.ObjectKey, obj runtime.Object) {
+				curObj := obj.(*corev1.Service)
+				etcd.UpdatePeerService(curObj, labels)
+			},
+		})
+		if err != nil {
+			resultBuilder.Error(err)
+		}
 	}
 
 	return resultBuilder.Result()

--- a/pkg/controller/vitesscell/reconcile_etcd.go
+++ b/pkg/controller/vitesscell/reconcile_etcd.go
@@ -30,7 +30,10 @@ import (
 func (r *ReconcileVitessCell) reconcileLocalEtcd(ctx context.Context, vtc *planetscalev2.VitessCell) error {
 	clusterName := vtc.Labels[planetscalev2.ClusterLabel]
 
-	key := client.ObjectKey{Namespace: vtc.Namespace, Name: lockserver.LocalEtcdName(clusterName, vtc.Spec.Name)}
+	key := client.ObjectKey{
+		Namespace: vtc.Namespace,
+		Name:      lockserver.LocalEtcdName(clusterName, vtc.Spec.Name),
+	}
 	labels := map[string]string{
 		planetscalev2.ClusterLabel:   clusterName,
 		planetscalev2.CellLabel:      vtc.Spec.Name,

--- a/pkg/controller/vitesscluster/reconcile_etcd.go
+++ b/pkg/controller/vitesscluster/reconcile_etcd.go
@@ -28,7 +28,10 @@ import (
 )
 
 func (r *ReconcileVitessCluster) reconcileGlobalEtcd(ctx context.Context, vt *planetscalev2.VitessCluster) error {
-	key := client.ObjectKey{Namespace: vt.Namespace, Name: lockserver.GlobalEtcdName(vt.Name)}
+	key := client.ObjectKey{
+		Namespace: vt.Namespace,
+		Name:      lockserver.GlobalEtcdName(vt.Name),
+	}
 	labels := map[string]string{
 		planetscalev2.ClusterLabel:   vt.Name,
 		planetscalev2.ComponentLabel: planetscalev2.EtcdComponentName,

--- a/pkg/controller/vitessshard/reconcile_topo.go
+++ b/pkg/controller/vitessshard/reconcile_topo.go
@@ -115,6 +115,13 @@ func (r *ReconcileVitessShard) pruneTablets(ctx context.Context, vts *planetscal
 
 	// Clean up tablets that exist but shouldn't.
 	for name, tabletInfo := range tablets {
+		if !vts.Spec.CellInCluster(tabletInfo.Alias.GetCell()) {
+			// Skip tablets whose cell is not defined in the VitessCluster.
+			// We should only operate on cells we've been told to manage,
+			// since others might be externally managed.
+			continue
+		}
+
 		if vts.Status.Tablets[name] == nil && vts.Status.OrphanedTablets[name] == nil {
 			// The tablet exists in topo, but not in the VitessShard spec.
 			// It's also not being kept around by a blocked turn-down.

--- a/pkg/operator/etcd/service.go
+++ b/pkg/operator/etcd/service.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	clientPortName   = "client"
-	clientPortNumber = 2379
+	ClientPortName   = "client"
+	ClientPortNumber = 2379
 
-	peerPortName   = "peer"
-	peerPortNumber = 2380
+	PeerPortName   = "peer"
+	PeerPortNumber = 2380
 )
 
 // ClientServiceName returns the name of the etcd client Service.
@@ -65,10 +65,10 @@ func UpdateClientService(svc *corev1.Service, labels map[string]string) {
 	svc.Spec.Selector = labels
 	svc.Spec.Ports = []corev1.ServicePort{
 		{
-			Name:       clientPortName,
+			Name:       ClientPortName,
 			Protocol:   corev1.ProtocolTCP,
-			Port:       clientPortNumber,
-			TargetPort: intstr.FromString(clientPortName),
+			Port:       ClientPortNumber,
+			TargetPort: intstr.FromString(ClientPortName),
 		},
 	}
 }
@@ -104,10 +104,10 @@ func UpdatePeerService(svc *corev1.Service, labels map[string]string) {
 	svc.Spec.Selector = labels
 	svc.Spec.Ports = []corev1.ServicePort{
 		{
-			Name:       peerPortName,
+			Name:       PeerPortName,
 			Protocol:   corev1.ProtocolTCP,
-			Port:       peerPortNumber,
-			TargetPort: intstr.FromString(peerPortName),
+			Port:       PeerPortNumber,
+			TargetPort: intstr.FromString(PeerPortName),
 		},
 	}
 }

--- a/pkg/operator/names/join.go
+++ b/pkg/operator/names/join.go
@@ -53,13 +53,34 @@ causing confusion if they happen to contain the separator.
 func Join(parts ...string) string {
 	all := make([]string, 0, len(parts)+1)
 	all = append(all, parts...)
-	all = append(all, hash(parts))
+	all = append(all, Hash(parts))
 	return strings.Join(all, "-")
 }
 
-// hash computes a hash for the given parts.
-// DO NOT CHANGE THIS!
-func hash(parts []string) string {
+// JoinSalt works like Join except the appended hash includes additional,
+// hidden salt values that don't get concatenated onto the name itself.
+//
+// Unlike regular name components, hidden salt values don't have to consist
+// solely of characters that are valid in an object name. This can be used to
+// ensure generation of deterministic, unique names when some of the determining
+// input values are not safe to use in names.
+func JoinSalt(salt []string, parts ...string) string {
+	// Include both the salt and name parts in the hash.
+	hashParts := make([]string, 0, len(salt)+len(parts))
+	hashParts = append(hashParts, salt...)
+	hashParts = append(hashParts, parts...)
+
+	// Exclude salt from the name itself.
+	nameParts := make([]string, 0, len(parts)+1)
+	nameParts = append(nameParts, parts...)
+	nameParts = append(nameParts, Hash(hashParts))
+	return strings.Join(nameParts, "-")
+}
+
+// Hash computes a hash suffix for the given name parts.
+func Hash(parts []string) string {
+	// DO NOT CHANGE THIS!
+
 	h := md5.New()
 	for _, part := range parts {
 		h.Write([]byte(part))

--- a/pkg/operator/names/join_test.go
+++ b/pkg/operator/names/join_test.go
@@ -72,6 +72,23 @@ func TestJoin(t *testing.T) {
 	}
 }
 
+// TestJoinSalt checks that the salt affects the hash without appearing in the name.
+func TestJoinSalt(t *testing.T) {
+	salt := []string{"salt1", "salt2"}
+	parts := []string{"hello", "world"}
+	want := "hello-world-462f1b88"
+	if got := JoinSalt(salt, parts...); got != want {
+		t.Errorf("JoinSalt(%v, %v) = %q, want %q", salt, parts, got, want)
+	}
+
+	salt = []string{"salt1-salt2"}
+	parts = []string{"hello", "world"}
+	want = "hello-world-c65378ee"
+	if got := JoinSalt(salt, parts...); got != want {
+		t.Errorf("JoinSalt(%v, %v) = %q, want %q", salt, parts, got, want)
+	}
+}
+
 // TestJoinHash checks that nobody changed the hash function for Join.
 func TestJoinHash(t *testing.T) {
 	// DO NOT CHANGE THIS TEST!


### PR DESCRIPTION
These are some necessary but not sufficient changes to support running etcd across Kubernetes clusters with the EtcdLockserver controller.

These new fields allow you to:

- Disable PDB since it can't see Pods in other clusters.
- Disable Services since they need to be managed separately.
- Deploy only one etcd member in each cluster.
- Override peer URLs so they can find each other across clusters.