### PR TITLE
Add option to configure storage endpoint for AWS

### DIFF
--- a/deploy/crds/planetscale_v2_vitessbackupstorage_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessbackupstorage_crd.yaml
@@ -199,9 +199,9 @@ spec:
                       minLength: 1
                       type: string
                     endpoint:
-                      description: 'Endpoint is the url endpoint for the S3 bucket.
-                        Default: User the endpoint associated with `Region` by the
-                        driver.'
+                      description: 'Endpoint is the `host:port` (port is required)
+                        for the S3 backend. Default: Use the endpoint associated with
+                        `region` by the driver.'
                       type: string
                     keyPrefix:
                       description: KeyPrefix is an optional prefix added to all object

--- a/deploy/crds/planetscale_v2_vitessbackupstorage_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessbackupstorage_crd.yaml
@@ -198,6 +198,11 @@ spec:
                       description: Bucket is the name of the S3 bucket to use.
                       minLength: 1
                       type: string
+                    endpoint:
+                      description: 'Endpoint is the url endpoint for the S3 bucket.
+                        Default: User the endpoint associated with `Region` by the
+                        driver.'
+                      type: string
                     keyPrefix:
                       description: KeyPrefix is an optional prefix added to all object
                         keys created by Vitess. This is only needed if the same bucket

--- a/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
@@ -236,9 +236,9 @@ spec:
                             minLength: 1
                             type: string
                           endpoint:
-                            description: 'Endpoint is the url endpoint for the S3
-                              bucket. Default: User the endpoint associated with `Region`
-                              by the driver.'
+                            description: 'Endpoint is the `host:port` (port is required)
+                              for the S3 backend. Default: Use the endpoint associated
+                              with `region` by the driver.'
                             type: string
                           keyPrefix:
                             description: KeyPrefix is an optional prefix added to

--- a/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
@@ -235,6 +235,11 @@ spec:
                             description: Bucket is the name of the S3 bucket to use.
                             minLength: 1
                             type: string
+                          endpoint:
+                            description: 'Endpoint is the url endpoint for the S3
+                              bucket. Default: User the endpoint associated with `Region`
+                              by the driver.'
+                            type: string
                           keyPrefix:
                             description: KeyPrefix is an optional prefix added to
                               all object keys created by Vitess. This is only needed

--- a/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
@@ -207,6 +207,11 @@ spec:
                         description: Bucket is the name of the S3 bucket to use.
                         minLength: 1
                         type: string
+                      endpoint:
+                        description: 'Endpoint is the url endpoint for the S3 bucket.
+                          Default: User the endpoint associated with `Region` by the
+                          driver.'
+                        type: string
                       keyPrefix:
                         description: KeyPrefix is an optional prefix added to all
                           object keys created by Vitess. This is only needed if the

--- a/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
@@ -208,9 +208,9 @@ spec:
                         minLength: 1
                         type: string
                       endpoint:
-                        description: 'Endpoint is the url endpoint for the S3 bucket.
-                          Default: User the endpoint associated with `Region` by the
-                          driver.'
+                        description: 'Endpoint is the `host:port` (port is required)
+                          for the S3 backend. Default: Use the endpoint associated
+                          with `region` by the driver.'
                         type: string
                       keyPrefix:
                         description: KeyPrefix is an optional prefix added to all

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -214,9 +214,9 @@ spec:
                         minLength: 1
                         type: string
                       endpoint:
-                        description: 'Endpoint is the url endpoint for the S3 bucket.
-                          Default: User the endpoint associated with `Region` by the
-                          driver.'
+                        description: 'Endpoint is the `host:port` (port is required)
+                          for the S3 backend. Default: Use the endpoint associated
+                          with `region` by the driver.'
                         type: string
                       keyPrefix:
                         description: KeyPrefix is an optional prefix added to all

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -213,6 +213,11 @@ spec:
                         description: Bucket is the name of the S3 bucket to use.
                         minLength: 1
                         type: string
+                      endpoint:
+                        description: 'Endpoint is the url endpoint for the S3 bucket.
+                          Default: User the endpoint associated with `Region` by the
+                          driver.'
+                        type: string
                       keyPrefix:
                         description: KeyPrefix is an optional prefix added to all
                           object keys created by Vitess. This is only needed if the

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1393,8 +1393,8 @@ string
 </em>
 </td>
 <td>
-<p>Endpoint is the url endpoint for the S3 bucket.
-Default: User the endpoint associated with <code>Region</code> by the driver.</p>
+<p>Endpoint is the <code>host:port</code> (port is required) for the S3 backend.
+Default: Use the endpoint associated with <code>region</code> by the driver.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1387,6 +1387,18 @@ string
 </tr>
 <tr>
 <td>
+<code>endpoint</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Endpoint is the url endpoint for the S3 bucket.
+Default: User the endpoint associated with <code>Region</code> by the driver.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>keyPrefix</code></br>
 <em>
 string

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.1.5-0.20190629210212-52e137b8d003
 	github.com/coreos/etcd v3.3.12+incompatible // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/elazarl/go-bindata-assetfs v1.0.0 // indirect
 	github.com/go-openapi/spec v0.19.3
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/gophercloud/gophercloud v0.0.0-20190410012400-2c55d17f707c // indirect

--- a/pkg/apis/planetscale/v2/vitessbackupstorage_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupstorage_types.go
@@ -103,8 +103,8 @@ type S3BackupLocation struct {
 	// Bucket is the name of the S3 bucket to use.
 	// +kubebuilder:validation:MinLength=1
 	Bucket string `json:"bucket"`
-	// Endpoint is the url endpoint for the S3 bucket.
-	// Default: User the endpoint associated with `Region` by the driver.
+	// Endpoint is the `host:port` (port is required) for the S3 backend.
+	// Default: Use the endpoint associated with `region` by the driver.
 	Endpoint string `json:"endpoint,omitempty"`
 	// KeyPrefix is an optional prefix added to all object keys created by Vitess.
 	// This is only needed if the same bucket is also used for something other

--- a/pkg/apis/planetscale/v2/vitessbackupstorage_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupstorage_types.go
@@ -103,6 +103,9 @@ type S3BackupLocation struct {
 	// Bucket is the name of the S3 bucket to use.
 	// +kubebuilder:validation:MinLength=1
 	Bucket string `json:"bucket"`
+	// Endpoint is the url endpoint for the S3 bucket.
+	// Default: User the endpoint associated with `Region` by the driver.
+	Endpoint string `json:"endpoint,omitempty"`
 	// KeyPrefix is an optional prefix added to all object keys created by Vitess.
 	// This is only needed if the same bucket is also used for something other
 	// than backups for VitessClusters. Backups from different clusters,

--- a/pkg/operator/vitessbackup/storage_s3.go
+++ b/pkg/operator/vitessbackup/storage_s3.go
@@ -25,12 +25,16 @@ import (
 )
 
 func s3BackupFlags(s3 *planetscalev2.S3BackupLocation, clusterName string) vitess.Flags {
-	return vitess.Flags{
+	flags := vitess.Flags{
 		"backup_storage_implementation": s3BackupStorageImplementationName,
 		"s3_backup_aws_region":          s3.Region,
 		"s3_backup_storage_bucket":      s3.Bucket,
 		"s3_backup_storage_root":        rootKeyPrefix(s3.KeyPrefix, clusterName),
 	}
+	if len(s3.Endpoint) > 0 {
+		flags["s3_backup_aws_endpoint"] = s3.Endpoint
+	}
+	return flags
 }
 
 func s3BackupVolumes(s3 *planetscalev2.S3BackupLocation) []corev1.Volume {


### PR DESCRIPTION
Allow the User to configure the endpoint for backups to S3 compatible systems. 

ref: https://developers.digitalocean.com/documentation/spaces/