### PR TITLE
vtbackup: Include ExtraEnv from tablet pool.

### DIFF
--- a/pkg/controller/vitessshard/reconcile_backup_job.go
+++ b/pkg/controller/vitessshard/reconcile_backup_job.go
@@ -242,6 +242,7 @@ func vtbackupSpec(key client.ObjectKey, vts *planetscalev2.VitessShard, parentLa
 			BackupEngine:             vts.Spec.BackupEngine,
 			InitContainers:           pool.InitContainers,
 			SidecarContainers:        pool.SidecarContainers,
+			ExtraEnv:                 pool.ExtraEnv,
 		},
 	}
 }

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -101,6 +101,9 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec) *corev1.Pod {
 		Name:  "HOME",
 		Value: homeDir,
 	})
+	// Then apply user-provided overrides last so they take precedence.
+	update.Env(&env, tabletSpec.ExtraEnv)
+
 	// Mount everything for both vttablet and mysqld, since vtbackup does both
 	// jobs. We also need an additional mount to get SSL certs.
 	volumeMounts := []corev1.VolumeMount{


### PR DESCRIPTION
The vtbackup Pods should share settings with vttablet where possible to keep things uniform, since vtbackup is really a special, stripped-down vttablet. Env vars should be safe to share since, unlike flags, unknown vars will be ignored.