### PR TITLE
Set GOMAXPROCS for vtgate and vttablet.

### DIFF
--- a/pkg/operator/vtgate/deployment.go
+++ b/pkg/operator/vtgate/deployment.go
@@ -151,6 +151,10 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 		obj.Spec.Template.Spec.Affinity = nil
 	}
 
+	env := []corev1.EnvVar{}
+	update.GOMAXPROCS(&env, spec.Resources)
+	update.Env(&env, spec.ExtraEnv)
+
 	// Start building the main Container to put in the Pod template.
 	vtgateContainer := &corev1.Container{
 		Name:            containerName,
@@ -197,7 +201,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 			FailureThreshold:    30,
 		},
 		VolumeMounts: spec.ExtraVolumeMounts,
-		Env:          spec.ExtraEnv,
+		Env:          env,
 	}
 
 	// Get all the flags that don't need any logic.

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -99,6 +99,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 	// Compute all operator-generated env vars first.
 	env := tabletEnvVars.Get(spec)
 	vttabletEnv := append(vttabletEnvVars.Get(spec), env...)
+	update.GOMAXPROCS(&vttabletEnv, spec.Vttablet.Resources)
 	// Then apply user-provided overrides last so they take precedence.
 	update.Env(&env, spec.ExtraEnv)
 	update.Env(&vttabletEnv, spec.ExtraEnv)


### PR DESCRIPTION
When a CPU limit is configured, we should set GOMAXPROCS to match. Otherwise, Go will run lots of threads which quickly use up CPU quota, leading to stalling when quota runs out.