### PR TITLE
Add/remove partitionings in place.

### DIFF
--- a/pkg/controller/vitesscluster/reconcile_keyspaces.go
+++ b/pkg/controller/vitesscluster/reconcile_keyspaces.go
@@ -216,6 +216,10 @@ func updateVitessKeyspaceInPlace(key client.ObjectKey, vtk *planetscalev2.Vitess
 		}
 	}
 
+	// Add or remove partitionings as needed, but don't immediately reconfigure
+	// partitionings that already exist.
+	update.PartitioningSet(&vtk.Spec.Partitionings, newKeyspace.Spec.Partitionings)
+
 	// Only update things that are safe to roll out immediately.
 	vtk.Spec.TurndownPolicy = newKeyspace.Spec.TurndownPolicy
 

--- a/pkg/operator/update/partitionings.go
+++ b/pkg/operator/update/partitionings.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"strings"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+)
+
+// PartitioningSet adds, removes, or reorders partitionings in dst as needed to
+// keep the set of partitionings in sync with src, without changing the content
+// of any partitioning that already existed in dst.
+func PartitioningSet(dst *[]planetscalev2.VitessKeyspacePartitioning, src []planetscalev2.VitessKeyspacePartitioning) {
+	// Make a map of partitionings that already exist in dst.
+	// If there are multiple partitionings with the same key, we take the latest
+	// one in the list to be consistent with the deduplication rule used in
+	// VitessKeyspaceTemplate.ShardTemplates().
+	dstMap := make(map[string]planetscalev2.VitessKeyspacePartitioning, len(*dst))
+	for _, partitioning := range *dst {
+		dstMap[partitioningKey(partitioning)] = partitioning
+	}
+
+	// Make a new slice of partitionings based on src, but replace the content
+	// with that from dst for any partitionings that already existed.
+	result := make([]planetscalev2.VitessKeyspacePartitioning, len(src))
+
+	for i, partitioning := range src {
+		key := partitioningKey(partitioning)
+
+		if dstPartitioning, exists := dstMap[key]; exists {
+			partitioning = dstPartitioning
+		}
+
+		result[i] = partitioning
+	}
+
+	*dst = result
+}
+
+// partitioningKey generates a map key to identify a partitioning by the set of
+// shards it contains. Any two partitionings that specify the same set of shard
+// ranges will be given the same key.
+func partitioningKey(partitioning planetscalev2.VitessKeyspacePartitioning) string {
+	return strings.Join(partitioning.ShardNameSet().List(), ",")
+}

--- a/pkg/operator/update/partitionings_test.go
+++ b/pkg/operator/update/partitionings_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+)
+
+func TestPartitioningSet(t *testing.T) {
+	dst := []planetscalev2.VitessKeyspacePartitioning{
+		testEqualPartitioning(2, "should be removed"),
+		testEqualPartitioning(4, "original value from dst"),
+	}
+	src := []planetscalev2.VitessKeyspacePartitioning{
+		testEqualPartitioning(4, "try to change value in src"),
+		testEqualPartitioning(8, "new partitioning"),
+	}
+	want := []planetscalev2.VitessKeyspacePartitioning{
+		testEqualPartitioning(4, "original value from dst"),
+		testEqualPartitioning(8, "new partitioning"),
+	}
+
+	PartitioningSet(&dst, src)
+	if !equality.Semantic.DeepEqual(dst, want) {
+		t.Errorf("dst = %v\nwant: %v", toJSON(dst), toJSON(want))
+	}
+}
+
+func testEqualPartitioning(parts int32, message string) planetscalev2.VitessKeyspacePartitioning {
+	return planetscalev2.VitessKeyspacePartitioning{
+		Equal: &planetscalev2.VitessKeyspaceEqualPartitioning{
+			Parts: parts,
+			ShardTemplate: planetscalev2.VitessShardTemplate{
+				Annotations: map[string]string{
+					"test": message,
+				},
+			},
+		},
+	}
+}
+
+func toJSON(obj interface{}) string {
+	b, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
Always immediately add or remove partitionings to stay in sync with the desired set of partitionings, even if changes to existing partitionings are held back by the update strategy. The deployment of new things or the removal of unwanted things should not need to wait for an external rollout.