### PR TITLE
Allow disabling of the VitessShard initial backup job

### DIFF
--- a/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
@@ -1117,6 +1117,11 @@ spec:
                                           routine maintenance.  Default: Semi-sync
                                           is not enforced.'
                                         type: boolean
+                                      initializeBackup:
+                                        description: 'InitializeBackup specifies whether
+                                          to take an initial placeholder backup before
+                                          a real one is created.  Default: true.'
+                                        type: boolean
                                       initializeMaster:
                                         description: 'InitializeMaster specifies whether
                                           to choose an initial master for a new or
@@ -1548,6 +1553,11 @@ spec:
                                         than 3 master-eligible replicas, as that may
                                         lead to master unavailability during routine
                                         maintenance.  Default: Semi-sync is not enforced.'
+                                      type: boolean
+                                    initializeBackup:
+                                      description: 'InitializeBackup specifies whether
+                                        to take an initial placeholder backup before
+                                        a real one is created.  Default: true.'
                                       type: boolean
                                     initializeMaster:
                                       description: 'InitializeMaster specifies whether

--- a/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
@@ -1119,8 +1119,11 @@ spec:
                                         type: boolean
                                       initializeBackup:
                                         description: 'InitializeBackup specifies whether
-                                          to take an initial placeholder backup before
-                                          a real one is created.  Default: true.'
+                                          to take an initial placeholder backup as
+                                          part of preparing tablets to begin replication.
+                                          This only takes effect if a backup location
+                                          is defined in the VitessCluster.  Default:
+                                          true.'
                                         type: boolean
                                       initializeMaster:
                                         description: 'InitializeMaster specifies whether
@@ -1556,8 +1559,11 @@ spec:
                                       type: boolean
                                     initializeBackup:
                                       description: 'InitializeBackup specifies whether
-                                        to take an initial placeholder backup before
-                                        a real one is created.  Default: true.'
+                                        to take an initial placeholder backup as part
+                                        of preparing tablets to begin replication.
+                                        This only takes effect if a backup location
+                                        is defined in the VitessCluster.  Default:
+                                        true.'
                                       type: boolean
                                     initializeMaster:
                                       description: 'InitializeMaster specifies whether

--- a/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
@@ -478,6 +478,11 @@ spec:
                                     routine maintenance.  Default: Semi-sync is not
                                     enforced.'
                                   type: boolean
+                                initializeBackup:
+                                  description: 'InitializeBackup specifies whether
+                                    to take an initial placeholder backup before a
+                                    real one is created.  Default: true.'
+                                  type: boolean
                                 initializeMaster:
                                   description: 'InitializeMaster specifies whether
                                     to choose an initial master for a new or restored
@@ -873,6 +878,11 @@ spec:
                                   as that may lead to master unavailability during
                                   routine maintenance.  Default: Semi-sync is not
                                   enforced.'
+                                type: boolean
+                              initializeBackup:
+                                description: 'InitializeBackup specifies whether to
+                                  take an initial placeholder backup before a real
+                                  one is created.  Default: true.'
                                 type: boolean
                               initializeMaster:
                                 description: 'InitializeMaster specifies whether to

--- a/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
@@ -480,8 +480,10 @@ spec:
                                   type: boolean
                                 initializeBackup:
                                   description: 'InitializeBackup specifies whether
-                                    to take an initial placeholder backup before a
-                                    real one is created.  Default: true.'
+                                    to take an initial placeholder backup as part
+                                    of preparing tablets to begin replication. This
+                                    only takes effect if a backup location is defined
+                                    in the VitessCluster.  Default: true.'
                                   type: boolean
                                 initializeMaster:
                                   description: 'InitializeMaster specifies whether
@@ -881,8 +883,10 @@ spec:
                                 type: boolean
                               initializeBackup:
                                 description: 'InitializeBackup specifies whether to
-                                  take an initial placeholder backup before a real
-                                  one is created.  Default: true.'
+                                  take an initial placeholder backup as part of preparing
+                                  tablets to begin replication. This only takes effect
+                                  if a backup location is defined in the VitessCluster.  Default:
+                                  true.'
                                 type: boolean
                               initializeMaster:
                                 description: 'InitializeMaster specifies whether to

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -414,7 +414,9 @@ spec:
                   type: boolean
                 initializeBackup:
                   description: 'InitializeBackup specifies whether to take an initial
-                    placeholder backup before a real one is created.  Default: true.'
+                    placeholder backup as part of preparing tablets to begin replication.
+                    This only takes effect if a backup location is defined in the
+                    VitessCluster.  Default: true.'
                   type: boolean
                 initializeMaster:
                   description: 'InitializeMaster specifies whether to choose an initial

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -412,6 +412,10 @@ spec:
                     than 3 master-eligible replicas, as that may lead to master unavailability
                     during routine maintenance.  Default: Semi-sync is not enforced.'
                   type: boolean
+                initializeBackup:
+                  description: 'InitializeBackup specifies whether to take an initial
+                    placeholder backup before a real one is created.  Default: true.'
+                  type: boolean
                 initializeMaster:
                   description: 'InitializeMaster specifies whether to choose an initial
                     master for a new or restored shard that has no master yet.  Default:

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4787,7 +4787,9 @@ bool
 </em>
 </td>
 <td>
-<p>InitializeBackup specifies whether to take an initial placeholder backup before a real one is created.</p>
+<p>InitializeBackup specifies whether to take an initial placeholder backup
+as part of preparing tablets to begin replication. This only takes effect
+if a backup location is defined in the VitessCluster.</p>
 <p>Default: true.</p>
 </td>
 </tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4779,6 +4779,18 @@ new or restored shard that has no master yet.</p>
 <p>Default: true.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>initializeBackup</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>InitializeBackup specifies whether to take an initial placeholder backup before a real one is created.</p>
+<p>Default: true.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.VitessShard">VitessShard

--- a/pkg/apis/planetscale/v2/vitessshard_defaults.go
+++ b/pkg/apis/planetscale/v2/vitessshard_defaults.go
@@ -42,4 +42,9 @@ func DefaultVitessReplicationSpec(replicationSpec *VitessReplicationSpec) {
 	if replicationSpec.InitializeMaster == nil {
 		replicationSpec.InitializeMaster = pointer.BoolPtr(true)
 	}
+
+	// Enable initialization of backup by default.
+	if replicationSpec.InitializeBackup == nil {
+		replicationSpec.InitializeBackup = pointer.BoolPtr(true)
+	}
 }

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -141,7 +141,9 @@ type VitessReplicationSpec struct {
 	// Default: true.
 	InitializeMaster *bool `json:"initializeMaster,omitempty"`
 
-	// InitializeBackup specifies whether to take an initial placeholder backup before a real one is created.
+	// InitializeBackup specifies whether to take an initial placeholder backup
+	// as part of preparing tablets to begin replication. This only takes effect
+	// if a backup location is defined in the VitessCluster.
 	//
 	// Default: true.
 	InitializeBackup *bool `json:"initializeBackup,omitempty"`

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -140,6 +140,11 @@ type VitessReplicationSpec struct {
 	//
 	// Default: true.
 	InitializeMaster *bool `json:"initializeMaster,omitempty"`
+
+	// InitializeBackup specifies whether to take an initial placeholder backup before a real one is created.
+	//
+	// Default: true.
+	InitializeBackup *bool `json:"initializeBackup,omitempty"`
 }
 
 // VitessShardTabletPool defines a pool of tablets with a similar purpose.

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -1789,6 +1789,11 @@ func (in *VitessReplicationSpec) DeepCopyInto(out *VitessReplicationSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.InitializeBackup != nil {
+		in, out := &in.InitializeBackup, &out.InitializeBackup
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/vitessshard/reconcile_backup_job.go
+++ b/pkg/controller/vitessshard/reconcile_backup_job.go
@@ -93,7 +93,7 @@ func (r *ReconcileVitessShard) reconcileBackupJob(ctx context.Context, vts *plan
 		// "initial backup", which is a special imaginary backup created from
 		// scratch (not from any tablet). If we're wrong and a backup exists
 		// already, the idempotent vtbackup "initial backup" mode will just do
-		// nothing and return succcess.
+		// nothing and return success.
 		initSpec := vtbackupInitSpec(initPodKey, vts, labels)
 		if initSpec != nil {
 			keys = append(keys, initPodKey)
@@ -174,6 +174,11 @@ func (r *ReconcileVitessShard) reconcileBackupJob(ctx context.Context, vts *plan
 }
 
 func vtbackupInitSpec(key client.ObjectKey, vts *planetscalev2.VitessShard, parentLabels map[string]string) *vttablet.BackupSpec {
+	// If we specifically set our cluster to avoid initial backups, bail early.
+	if !*vts.Spec.Replication.InitializeBackup {
+		return nil
+	}
+
 	if len(vts.Spec.TabletPools) == 0 {
 		// No tablet pools are defined for this shard.
 		// We don't know enough to make a vtbackup spec.


### PR DESCRIPTION
## Main Changes
- Allow disabling of the initial backup job to allow for the manual configuration of multiple actors racing to initialize it.