### PR TITLE
Support keyspace name with underscore

### DIFF
--- a/pkg/controller/vitesscluster/reconcile_keyspaces.go
+++ b/pkg/controller/vitesscluster/reconcile_keyspaces.go
@@ -19,6 +19,7 @@ package vitesscluster
 import (
 	"context"
 	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +46,7 @@ func (r *ReconcileVitessCluster) reconcileKeyspaces(ctx context.Context, vt *pla
 	keyspaceMap := make(map[client.ObjectKey]*planetscalev2.VitessKeyspaceTemplate, len(vt.Spec.Keyspaces))
 	for i := range vt.Spec.Keyspaces {
 		keyspace := &vt.Spec.Keyspaces[i]
-		key := client.ObjectKey{Namespace: vt.Namespace, Name: vitesskeyspace.Name(vt.Name, keyspace.Name)}
+		key := client.ObjectKey{Namespace: vt.Namespace, Name: strings.ReplaceAll(vitesskeyspace.Name(vt.Name, keyspace.Name), "_", "-")}
 		keys = append(keys, key)
 		keyspaceMap[key] = keyspace
 

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -18,6 +18,7 @@ package vitesskeyspace
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +48,7 @@ func (r *ReconcileVitessKeyspace) reconcileShards(ctx context.Context, vtk *plan
 	keys := make([]client.ObjectKey, 0, len(shards))
 	shardMap := make(map[client.ObjectKey]*planetscalev2.VitessKeyspaceKeyRangeShard, len(shards))
 	for _, shard := range shards {
-		key := client.ObjectKey{Namespace: vtk.Namespace, Name: vitessshard.Name(clusterName, vtk.Spec.Name, shard.KeyRange)}
+		key := client.ObjectKey{Namespace: vtk.Namespace, Name: strings.ReplaceAll(vitessshard.Name(clusterName, vtk.Spec.Name, shard.KeyRange), "_", "-")}
 		keys = append(keys, key)
 		shardMap[key] = shard
 


### PR DESCRIPTION
According to https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions,
underscore is not allowed in the name of CRD resource, we replace the underscore with hypen as a workaround.