### PR TITLE
Export Defaulting Code for Update Strategy

### DIFF
--- a/pkg/apis/planetscale/v2/vitesscluster_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_defaults.go
@@ -30,7 +30,7 @@ func DefaultVitessCluster(vt *VitessCluster) {
 	DefaultVitessKeyspaceTemplates(vt.Spec.Keyspaces)
 	defaultClusterBackup(vt.Spec.Backup)
 	DefaultTopoReconcileConfig(&vt.Spec.TopologyReconciliation)
-	defaultUpdateStrategy(&vt.Spec.UpdateStrategy)
+	DefaultUpdateStrategy(&vt.Spec.UpdateStrategy)
 }
 
 func defaultGlobalLockserver(vt *VitessCluster) {
@@ -170,7 +170,7 @@ func DefaultTopoReconcileConfig(confPtr **TopoReconcileConfig) {
 	}
 }
 
-func defaultUpdateStrategy(updateStratPtr **VitessClusterUpdateStrategy) {
+func DefaultUpdateStrategy(updateStratPtr **VitessClusterUpdateStrategy) {
 	if *updateStratPtr == nil {
 		*updateStratPtr = &VitessClusterUpdateStrategy{}
 	}

--- a/pkg/apis/planetscale/v2/vitesskeyspace_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_defaults.go
@@ -22,7 +22,7 @@ package v2
 // might not be safe to deref.
 func DefaultVitessKeyspace(dst *VitessKeyspace) {
 	DefaultTopoReconcileConfig(&dst.Spec.TopologyReconciliation)
-	defaultUpdateStrategy(&dst.Spec.UpdateStrategy)
+	DefaultUpdateStrategy(&dst.Spec.UpdateStrategy)
 }
 
 // DefaultVitessKeyspaceImages fills in unspecified keyspace-level images from cluster-level defaults.


### PR DESCRIPTION
This should have been exported in the original PR, in case consumers of `vitess-operator` need to re-use this defaulting logic.