### PR TITLE
Fix: Nil Check BackupLocation

### DIFF
--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -306,7 +306,9 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 				drain.SupportedAnnotation: "ensure that the tablet is not a master",
 			}
 			update.Annotations(&annotations, pool.Annotations)
-			update.Annotations(&annotations, backupLocation.Annotations)
+			if backupLocation != nil {
+				update.Annotations(&annotations, backupLocation.Annotations)
+			}
 			tablets = append(tablets, &vttablet.Spec{
 				GlobalLockserver:         vts.Spec.GlobalLockserver,
 				Labels:                   labels,


### PR DESCRIPTION
This safety check fixes a panic caused by trying to update annotations off a potentially nil backup location.