### PR TITLE
Add a field to propagate annotations to VitessKeyspace objects.

### DIFF
--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -878,6 +878,10 @@ spec:
             keyspaces:
               items:
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
                   databaseName:
                     type: string
                   name:

--- a/deploy/crds/planetscale.com_vitesskeyspaces.yaml
+++ b/deploy/crds/planetscale.com_vitesskeyspaces.yaml
@@ -28,6 +28,10 @@ spec:
           type: object
         spec:
           properties:
+            annotations:
+              additionalProperties:
+                type: string
+              type: object
             backupEngine:
               type: string
             backupLocations:

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -5176,6 +5176,17 @@ you can set the policy to Immediate to skip these checks.</p>
 <p>Default: RequireIdle</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>annotations</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Annotations can optionally be used to attach custom annotations to the VitessKeyspace object.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.VitessKeyspaceTurndownPolicy">VitessKeyspaceTurndownPolicy

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -166,6 +166,9 @@ type VitessKeyspaceTemplate struct {
 	// Default: RequireIdle
 	// +kubebuilder:validation:Enum=RequireIdle;Immediate
 	TurndownPolicy VitessKeyspaceTurndownPolicy `json:"turndownPolicy,omitempty"`
+
+	// Annotations can optionally be used to attach custom annotations to the VitessKeyspace object.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // VitessKeyspaceTurndownPolicy is the policy for turning down a keyspace.

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -1865,6 +1865,13 @@ func (in *VitessKeyspaceTemplate) DeepCopyInto(out *VitessKeyspaceTemplate) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
This is copied from the existing field to add annotations to VitessShard objects.