### PR TITLE
DefaultUpdateStrategy: Only default External options if not specified.

### DIFF
--- a/pkg/apis/planetscale/v2/vitesscluster_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_defaults.go
@@ -184,6 +184,8 @@ func DefaultUpdateStrategy(updateStratPtr **VitessClusterUpdateStrategy) {
 	}
 
 	if *updateStrat.Type == ExternalVitessClusterUpdateStrategyType {
-		updateStrat.External = &ExternalVitessClusterUpdateStrategyOptions{}
+		if updateStrat.External == nil {
+			updateStrat.External = &ExternalVitessClusterUpdateStrategyOptions{}
+		}
 	}
 }


### PR DESCRIPTION
If it's already non-nil, it means the user specified options.