### PR TITLE
Tolerate config dir missing from Vitess image.

### DIFF
--- a/pkg/operator/vttablet/mysqlctld.go
+++ b/pkg/operator/vttablet/mysqlctld.go
@@ -28,10 +28,15 @@ const (
 mkdir -p /mnt/vt/bin
 cp --no-clobber /vt/bin/mysqlctld /mnt/vt/bin/
 mkdir -p /mnt/vt/config
-cp --no-clobber -R /vt/config/mycnf /mnt/vt/config/
+if [[ -d /vt/config/mycnf ]]; then
+  cp --no-clobber -R /vt/config/mycnf /mnt/vt/config/
+else
+  mkdir -p /mnt/vt/config/mycnf
+fi
 mkdir -p /mnt/vt/vtdataroot
 ln -sf /dev/stderr /mnt/vt/config/stderr.symlink
-echo "log-error = /vt/config/stderr.symlink" > /mnt/vt/config/mycnf/log-error.cnf`
+echo "log-error = /vt/config/stderr.symlink" > /mnt/vt/config/mycnf/log-error.cnf
+echo "binlog_format=row" > /mnt/vt/config/mycnf/rbr.cnf`
 )
 
 func init() {

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -35,9 +35,14 @@ const (
 mkdir -p /mnt/vt/bin
 cp --no-clobber /vt/bin/vtbackup /mnt/vt/bin/
 mkdir -p /mnt/vt/config
-cp --no-clobber -R /vt/config/mycnf /mnt/vt/config/
+if [[ -d /vt/config/mycnf ]]; then
+  cp --no-clobber -R /vt/config/mycnf /mnt/vt/config/
+else
+  mkdir -p /mnt/vt/config/mycnf
+fi
 ln -sf /dev/stderr /mnt/vt/config/stderr.symlink
 echo "log-error = /vt/config/stderr.symlink" > /mnt/vt/config/mycnf/log-error.cnf
+echo "binlog_format=row" > /mnt/vt/config/mycnf/rbr.cnf
 mkdir -p /mnt/vt/certs
 cp --no-clobber /etc/ssl/certs/ca-certificates.crt /mnt/vt/certs/`
 )


### PR DESCRIPTION
Newer Vitess images no longer contain the config dir because the
necessary files are baked into the binaries instead. To support both
old and new images, we now copy the dir if it exists, but we don't
require it to exist.

The RBR setting has also become default in Vitess without needing an
override, but to maintain compatibility with older images we continue to
override it by writing out our own rbr.cnf.