### PR TITLE
Update Gateway Implementation

### DIFF
--- a/pkg/operator/vtgate/deployment.go
+++ b/pkg/operator/vtgate/deployment.go
@@ -43,7 +43,7 @@ const (
 	runAsUser  = 999
 
 	tabletTypesToWait     = "MASTER,REPLICA"
-	gatewayImplementation = "discoverygateway"
+	gatewayImplementation = "tabletgateway"
 
 	bufferMasterTrafficDuringFailover = true
 	bufferMinTimeBetweenFailovers     = "20s"


### PR DESCRIPTION
This PR updates the gateway implementation. Without this we cannot support SET statements that are supported in v7, even though `vtop` has already been updated to use v7.