### PR TITLE
Update Example With Immediate Update Strategy

### DIFF
--- a/deploy/example.yaml
+++ b/deploy/example.yaml
@@ -57,6 +57,8 @@ spec:
               resources:
                 requests:
                   storage: 10Gi
+  updateStrategy:
+    type: Immediate
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
This PR updates the example deployment config by explicitely setting the update strategy to immediate. It's likely that this is the behavior a new user expects, and so we should include this in the example config.