### PR TITLE
Add option to disable replication repair

### DIFF
--- a/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
@@ -1169,11 +1169,13 @@ spec:
                                           restored shard that has no master yet.  Default:
                                           true.'
                                         type: boolean
-                                      replicationRepair:
-                                        description: 'ReplicationRepair specifies
-                                          whether the replication repair should be
-                                          executed when replica tablets have broken
-                                          replication.  Default: true.'
+                                      recoverRestartedMaster:
+                                        description: 'RecoverRestartedMaster specifies
+                                          whether the operator attempts to repair
+                                          replication when the master MySQL restarts
+                                          in-place (due to a crash) or its Pod gets
+                                          deleted and recreated, causing the Pod IP
+                                          to change.  Default: true.'
                                         type: boolean
                                     type: object
                                   tabletPools:
@@ -1621,11 +1623,12 @@ spec:
                                         to choose an initial master for a new or restored
                                         shard that has no master yet.  Default: true.'
                                       type: boolean
-                                    replicationRepair:
-                                      description: 'ReplicationRepair specifies whether
-                                        the replication repair should be executed
-                                        when replica tablets have broken replication.  Default:
-                                        true.'
+                                    recoverRestartedMaster:
+                                      description: 'RecoverRestartedMaster specifies
+                                        whether the operator attempts to repair replication
+                                        when the master MySQL restarts in-place (due
+                                        to a crash) or its Pod gets deleted and recreated,
+                                        causing the Pod IP to change.  Default: true.'
                                       type: boolean
                                   type: object
                                 tabletPools:

--- a/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesscluster_crd.yaml
@@ -1169,6 +1169,12 @@ spec:
                                           restored shard that has no master yet.  Default:
                                           true.'
                                         type: boolean
+                                      replicationRepair:
+                                        description: 'ReplicationRepair specifies
+                                          whether the replication repair should be
+                                          executed when replica tablets have broken
+                                          replication.  Default: true.'
+                                        type: boolean
                                     type: object
                                   tabletPools:
                                     description: TabletPools specify groups of tablets
@@ -1614,6 +1620,12 @@ spec:
                                       description: 'InitializeMaster specifies whether
                                         to choose an initial master for a new or restored
                                         shard that has no master yet.  Default: true.'
+                                      type: boolean
+                                    replicationRepair:
+                                      description: 'ReplicationRepair specifies whether
+                                        the replication repair should be executed
+                                        when replica tablets have broken replication.  Default:
+                                        true.'
                                       type: boolean
                                   type: object
                                 tabletPools:

--- a/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
@@ -508,11 +508,12 @@ spec:
                                     to choose an initial master for a new or restored
                                     shard that has no master yet.  Default: true.'
                                   type: boolean
-                                replicationRepair:
-                                  description: 'ReplicationRepair specifies whether
-                                    the replication repair should be executed when
-                                    replica tablets have broken replication.  Default:
-                                    true.'
+                                recoverRestartedMaster:
+                                  description: 'RecoverRestartedMaster specifies whether
+                                    the operator attempts to repair replication when
+                                    the master MySQL restarts in-place (due to a crash)
+                                    or its Pod gets deleted and recreated, causing
+                                    the Pod IP to change.  Default: true.'
                                   type: boolean
                               type: object
                             tabletPools:
@@ -924,10 +925,12 @@ spec:
                                   choose an initial master for a new or restored shard
                                   that has no master yet.  Default: true.'
                                 type: boolean
-                              replicationRepair:
-                                description: 'ReplicationRepair specifies whether
-                                  the replication repair should be executed when replica
-                                  tablets have broken replication.  Default: true.'
+                              recoverRestartedMaster:
+                                description: 'RecoverRestartedMaster specifies whether
+                                  the operator attempts to repair replication when
+                                  the master MySQL restarts in-place (due to a crash)
+                                  or its Pod gets deleted and recreated, causing the
+                                  Pod IP to change.  Default: true.'
                                 type: boolean
                             type: object
                           tabletPools:

--- a/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitesskeyspace_crd.yaml
@@ -508,6 +508,12 @@ spec:
                                     to choose an initial master for a new or restored
                                     shard that has no master yet.  Default: true.'
                                   type: boolean
+                                replicationRepair:
+                                  description: 'ReplicationRepair specifies whether
+                                    the replication repair should be executed when
+                                    replica tablets have broken replication.  Default:
+                                    true.'
+                                  type: boolean
                               type: object
                             tabletPools:
                               description: TabletPools specify groups of tablets in
@@ -917,6 +923,11 @@ spec:
                                 description: 'InitializeMaster specifies whether to
                                   choose an initial master for a new or restored shard
                                   that has no master yet.  Default: true.'
+                                type: boolean
+                              replicationRepair:
+                                description: 'ReplicationRepair specifies whether
+                                  the replication repair should be executed when replica
+                                  tablets have broken replication.  Default: true.'
                                 type: boolean
                             type: object
                           tabletPools:

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -433,6 +433,11 @@ spec:
                     master for a new or restored shard that has no master yet.  Default:
                     true.'
                   type: boolean
+                replicationRepair:
+                  description: 'ReplicationRepair specifies whether the replication
+                    repair should be executed when replica tablets have broken replication.  Default:
+                    true.'
+                  type: boolean
               type: object
             tabletPools:
               description: TabletPools specify groups of tablets in a given cell with

--- a/deploy/crds/planetscale_v2_vitessshard_crd.yaml
+++ b/deploy/crds/planetscale_v2_vitessshard_crd.yaml
@@ -433,10 +433,11 @@ spec:
                     master for a new or restored shard that has no master yet.  Default:
                     true.'
                   type: boolean
-                replicationRepair:
-                  description: 'ReplicationRepair specifies whether the replication
-                    repair should be executed when replica tablets have broken replication.  Default:
-                    true.'
+                recoverRestartedMaster:
+                  description: 'RecoverRestartedMaster specifies whether the operator
+                    attempts to repair replication when the master MySQL restarts
+                    in-place (due to a crash) or its Pod gets deleted and recreated,
+                    causing the Pod IP to change.  Default: true.'
                   type: boolean
               type: object
             tabletPools:

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4978,6 +4978,19 @@ if a backup location is defined in the VitessCluster.</p>
 <p>Default: true.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>replicationRepair</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ReplicationRepair specifies whether the replication repair should be executed
+when replica tablets have broken replication.</p>
+<p>Default: true.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.VitessShard">VitessShard

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4980,14 +4980,15 @@ if a backup location is defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>replicationRepair</code></br>
+<code>recoverRestartedMaster</code></br>
 <em>
 bool
 </em>
 </td>
 <td>
-<p>ReplicationRepair specifies whether the replication repair should be executed
-when replica tablets have broken replication.</p>
+<p>RecoverRestartedMaster specifies whether the operator attempts to repair
+replication when the master MySQL restarts in-place (due to a crash) or
+its Pod gets deleted and recreated, causing the Pod IP to change.</p>
 <p>Default: true.</p>
 </td>
 </tr>

--- a/pkg/apis/planetscale/v2/vitessshard_defaults.go
+++ b/pkg/apis/planetscale/v2/vitessshard_defaults.go
@@ -49,7 +49,7 @@ func DefaultVitessReplicationSpec(replicationSpec *VitessReplicationSpec) {
 	}
 
 	// Enable replication repair by default.
-	if replicationSpec.ReplicationRepair == nil {
-		replicationSpec.ReplicationRepair = pointer.BoolPtr(true)
+	if replicationSpec.RecoverRestartedMaster == nil {
+		replicationSpec.RecoverRestartedMaster = pointer.BoolPtr(true)
 	}
 }

--- a/pkg/apis/planetscale/v2/vitessshard_defaults.go
+++ b/pkg/apis/planetscale/v2/vitessshard_defaults.go
@@ -47,4 +47,9 @@ func DefaultVitessReplicationSpec(replicationSpec *VitessReplicationSpec) {
 	if replicationSpec.InitializeBackup == nil {
 		replicationSpec.InitializeBackup = pointer.BoolPtr(true)
 	}
+
+	// Enable replication repair by default.
+	if replicationSpec.ReplicationRepair == nil {
+		replicationSpec.ReplicationRepair = pointer.BoolPtr(true)
+	}
 }

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -152,6 +152,12 @@ type VitessReplicationSpec struct {
 	//
 	// Default: true.
 	InitializeBackup *bool `json:"initializeBackup,omitempty"`
+
+	// ReplicationRepair specifies whether the replication repair should be executed
+	// when replica tablets have broken replication.
+	//
+	// Default: true.
+	ReplicationRepair *bool `json:"replicationRepair,omitempty"`
 }
 
 // VitessShardTabletPool defines a pool of tablets with a similar purpose.

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -153,11 +153,12 @@ type VitessReplicationSpec struct {
 	// Default: true.
 	InitializeBackup *bool `json:"initializeBackup,omitempty"`
 
-	// ReplicationRepair specifies whether the replication repair should be executed
-	// when replica tablets have broken replication.
+	// RecoverRestartedMaster specifies whether the operator attempts to repair
+	// replication when the master MySQL restarts in-place (due to a crash) or
+	// its Pod gets deleted and recreated, causing the Pod IP to change.
 	//
 	// Default: true.
-	ReplicationRepair *bool `json:"replicationRepair,omitempty"`
+	RecoverRestartedMaster *bool `json:"recoverRestartedMaster,omitempty"`
 }
 
 // VitessShardTabletPool defines a pool of tablets with a similar purpose.

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -1849,8 +1849,8 @@ func (in *VitessReplicationSpec) DeepCopyInto(out *VitessReplicationSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.ReplicationRepair != nil {
-		in, out := &in.ReplicationRepair, &out.ReplicationRepair
+	if in.RecoverRestartedMaster != nil {
+		in, out := &in.RecoverRestartedMaster, &out.RecoverRestartedMaster
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -1849,6 +1849,11 @@ func (in *VitessReplicationSpec) DeepCopyInto(out *VitessReplicationSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ReplicationRepair != nil {
+		in, out := &in.ReplicationRepair, &out.ReplicationRepair
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/vitessshardreplication/repair_replication.go
+++ b/pkg/controller/vitessshardreplication/repair_replication.go
@@ -81,6 +81,12 @@ func (r *ReconcileVitessShard) repairReplication(ctx context.Context, vts *plane
 
 	// If using external datastore then replication is handled for us.
 	if vts.Spec.UsingExternalDatastore() {
+	 	return resultBuilder.Result()
+	}
+
+	// If we have configured the operator to ignore replication repair, bail.
+	if !*vts.Spec.Replication.ReplicationRepair {
+		log.Warningf("skip replication repair for master tablet %v", vts.Status.MasterAlias)
 		return resultBuilder.Result()
 	}
 

--- a/pkg/controller/vitessshardreplication/repair_replication.go
+++ b/pkg/controller/vitessshardreplication/repair_replication.go
@@ -85,8 +85,7 @@ func (r *ReconcileVitessShard) repairReplication(ctx context.Context, vts *plane
 	}
 
 	// If we have configured the operator to ignore replication repair, bail.
-	if !*vts.Spec.Replication.ReplicationRepair {
-		log.Warningf("skip replication repair for master tablet %v", vts.Status.MasterAlias)
+	if !*vts.Spec.Replication.RecoverRestartedMaster {
 		return resultBuilder.Result()
 	}
 


### PR DESCRIPTION
When using the operator with orchestrator the repair replication should be disabled to avoid any race condition with multiple agents fixing the same master.
The following PR adds the replication option for disabling the operator replication repair.

```yaml
replication:
   recoverRestartedMaster: false
```

Closes: #85 

