### PR TITLE
Fix: Copy ExtraLabels from EtcdLockserverSpec down to etcd pod Spec

### DIFF
--- a/pkg/controller/etcdlockserver/reconcile_members.go
+++ b/pkg/controller/etcdlockserver/reconcile_members.go
@@ -157,6 +157,7 @@ func memberSpecs(ls *planetscalev2.EtcdLockserver, parentLabels map[string]strin
 			ExtraEnv:          ls.Spec.ExtraEnv,
 			ExtraVolumes:      ls.Spec.ExtraVolumes,
 			ExtraVolumeMounts: ls.Spec.ExtraVolumeMounts,
+			ExtraLabels:       ls.Spec.ExtraLabels,
 			InitContainers:    ls.Spec.InitContainers,
 			SidecarContainers: ls.Spec.SidecarContainers,
 			Affinity:          ls.Spec.Affinity,


### PR DESCRIPTION
This fixes a bug where we were not copying `ExtraLabels` from the `EtcdLockserverSpec` down to the etcd pod `Spec`.