### PR TITLE
Apply Annotations Instantly

### DIFF
--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -156,6 +156,8 @@ func updateVitessShard(key client.ObjectKey, vts *planetscalev2.VitessShard, vtk
 	// Update labels, but ignore existing ones we don't set.
 	update.Labels(&vts.Labels, newShard.Labels)
 
+	// Remove old annotations that shouldn't be there that we injected previously.
+	// This must be done before we update vts.Spec.
 	updateVitessShardAnnotations(vts, newShard)
 
 	// For now, everything in Spec is safe to update.
@@ -168,12 +170,11 @@ func updateVitessShardInPlace(key client.ObjectKey, vts *planetscalev2.VitessSha
 	// For now, only disk size & annotations are safe to update in place.
 	update.ShardDiskSize(vts.Spec.TabletPools, newShard.Spec.TabletPools)
 
+	// Remove old annotations that shouldn't be there that we injected previously.
 	updateVitessShardAnnotations(vts, newShard)
 }
 
 func updateVitessShardAnnotations(vts *planetscalev2.VitessShard, newShard *planetscalev2.VitessShard) {
-	// Remove old annotations that shouldn't be there that we injected previously.
-	// This must be done before we update vts.Spec.
 	differentAnnotations := differentKeys(vts.Spec.Annotations, newShard.Spec.Annotations)
 	for _, annotation := range differentAnnotations {
 		delete(vts.Annotations, annotation)

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -182,6 +182,8 @@ func updateVitessShardAnnotations(vts *planetscalev2.VitessShard, newShard *plan
 
 	// Update annotations we set.
 	update.Annotations(&vts.Annotations, newShard.Annotations)
+
+	vts.Spec.Annotations = newShard.Spec.Annotations
 }
 
 // differentKeys returns keys from an older map instance that are no longer in a newer map instance.

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -162,6 +162,15 @@ func updateVitessShard(key client.ObjectKey, vts *planetscalev2.VitessShard, vtk
 	vts.Spec = newShard.Spec
 }
 
+func updateVitessShardInPlace(key client.ObjectKey, vts *planetscalev2.VitessShard, vtk *planetscalev2.VitessKeyspace, parentLabels map[string]string, shard *planetscalev2.VitessKeyspaceKeyRangeShard) {
+	newShard := newVitessShard(key, vtk, parentLabels, shard)
+
+	// For now, only disk size & annotations are safe to update in place.
+	update.ShardDiskSize(vts.Spec.TabletPools, newShard.Spec.TabletPools)
+
+	updateVitessShardAnnotations(vts, newShard)
+}
+
 func updateVitessShardAnnotations(vts *planetscalev2.VitessShard, newShard *planetscalev2.VitessShard) {
 	// Remove old annotations that shouldn't be there that we injected previously.
 	// This must be done before we update vts.Spec.
@@ -172,15 +181,6 @@ func updateVitessShardAnnotations(vts *planetscalev2.VitessShard, newShard *plan
 
 	// Update annotations we set.
 	update.Annotations(&vts.Annotations, newShard.Annotations)
-}
-
-func updateVitessShardInPlace(key client.ObjectKey, vts *planetscalev2.VitessShard, vtk *planetscalev2.VitessKeyspace, parentLabels map[string]string, shard *planetscalev2.VitessKeyspaceKeyRangeShard) {
-	newShard := newVitessShard(key, vtk, parentLabels, shard)
-
-	// For now, only disk size & annotations are safe to update in place.
-	update.ShardDiskSize(vts.Spec.TabletPools, newShard.Spec.TabletPools)
-
-	updateVitessShardAnnotations(vts, newShard)
 }
 
 // differentKeys returns keys from an older map instance that are no longer in a newer map instance.

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -156,7 +156,7 @@ func updateVitessShard(key client.ObjectKey, vts *planetscalev2.VitessShard, vtk
 	// Update labels, but ignore existing ones we don't set.
 	update.Labels(&vts.Labels, newShard.Labels)
 
-	// Remove old annotations that shouldn't be there that we injected previously.
+	// Add or remove annotations requested in vts.Spec.Annotations.
 	// This must be done before we update vts.Spec.
 	updateVitessShardAnnotations(vts, newShard)
 
@@ -170,7 +170,7 @@ func updateVitessShardInPlace(key client.ObjectKey, vts *planetscalev2.VitessSha
 	// For now, only disk size & annotations are safe to update in place.
 	update.ShardDiskSize(vts.Spec.TabletPools, newShard.Spec.TabletPools)
 
-	// Remove old annotations that shouldn't be there that we injected previously.
+	// Add or remove annotations requested in vts.Spec.Annotations.
 	updateVitessShardAnnotations(vts, newShard)
 }
 

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -156,6 +156,13 @@ func updateVitessShard(key client.ObjectKey, vts *planetscalev2.VitessShard, vtk
 	// Update labels, but ignore existing ones we don't set.
 	update.Labels(&vts.Labels, newShard.Labels)
 
+	updateVitessShardAnnotations(vts, newShard)
+
+	// For now, everything in Spec is safe to update.
+	vts.Spec = newShard.Spec
+}
+
+func updateVitessShardAnnotations(vts *planetscalev2.VitessShard, newShard *planetscalev2.VitessShard) {
 	// Remove old annotations that shouldn't be there that we injected previously.
 	// This must be done before we update vts.Spec.
 	differentAnnotations := differentKeys(vts.Spec.Annotations, newShard.Spec.Annotations)
@@ -165,16 +172,15 @@ func updateVitessShard(key client.ObjectKey, vts *planetscalev2.VitessShard, vtk
 
 	// Update annotations we set.
 	update.Annotations(&vts.Annotations, newShard.Annotations)
-
-	// For now, everything in Spec is safe to update.
-	vts.Spec = newShard.Spec
 }
 
 func updateVitessShardInPlace(key client.ObjectKey, vts *planetscalev2.VitessShard, vtk *planetscalev2.VitessKeyspace, parentLabels map[string]string, shard *planetscalev2.VitessKeyspaceKeyRangeShard) {
 	newShard := newVitessShard(key, vtk, parentLabels, shard)
 
-	// For now, only disk size is safe to update in place.
+	// For now, only disk size & annotations are safe to update in place.
 	update.ShardDiskSize(vts.Spec.TabletPools, newShard.Spec.TabletPools)
+
+	updateVitessShardAnnotations(vts, newShard)
 }
 
 // differentKeys returns keys from an older map instance that are no longer in a newer map instance.

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -61,6 +61,8 @@ func NewPod(key client.ObjectKey, spec *Spec) *corev1.Pod {
 func UpdatePodInPlace(obj *corev1.Pod, spec *Spec) {
 	// Update labels and annotations, but ignore existing ones we don't set.
 	update.Labels(&obj.Labels, spec.Labels)
+
+	updatePodAnnotations(obj, spec)
 }
 
 // UpdatePod updates all parts of a vttablet Pod to match the desired state,
@@ -73,15 +75,8 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 
 	// Update desired user labels.
 	update.Labels(&obj.Labels, spec.ExtraLabels)
-	// Update desired annotations.
-	update.Annotations(&obj.Annotations, spec.Annotations)
 
-	// Record hashes of desired label and annotation keys to force the Pod
-	// to be recreated if a key disappears from the desired list.
-	update.Annotations(&obj.Annotations, map[string]string{
-		"planetscale.com/labels-keys-hash":      contenthash.StringMapKeys(spec.ExtraLabels),
-		"planetscale.com/annotations-keys-hash": contenthash.StringMapKeys(spec.Annotations),
-	})
+	updatePodAnnotations(obj, spec)
 
 	// Collect some common values that will be shared across containers.
 	volumeMounts := tabletVolumeMounts.Get(spec)
@@ -336,6 +331,18 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 
 	// Use the PriorityClass we defined for vttablets in deploy/priority.yaml.
 	obj.Spec.PriorityClassName = vttabletPriorityClassName
+}
+
+func updatePodAnnotations(obj *corev1.Pod, spec *Spec) {
+	// Update desired annotations.
+	update.Annotations(&obj.Annotations, spec.Annotations)
+
+	// Record hashes of desired label and annotation keys to force the Pod
+	// to be recreated if a key disappears from the desired list.
+	update.Annotations(&obj.Annotations, map[string]string{
+		"planetscale.com/labels-keys-hash":      contenthash.StringMapKeys(spec.ExtraLabels),
+		"planetscale.com/annotations-keys-hash": contenthash.StringMapKeys(spec.Annotations),
+	})
 }
 
 // AliasFromPod returns a TabletAlias corresponding to a vttablet Pod.


### PR DESCRIPTION
We discovered that for all of our use cases, we always want annotations to apply instantly, so we decided to reverse the current behavior. This PR ensures that annotations that were previously held behind updates issued by an external actor, are always applied immediately. 