### PR TITLE
VitessBackupStorage: Fix subcontroller reconcile errors.

### DIFF
--- a/pkg/apis/planetscale/v2/vitessbackup_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackup_types.go
@@ -53,7 +53,7 @@ type VitessBackupStatus struct {
 	// StartTime is the time when the backup started.
 	StartTime metav1.Time `json:"startTime,omitempty"`
 	// FinishedTime is the time when the backup finished.
-	FinishedTime metav1.Time `json:"finishedTime,omitempty"`
+	FinishedTime *metav1.Time `json:"finishedTime,omitempty"`
 	// Complete indicates whether the backup ever completed.
 	Complete bool `json:"complete,omitempty"`
 	// Position is the replication position of the snapshot that was backed up.

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -609,7 +609,10 @@ func (in *VitessBackupSpec) DeepCopy() *VitessBackupSpec {
 func (in *VitessBackupStatus) DeepCopyInto(out *VitessBackupStatus) {
 	*out = *in
 	in.StartTime.DeepCopyInto(&out.StartTime)
-	in.FinishedTime.DeepCopyInto(&out.FinishedTime)
+	if in.FinishedTime != nil {
+		in, out := &in.FinishedTime, &out.FinishedTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/controller/vitessbackupstorage/subcontroller/subcontroller.go
+++ b/pkg/controller/vitessbackupstorage/subcontroller/subcontroller.go
@@ -68,7 +68,8 @@ const (
 
 var (
 	resyncPeriod     = flag.Duration("vitessbackupstorage_subcontroller_resync_period", 60*time.Second, "reconcile each vitessbackupstorage with this period even if no Kubernetes events occur")
-	reconcileTimeout = flag.Duration("vitessbackupstorage_subcontroller_reconcile_timeout", 60*time.Second, "timeout for a single reconcile pass of the vitessbackupstorage subcontroller")
+	reconcileTimeout = flag.Duration("vitessbackupstorage_subcontroller_reconcile_timeout", 10*time.Minute, "timeout for a single reconcile pass of the vitessbackupstorage subcontroller")
+	requestTimeout   = flag.Duration("vitessbackupstorage_subcontroller_request_timeout", 10*time.Second, "timeout for a single request by the vitessbackupstorage subcontroller to read the status of a backup")
 )
 
 var log = logrus.WithField("subcontroller", "VitessBackupStorage")


### PR DESCRIPTION
1. We were failing to create the vtb upon starting the backup because
   optional, non-pointer metav1.Time values do not work, causing
   validation to reject our null FinishTime.
2. The timeout for fetching MANIFEST was too low for the blob stores of
   certain cloud providers.
3. Add logging for errors reading the MANIFEST.