### PR TITLE
Restart tablet Pods to complete pending PVC filesystem resizes.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.1.5-0.20190629210212-52e137b8d003
 	github.com/coreos/etcd v3.3.12+incompatible // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/elazarl/go-bindata-assetfs v1.0.0 // indirect
 	github.com/go-openapi/spec v0.19.3
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/gophercloud/gophercloud v0.0.0-20190410012400-2c55d17f707c // indirect

--- a/pkg/apis/planetscale/v2/vitessshard_methods.go
+++ b/pkg/apis/planetscale/v2/vitessshard_methods.go
@@ -218,6 +218,7 @@ func (s *VitessShardStatus) DeepCopyConditions() map[VitessShardConditionType]*V
 	return out
 }
 
+// TabletAliases returns a sorted list of desired tablet aliases for the shard.
 func (s *VitessShardStatus) TabletAliases() []string {
 	tabletKeys := make([]string, 0, len(s.Tablets))
 	for key := range s.Tablets {

--- a/pkg/apis/planetscale/v2/vitessshard_methods.go
+++ b/pkg/apis/planetscale/v2/vitessshard_methods.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v2
 
 import (
+	"sort"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -215,4 +216,14 @@ func (s *VitessShardStatus) DeepCopyConditions() map[VitessShardConditionType]*V
 	}
 
 	return out
+}
+
+func (s *VitessShardStatus) TabletAliases() []string {
+	tabletKeys := make([]string, 0, len(s.Tablets))
+	for key := range s.Tablets {
+		tabletKeys = append(tabletKeys, key)
+	}
+	sort.Strings(tabletKeys)
+
+	return tabletKeys
 }

--- a/pkg/controller/vitessshard/reconcile_disk.go
+++ b/pkg/controller/vitessshard/reconcile_disk.go
@@ -1,0 +1,124 @@
+package vitessshard
+
+import (
+	"context"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+	"planetscale.dev/vitess-operator/pkg/operator/results"
+	"planetscale.dev/vitess-operator/pkg/operator/rollout"
+)
+
+const (
+	pvcDiskSizeAnnotation = "pvc-disk-size"
+)
+
+func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetscalev2.VitessShard) (reconcile.Result, error) {
+	resultBuilder := &results.Builder{}
+	changed := false
+	tabletKeys := tabletKeysFromShard(vts)
+	tabletPods, err := r.tabletPodsFromShard(ctx, vts)
+	if err != nil {
+		return resultBuilder.Error(err)
+	}
+
+	for i  := range vts.Spec.TabletPools {
+		tabletPool := &vts.Spec.TabletPools[i]
+		requestedDisk := tabletPool.DataVolumeClaimTemplate.Resources.Requests[v1.ResourceStorage].String()
+		poolTablets := tabletsForPool(vts, tabletKeys, tabletPool.Cell, string(tabletPool.Type))
+
+		for _, tabletKey := range poolTablets {
+			pod, ok := tabletPods[tabletKey]
+			if !ok {
+				continue
+			}
+
+			tabletDiskSize, ok := pod.Annotations[pvcDiskSizeAnnotation]
+			if !ok {
+				// If it's never been set before, apply the disk size annotation.
+				setDiskSizeAnnotation(pod, requestedDisk)
+				continue
+			}
+
+			// If disk size is unchanged, move on to the next tablet.
+			if tabletDiskSize == requestedDisk {
+				continue
+			}
+
+			// If there are disk size changes, mark the shard as changed to cascade later.
+			changed = true
+
+			pvc, err := r.claimForTabletPod(ctx, pod)
+			if err != nil {
+				return resultBuilder.Error(err)
+			}
+
+			// Make sure that the tablet's PVC has the updated disk size before proceeding.
+			if pvc.Spec.Resources.Requests[v1.ResourceStorage].String() != requestedDisk {
+				r.recorder.Eventf(vts, v1.EventTypeNormal, "RolloutCheckPaused", "Waiting for pvc %v to reflect updated disk.", pvc.Name)
+				return resultBuilder.Result()
+			}
+
+			// Set the disk size annotation to schedule this Pod for changes.
+			setDiskSizeAnnotation(pod, requestedDisk)
+		}
+	}
+
+	if changed {
+		rollout.Cascade(vts)
+	}
+
+	return resultBuilder.Result()
+}
+
+func (r *ReconcileVitessShard) claimForTabletPod(ctx context.Context, pod *v1.Pod) (*v1.PersistentVolumeClaim, error) {
+	var claimName string
+	for i := range pod.Spec.Volumes {
+		volume := &pod.Spec.Volumes[i]
+		if volume.PersistentVolumeClaim != nil {
+			claimName = volume.Name
+			break
+		}
+	}
+
+	pvc := &v1.PersistentVolumeClaim{}
+	namespacedClaim := apitypes.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      claimName,
+	}
+	err := r.client.Get(ctx, namespacedClaim, pvc)
+	if err != nil {
+		return nil, err
+	}
+
+	return pvc, nil
+}
+
+func tabletsForPool(vts *planetscalev2.VitessShard, tabletKeys []string, poolCell string, poolType string) []string {
+	tabletsInCell := make([]string, 0, len(tabletKeys))
+	for _, tabletKey := range tabletKeys {
+		tablet := vts.Status.Tablets[tabletKey]
+		tabletCell := strings.Split(tabletKey, "-")[0]
+
+		if tablet.Type != poolType || tabletCell != poolCell{
+			continue
+		}
+
+		tabletsInCell = append(tabletsInCell, tabletKey)
+	}
+
+	return tabletsInCell
+}
+
+func setDiskSizeAnnotation(pod *v1.Pod, requestedDisk string) {
+	ann := pod.GetAnnotations()
+	if ann == nil {
+		ann = make(map[string]string, 1)
+	}
+	ann[pvcDiskSizeAnnotation] = requestedDisk
+	pod.SetAnnotations(ann)
+}

--- a/pkg/controller/vitessshard/reconcile_disk.go
+++ b/pkg/controller/vitessshard/reconcile_disk.go
@@ -43,7 +43,7 @@ func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetsca
 			continue
 		}
 
-		poolTablets, err := tabletKeysForPool(vts, tabletPool.Cell, string(tabletPool.Type))
+		poolTablets, err := tabletKeysForPool(vts, tabletPool.Cell, tabletPool.Type)
 		if err != nil {
 			return resultBuilder.Error(err)
 		}
@@ -119,7 +119,7 @@ func (r *ReconcileVitessShard) claimForTabletPod(ctx context.Context, pod *v1.Po
 	return pvc, nil
 }
 
-func tabletKeysForPool(vts *planetscalev2.VitessShard, poolCell string, poolType string) ([]string, error) {
+func tabletKeysForPool(vts *planetscalev2.VitessShard, poolCell string, poolType planetscalev2.VitessTabletPoolType) ([]string, error) {
 	tabletKeys := vts.Status.TabletAliases()
 
 	tabletsInCell := make([]string, 0, len(tabletKeys))
@@ -130,7 +130,7 @@ func tabletKeysForPool(vts *planetscalev2.VitessShard, poolCell string, poolType
 			return nil, err
 		}
 
-		if tablet.PoolType != poolType || tabletAlias.Cell != poolCell{
+		if tablet.PoolType != string(poolType) || tabletAlias.Cell != poolCell{
 			continue
 		}
 

--- a/pkg/controller/vitessshard/reconcile_disk.go
+++ b/pkg/controller/vitessshard/reconcile_disk.go
@@ -2,11 +2,11 @@ package vitessshard
 
 import (
 	"context"
-	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 
 	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
 	"planetscale.dev/vitess-operator/pkg/operator/results"
@@ -14,13 +14,12 @@ import (
 )
 
 const (
-	pvcDiskSizeAnnotation = "pvc-disk-size"
+	pvcDiskSizeAnnotation = "planetscale.com/pvc-filesystem-resize"
 )
 
 func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetscalev2.VitessShard) (reconcile.Result, error) {
 	resultBuilder := &results.Builder{}
-	changed := false
-	tabletKeys := tabletKeysFromShard(vts)
+	anythingChanged := false
 	tabletPods, err := r.tabletPodsFromShard(ctx, vts)
 	if err != nil {
 		return resultBuilder.Error(err)
@@ -30,7 +29,10 @@ func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetsca
 		tabletPool := &vts.Spec.TabletPools[i]
 		requestedDiskQuantity := tabletPool.DataVolumeClaimTemplate.Resources.Requests[v1.ResourceStorage]
 		requestedDisk := requestedDiskQuantity.String()
-		poolTablets := tabletsForPool(vts, tabletKeys, tabletPool.Cell, string(tabletPool.Type))
+		poolTablets, err := tabletsForPool(vts, tabletPool.Cell, string(tabletPool.Type))
+		if err != nil {
+			return resultBuilder.Error(err)
+		}
 
 		for _, tabletKey := range poolTablets {
 			pod, ok := tabletPods[tabletKey]
@@ -38,40 +40,42 @@ func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetsca
 				continue
 			}
 
-			tabletDiskSize, ok := pod.Annotations[pvcDiskSizeAnnotation]
-			if !ok {
-				// If it's never been set before, apply the disk size annotation.
-				setDiskSizeAnnotation(pod, requestedDisk)
-				continue
-			}
-
-			// If disk size is unchanged, move on to the next tablet.
-			if tabletDiskSize == requestedDisk {
-				continue
-			}
-
-			// If there are disk size changes, mark the shard as changed to cascade later.
-			changed = true
-
 			pvc, err := r.claimForTabletPod(ctx, pod)
 			if err != nil {
 				return resultBuilder.Error(err)
 			}
 
-			// Make sure that the tablet's PVC has the updated disk size before proceeding.
-			currentPVCDisk := pvc.Spec.Resources.Requests[v1.ResourceStorage]
-			if currentPVCDisk.String() != requestedDisk {
-				r.recorder.Eventf(vts, v1.EventTypeNormal, "RolloutCheckPaused", "Waiting for pvc %v to reflect updated disk.", pvc.Name)
+			// If the PVC does not have the FileSystemResizeCondition, bail out.
+			if !checkPVCFileSystemResizeCondition(pvc) {
 				return resultBuilder.Result()
 			}
 
-			// Set the disk size annotation to schedule this Pod for changes.
-			setDiskSizeAnnotation(pod, requestedDisk)
+			// If we have reached this point in the loop, it indicates that there are disk size changes, so we
+			// set the variable anythingChanged to true. If we successfully complete this loop without bailing,
+			// we can be certain that we have disk size changes and that all required changes have been set.
+			anythingChanged = true
+
+			// If the pod does not have updates scheduled, bail out and wait until the scheduled annotation is applied.
+			if !rollout.Scheduled(pod) {
+				return resultBuilder.Result()
+			}
+
+			// Finally, if the PVC's disk spec does not equal the new requested disk, bail out.
+			pvcDisk := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+			if pvcDisk.String() != requestedDisk {
+				r.recorder.Eventf(vts, v1.EventTypeNormal, "RolloutCheckPaused", "Waiting for pvc %v to reflect updated disk.", pvc.Name)
+				return resultBuilder.Result()
+			}
 		}
 	}
 
-	if changed {
+	// If disk size has changed and the changes are all ready, mark the shard as ready to cascade. Otherwise, skip this.
+	if anythingChanged {
 		rollout.Cascade(vts)
+		err := r.client.Update(ctx, vts)
+		if err != nil {
+			 return resultBuilder.Error(err)
+		}
 	}
 
 	return resultBuilder.Result()
@@ -81,7 +85,7 @@ func (r *ReconcileVitessShard) claimForTabletPod(ctx context.Context, pod *v1.Po
 	var claimName string
 	for i := range pod.Spec.Volumes {
 		volume := &pod.Spec.Volumes[i]
-		if volume.PersistentVolumeClaim != nil {
+		if volume.PersistentVolumeClaim != nil && volume.Name == pod.Name {
 			claimName = volume.Name
 			break
 		}
@@ -100,27 +104,26 @@ func (r *ReconcileVitessShard) claimForTabletPod(ctx context.Context, pod *v1.Po
 	return pvc, nil
 }
 
-func tabletsForPool(vts *planetscalev2.VitessShard, tabletKeys []string, poolCell string, poolType string) []string {
+func tabletsForPool(vts *planetscalev2.VitessShard, poolCell string, poolType string) ([]string, error) {
+	tabletKeys := make([]string, 0, len(vts.Status.Tablets))
+	for key := range vts.Status.Tablets {
+		tabletKeys = append(tabletKeys, key)
+	}
+
 	tabletsInCell := make([]string, 0, len(tabletKeys))
 	for _, tabletKey := range tabletKeys {
 		tablet := vts.Status.Tablets[tabletKey]
-		tabletCell := strings.Split(tabletKey, "-")[0]
+		tabletAlias, err := topoproto.ParseTabletAlias(tabletKey)
+		if err != nil {
+			return tabletKeys, err
+		}
 
-		if tablet.Type != poolType || tabletCell != poolCell{
+		if tablet.PoolType != poolType || tabletAlias.Cell != poolCell{
 			continue
 		}
 
 		tabletsInCell = append(tabletsInCell, tabletKey)
 	}
 
-	return tabletsInCell
-}
-
-func setDiskSizeAnnotation(pod *v1.Pod, requestedDisk string) {
-	ann := pod.GetAnnotations()
-	if ann == nil {
-		ann = make(map[string]string, 1)
-	}
-	ann[pvcDiskSizeAnnotation] = requestedDisk
-	pod.SetAnnotations(ann)
+	return tabletsInCell, nil
 }

--- a/pkg/controller/vitessshard/reconcile_disk.go
+++ b/pkg/controller/vitessshard/reconcile_disk.go
@@ -28,7 +28,8 @@ func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetsca
 
 	for i  := range vts.Spec.TabletPools {
 		tabletPool := &vts.Spec.TabletPools[i]
-		requestedDisk := tabletPool.DataVolumeClaimTemplate.Resources.Requests[v1.ResourceStorage].String()
+		requestedDiskQuantity := tabletPool.DataVolumeClaimTemplate.Resources.Requests[v1.ResourceStorage]
+		requestedDisk := requestedDiskQuantity.String()
 		poolTablets := tabletsForPool(vts, tabletKeys, tabletPool.Cell, string(tabletPool.Type))
 
 		for _, tabletKey := range poolTablets {
@@ -58,7 +59,8 @@ func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetsca
 			}
 
 			// Make sure that the tablet's PVC has the updated disk size before proceeding.
-			if pvc.Spec.Resources.Requests[v1.ResourceStorage].String() != requestedDisk {
+			currentPVCDisk := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+			if currentPVCDisk.String() != requestedDisk {
 				r.recorder.Eventf(vts, v1.EventTypeNormal, "RolloutCheckPaused", "Waiting for pvc %v to reflect updated disk.", pvc.Name)
 				return resultBuilder.Result()
 			}

--- a/pkg/controller/vitessshard/reconcile_disk.go
+++ b/pkg/controller/vitessshard/reconcile_disk.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -55,7 +55,7 @@ func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetsca
 			}
 
 			pvc, err := r.claimForTabletPod(ctx, pod)
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			} else if err != nil {
 				return resultBuilder.Error(err)
@@ -81,7 +81,7 @@ func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetsca
 
 			// If the PVC does not have the FileSystemResizeCondition, bail out.
 			if !checkPVCFileSystemResizeCondition(pvc) {
-				r.recorder.Eventf(vts, v1.EventTypeNormal, "PVCResizeWaiting", "Waiting for pvc %v to reflect the filesystem resize condition.", pvc.Name)
+				r.recorder.Eventf(vts, v1.EventTypeNormal, "PVCResizeWaiting", "Waiting for PVC %v to be ready for filesystem resize.", pvc.Name)
 				return resultBuilder.Result()
 			}
 

--- a/pkg/controller/vitessshard/reconcile_rollout.go
+++ b/pkg/controller/vitessshard/reconcile_rollout.go
@@ -87,12 +87,12 @@ func (r *ReconcileVitessShard) tabletPodsFromShard(ctx context.Context, vts *pla
 	podList := &v1.PodList{}
 	listOpts := &client.ListOptions{
 		Namespace: vts.Namespace,
-		LabelSelector: apilabels.Set(map[string]string{
+		LabelSelector: apilabels.Set{
 			planetscalev2.ComponentLabel: planetscalev2.VttabletComponentName,
 			planetscalev2.ClusterLabel:   vts.Labels[planetscalev2.ClusterLabel],
 			planetscalev2.KeyspaceLabel:  vts.Labels[planetscalev2.KeyspaceLabel],
 			planetscalev2.ShardLabel:     vts.Spec.KeyRange.SafeName(),
-		}).AsSelector(),
+		}.AsSelector(),
 	}
 
 	if err := r.client.List(ctx, listOpts, podList); err != nil {

--- a/pkg/controller/vitessshard/reconcile_rollout.go
+++ b/pkg/controller/vitessshard/reconcile_rollout.go
@@ -2,7 +2,6 @@ package vitessshard
 
 import (
 	"context"
-	"sort"
 
 	"k8s.io/api/core/v1"
 	apilabels "k8s.io/apimachinery/pkg/labels"
@@ -29,7 +28,7 @@ func (r *ReconcileVitessShard) reconcileRollout(ctx context.Context, vts *planet
 		return resultBuilder.Error(err)
 	}
 
-	tabletKeys := tabletKeysFromShard(vts)
+	tabletKeys := vts.Status.TabletAliases()
 
 	for _, tabletKey := range tabletKeys {
 		tablet := vts.Status.Tablets[tabletKey]
@@ -138,14 +137,4 @@ func getNextScheduledTablet(tabletKeys []string, tabletPods map[string]*v1.Pod) 
 	}
 
 	return "", nil
-}
-
-func tabletKeysFromShard(vts *planetscalev2.VitessShard) []string {
-	tabletKeys := make([]string, 0, len(vts.Status.Tablets))
-	for key := range vts.Status.Tablets {
-		tabletKeys = append(tabletKeys, key)
-	}
-	sort.Strings(tabletKeys)
-
-	return tabletKeys
 }

--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -168,7 +168,7 @@ func (r *ReconcileVitessShard) reconcileTablets(ctx context.Context, vts *planet
 		UpdateRollingRecreate: func(key client.ObjectKey, obj runtime.Object) {
 			newObj := obj.(*corev1.Pod)
 			tablet := tabletMap[key]
-			r.checkPVCDiskUpdates(ctx, tablet, newObj)
+			r.updatePVCFilesystemResizeAnnotation(ctx, tablet, newObj)
 			vttablet.UpdatePod(newObj, tablet)
 		},
 		Status: func(key client.ObjectKey, obj runtime.Object) {
@@ -362,7 +362,7 @@ func tabletAvailableStatus(resultBuilder *results.Builder, pod *corev1.Pod, read
 	return corev1.ConditionFalse
 }
 
-func (r *ReconcileVitessShard) checkPVCDiskUpdates(ctx context.Context, tabletSpec *vttablet.Spec, pod *corev1.Pod) {
+func (r *ReconcileVitessShard) updatePVCFilesystemResizeAnnotation(ctx context.Context, tabletSpec *vttablet.Spec, pod *corev1.Pod) {
 	// If no PVC is configured for this tablet pod, bail out.
 	if tabletSpec.DataVolumePVCSpec == nil {
 		return

--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"time"
 
-	apitypes "k8s.io/apimachinery/pkg/types"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 

--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"time"
 
+	apitypes "k8s.io/apimachinery/pkg/types"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 
@@ -168,6 +169,7 @@ func (r *ReconcileVitessShard) reconcileTablets(ctx context.Context, vts *planet
 		UpdateRollingRecreate: func(key client.ObjectKey, obj runtime.Object) {
 			newObj := obj.(*corev1.Pod)
 			tablet := tabletMap[key]
+			r.checkPVCDiskUpdates(ctx, tablet, newObj)
 			vttablet.UpdatePod(newObj, tablet)
 		},
 		Status: func(key client.ObjectKey, obj runtime.Object) {
@@ -359,4 +361,46 @@ func tabletAvailableStatus(resultBuilder *results.Builder, pod *corev1.Pod, read
 	// anything in the Pod status to change and trigger a watch event.
 	resultBuilder.RequeueAfter(tabletAvailableTime - readyDuration)
 	return corev1.ConditionFalse
+}
+
+func (r *ReconcileVitessShard) checkPVCDiskUpdates(ctx context.Context, tabletSpec *vttablet.Spec, pod *corev1.Pod) {
+	// If no PVC is configured for this tablet pod, bail out.
+	if tabletSpec.DataVolumePVCSpec == nil {
+		return
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	namespacedClaim := apitypes.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      tabletSpec.DataVolumePVCName,
+	}
+
+	// If a matching PVC doesn't exist for this tablet pod, bail out.
+	err := r.client.Get(ctx, namespacedClaim, pvc)
+	if err != nil {
+		return
+	}
+
+	// If the matching PVC does not have the FileSystemResizePending condition, bail out.
+	if !checkPVCFileSystemResizeCondition(pvc) {
+		return
+	}
+
+	// If all checks pass, set the resize annotation.
+	requestedDiskQuantity := tabletSpec.DataVolumePVCSpec.Resources.Requests[corev1.ResourceStorage]
+	tabletSpec.Annotations[pvcDiskSizeAnnotation] = requestedDiskQuantity.String()
+}
+
+func checkPVCFileSystemResizeCondition (pvc *corev1.PersistentVolumeClaim) bool {
+	for _, condition := range pvc.Status.Conditions {
+		if condition.Type != corev1.PersistentVolumeClaimFileSystemResizePending {
+			continue
+		}
+
+		if condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/controller/vitessshard/vitessshard_controller.go
+++ b/pkg/controller/vitessshard/vitessshard_controller.go
@@ -184,6 +184,11 @@ func (r *ReconcileVitessShard) Reconcile(request reconcile.Request) (reconcile.R
 	tabletResult, err := r.reconcileTablets(ctx, vts)
 	resultBuilder.Merge(tabletResult, err)
 
+	// Mark tablet pods for disk size updates if needed.
+	// NOTE: This must always be done after reconcileTablets, so Status.Tablets is populated
+	diskUpdateResult, err := r.reconcileDisk(ctx, vts)
+	resultBuilder.Merge(diskUpdateResult, err)
+
 	// Perform rolling updates on tablets if needed.
 	// NOTE: This must always be done after reconcileTablets, so Status.Tablets is populated.
 	rolloutResult, err := r.reconcileRollout(ctx, vts)


### PR DESCRIPTION
## Main Changes
- This marks pods as ready to be restarted if they have undergone a disk size change. It checks that their associated PVC has received the updates and only cascades the shard when all tablet pools within a shard are ready. 