### PR TITLE
Delete Vschema Before Deleting Keyspace

### DIFF
--- a/pkg/operator/vitesstopo/prune_keyspaces.go
+++ b/pkg/operator/vitesstopo/prune_keyspaces.go
@@ -95,7 +95,7 @@ func DeleteKeyspaces(ctx context.Context, ts *topo.Server, recorder record.Event
 	for _, name := range keyspaceNames {
 		// Before we delete a keyspace, we must delete vschema for this operation to be idempotent.
 		if err := ts.DeleteVSchema(ctx, name); err != nil && !topo.IsErrType(err, topo.NoNode) {
-			recorder.Eventf(eventObj, corev1.EventTypeWarning, "TopoCleanupFailed", "unable to remove keyspace's vschema %s from topology: %v", name, err)
+			recorder.Eventf(eventObj, corev1.EventTypeWarning, "TopoCleanupFailed", "unable to remove keyspace %s vschema from topology: %v", name, err)
 			resultBuilder.RequeueAfter(topoRequeueDelay)
 			// If we can't delete the vschema for this keyspace, then we shouldn't try to delete the keyspace.
 			// We'll retry later.

--- a/pkg/operator/vitesstopo/prune_keyspaces.go
+++ b/pkg/operator/vitesstopo/prune_keyspaces.go
@@ -101,7 +101,7 @@ func DeleteKeyspaces(ctx context.Context, ts *topo.Server, recorder record.Event
 			// We'll retry later.
 			continue
 		}
-		recorder.Eventf(eventObj, corev1.EventTypeNormal, "TopoCleanup", "removed unwanted keyspace %s from topology", name)
+		recorder.Eventf(eventObj, corev1.EventTypeNormal, "TopoCleanup", "removed unwanted keyspace %s vschema from topology", name)
 
 		// topo.NoNode is the error type returned if we can't find the keyspace when deleting. This ensures that this operation is idempotent.
 		if err := wr.DeleteKeyspace(ctx, name, true); err != nil && !topo.IsErrType(err, topo.NoNode) {

--- a/pkg/operator/vitesstopo/prune_keyspaces.go
+++ b/pkg/operator/vitesstopo/prune_keyspaces.go
@@ -88,10 +88,20 @@ func KeyspacesToPrune(keyspaceNames []string, desiredKeyspaces sets.String, orph
 func DeleteKeyspaces(ctx context.Context, ts *topo.Server, recorder record.EventRecorder, eventObj runtime.Object, keyspaceNames []string) (reconcile.Result, error) {
 	resultBuilder := &results.Builder{}
 
+	// We use the Vitess wrangler (multi-step command executor) to recursively delete the keyspace.
+	// This is equivalent to `vtctl DeleteKeyspace -recursive`.
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, nil)
+
 	for _, name := range keyspaceNames {
-		// We use the Vitess wrangler (multi-step command executor) to recursively delete the keyspace.
-		// This is equivalent to `vtctl DeleteKeyspace -recursive`.
-		wr := wrangler.New(logutil.NewConsoleLogger(), ts, nil)
+		// Before we delete a keyspace, we must delete vschema for this operation to be idempotent.
+		if err := ts.DeleteVSchema(ctx, name); err != nil && !topo.IsErrType(err, topo.NoNode) {
+			recorder.Eventf(eventObj, corev1.EventTypeWarning, "TopoCleanupFailed", "unable to remove keyspace's vschema %s from topology: %v", name, err)
+			resultBuilder.RequeueAfter(topoRequeueDelay)
+			// If we can't delete the vschema for this keyspace, then we shouldn't try to delete the keyspace.
+			// We'll retry later.
+			continue
+		}
+		recorder.Eventf(eventObj, corev1.EventTypeNormal, "TopoCleanup", "removed unwanted keyspace %s from topology", name)
 
 		// topo.NoNode is the error type returned if we can't find the keyspace when deleting. This ensures that this operation is idempotent.
 		if err := wr.DeleteKeyspace(ctx, name, true); err != nil && !topo.IsErrType(err, topo.NoNode) {

--- a/pkg/operator/vitesstopo/prune_shards.go
+++ b/pkg/operator/vitesstopo/prune_shards.go
@@ -82,11 +82,11 @@ func ShardsToPrune(currentShards []string, desiredShards sets.String, orphanedSh
 func DeleteShards(ctx context.Context, ts *topo.Server, recorder record.EventRecorder, eventObj runtime.Object, keyspaceName string, shardNames []string) (reconcile.Result, error) {
 	resultBuilder := &results.Builder{}
 
-	for _, name := range shardNames {
-		// We use the Vitess wrangler (multi-step command executor) to recursively delete the shard.
-		// This is equivalent to `vtctl DeleteShard -recursive`.
-		wr := wrangler.New(logutil.NewConsoleLogger(), ts, nil)
+	// We use the Vitess wrangler (multi-step command executor) to recursively delete the shard.
+	// This is equivalent to `vtctl DeleteShard -recursive`.
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, nil)
 
+	for _, name := range shardNames {
 		// topo.NoNode is the error type returned if we can't find the shard when deleting. This ensures that this operation is idempotent.
 		if err := wr.DeleteShard(ctx, keyspaceName, name, true, false); err != nil && !topo.IsErrType(err, topo.NoNode) {
 			recorder.Eventf(eventObj, corev1.EventTypeWarning, "TopoCleanupFailed", "unable to remove shard %s from topology: %v", name, err)


### PR DESCRIPTION
This PR deletes vschema before deleting the keyspace, and does so in an idempotent way.