### PR TITLE
Fix: Copy ExtraLabels from VitessShardTabletPool down to vttablet Spec

### DIFF
--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -333,6 +333,7 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 				Affinity:                 pool.Affinity,
 				ExtraEnv:                 pool.ExtraEnv,
 				ExtraVolumes:             pool.ExtraVolumes,
+				ExtraLabels:              pool.ExtraLabels,
 				InitContainers:           pool.InitContainers,
 				SidecarContainers:        pool.SidecarContainers,
 				ExtraVolumeMounts:        pool.ExtraVolumeMounts,


### PR DESCRIPTION
This fixes a bug where we were not copying `ExtraLabels` from the `VitessShardTabletPool` down to the vttablet `Spec`.