### PR TITLE
Put UNIX socket files on ephemeral storage (emptyDir).

### DIFF
--- a/pkg/operator/vttablet/constants.go
+++ b/pkg/operator/vttablet/constants.go
@@ -68,9 +68,11 @@ const (
 	vtConfigPath       = vtRootPath + "/config"
 	vtMycnfPath        = vtConfigPath + "/mycnf"
 	vtDataRootPath     = vtRootPath + "/vtdataroot"
+	vtSocketPath       = vtRootPath + "/socket"
 	vtMysqlRootPath    = "/usr"
 	vtRootVolumeName   = "vt-root"
-	mysqlctlSocketPath = vtDataRootPath + "/mysqlctl.sock"
+	mysqlctlSocketPath = vtSocketPath + "/mysqlctl.sock"
+	mysqlSocketPath    = vtSocketPath + "/mysql.sock"
 	sslCertsPath       = "/etc/ssl/certs"
 
 	pvcVolumeName = "persistent-volume-claim"

--- a/pkg/operator/vttablet/datastore.go
+++ b/pkg/operator/vttablet/datastore.go
@@ -90,8 +90,9 @@ func localDatastoreFlags(spec *Spec) vitess.Flags {
 		// TODO: Should this be configurable?
 		"enable_replication_reporter": true,
 
-		"enable_semi_sync": spec.EnableSemiSync,
-		"mysqlctl_socket":  mysqlctlSocketPath,
+		"enable_semi_sync":  spec.EnableSemiSync,
+		"mysqlctl_socket":   mysqlctlSocketPath,
+		"mycnf_socket_file": mysqlSocketPath,
 	}
 }
 

--- a/pkg/operator/vttablet/flags.go
+++ b/pkg/operator/vttablet/flags.go
@@ -87,6 +87,7 @@ func init() {
 			"logtostderr":         true,
 			"tablet_uid":          spec.Alias.Uid,
 			"socket_file":         mysqlctlSocketPath,
+			"mysql_socket":        mysqlSocketPath,
 			"db-config-dba-uname": dbConfigDbaUname,
 			"db_charset":          spec.dbConfigCharset(),
 			"init_db_sql_file":    dbInitScript.FilePath(),
@@ -123,6 +124,8 @@ func init() {
 			"db_charset":          spec.dbConfigCharset(),
 
 			"init_db_sql_file": dbInitScript.FilePath(),
+
+			"mysql_socket": mysqlSocketPath,
 		}
 	})
 }

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -204,7 +204,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 			Env: []corev1.EnvVar{
 				{
 					Name:  "DATA_SOURCE_NAME",
-					Value: fmt.Sprintf("%s@unix(%s)/", mysqldExporterUser, spec.mysqldUnixSocketPath()),
+					Value: fmt.Sprintf("%s@unix(%s)/", mysqldExporterUser, mysqlSocketPath),
 				},
 			},
 			Ports: []corev1.ContainerPort{

--- a/pkg/operator/vttablet/spec.go
+++ b/pkg/operator/vttablet/spec.go
@@ -93,11 +93,6 @@ func (spec *Spec) myCnfFilePath() string {
 	return spec.tabletDir() + "/my.cnf"
 }
 
-// mysqldUnixSocketPath returns the path to the mysqld socket file.
-func (spec *Spec) mysqldUnixSocketPath() string {
-	return spec.tabletDir() + "/mysql.sock"
-}
-
 // dbConfigCharset returns the charset for vttablet's mysql connection pools.
 func (spec *Spec) dbConfigCharset() string {
 	// For flavors that we know are 8.0-compatible, use the new default charset

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -44,7 +44,9 @@ ln -sf /dev/stderr /mnt/vt/config/stderr.symlink
 echo "log-error = /vt/config/stderr.symlink" > /mnt/vt/config/mycnf/log-error.cnf
 echo "binlog_format=row" > /mnt/vt/config/mycnf/rbr.cnf
 mkdir -p /mnt/vt/certs
-cp --no-clobber /etc/ssl/certs/ca-certificates.crt /mnt/vt/certs/`
+cp --no-clobber /etc/ssl/certs/ca-certificates.crt /mnt/vt/certs/
+echo "socket = ` + mysqlSocketPath + `" > /mnt/vt/config/mycnf/socket.cnf
+`
 )
 
 // BackupSpec is the spec for a Backup Pod.


### PR DESCRIPTION
It doesn't make sense for these to persist beyond the lifetime of a given Pod. Having them on the PVC has been seen to cause problems when the PVC is reattached to a new Pod after an unclean shutdown.