### PR TITLE
Elaborate on docs for backup location name field.

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1908,10 +1908,12 @@ string
 </td>
 <td>
 <p>Name is used to refer to this backup location from other parts of a
-VitessCluster object, such as in tablet pool definitions. This name
-must be unique among all backup locations defined in a given cluster.
-A backup location with an empty name defines the default location used
-when a tablet pool does not specify a backup location name.</p>
+VitessCluster object.</p>
+<p>In particular, the backupLocationName field in each tablet pool within
+each shard must match one of the names defined by this field.</p>
+<p>This name must be unique among all backup locations defined in a given
+cluster. A backup location with an empty name defines the default
+location used when a tablet pool does not specify a backupLocationName.</p>
 </td>
 </tr>
 <tr>
@@ -1977,7 +1979,7 @@ map[string]string
 </td>
 <td>
 <p>Annotations can optionally be used to attach custom annotations to Pods
-created for this component.</p>
+that need access to this backup storage location.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/planetscale/v2/vitessbackupstorage_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupstorage_types.go
@@ -54,10 +54,14 @@ type VitessBackupStorageSpec struct {
 // VitessBackupLocation defines a location where Vitess backups can be stored.
 type VitessBackupLocation struct {
 	// Name is used to refer to this backup location from other parts of a
-	// VitessCluster object, such as in tablet pool definitions. This name
-	// must be unique among all backup locations defined in a given cluster.
-	// A backup location with an empty name defines the default location used
-	// when a tablet pool does not specify a backup location name.
+	// VitessCluster object.
+	//
+	// In particular, the backupLocationName field in each tablet pool within
+	// each shard must match one of the names defined by this field.
+	//
+	// This name must be unique among all backup locations defined in a given
+	// cluster. A backup location with an empty name defines the default
+	// location used when a tablet pool does not specify a backupLocationName.
 	// +kubebuilder:validation:MaxLength=25
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([a-z0-9]*[a-z0-9])?$
 	Name string `json:"name,omitempty"`


### PR DESCRIPTION
The required matching between `spec.backup.locations[]` and `backupLocationName` was not well documented.