### PR TITLE
Fix compatibility with older Vitess builds.

### DIFF
--- a/pkg/controller/vitessshardreplication/init_shard_master.go
+++ b/pkg/controller/vitessshardreplication/init_shard_master.go
@@ -20,13 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
@@ -198,7 +196,7 @@ func readyForShardInit(ctx context.Context, ts *topo.Server, tmc tmclient.Tablet
 	}
 	// We expect the error ErrNotReplica, which means "SHOW SLAVE STATUS" returned
 	// zero rows (replication is not configured at all).
-	if !strings.Contains(err.Error(), mysql.ErrNotReplica.Error()) {
+	if !isErrNotReplica(err) {
 		// SlaveStatus() failed for the wrong reason.
 		return fmt.Errorf("failed to get slave status for tablet %v: %v", name, err)
 	}


### PR DESCRIPTION
We have been depending on the text of an RPC error message in a brittle way because there's no better alternative yet. Vitess changed the text of the error, so we need to check for multiple possibilities to remain compatible with both older and newer Vitess versions.