### PR TITLE
Add customization flags for better OpenShift support

### DIFF
--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -134,12 +134,14 @@ var (
 
 	// DefaultVitessRunAsUser is the UID to use by default for Pods that run
 	// Vitess components. This value can be configured at operator startup time
-	// with the --default_vitess_run_as_user flag.
+	// with the --default_vitess_run_as_user flag. A value less than 0 means
+	// don't set RunAsUser at all.
 	DefaultVitessRunAsUser int64 = 999
 
 	// DefaultVitessFSGroup is the GID to use by default for Pods that run
 	// Vitess components. This value can be configured at operator startup time
-	// with the --default_vitess_fs_group flag.
+	// with the --default_vitess_fs_group flag. A value less than 0 means don't
+	// set FSGroup at all.
 	DefaultVitessFSGroup int64 = 999
 
 	// DefaultEtcdServiceAccount is the name of the ServiceAccount to use by
@@ -149,13 +151,15 @@ var (
 
 	// DefaultEtcdRunAsUser is the UID to use by default for etcd Pods.
 	// This value can be configured at operator startup time with the
-	// --default_etcd_run_as_user flag.
-	DefaultEtcdRunAsUser int64 = 0
+	// --default_etcd_run_as_user flag. A value less than 0 means don't set
+	// RunAsUser at all.
+	DefaultEtcdRunAsUser int64 = -1
 
 	// DefaultEtcdFSGroup is the GID to use by default for etcd Pods.
 	// This value can be configured at operator startup time with the
-	// --default_etcd_fs_group flag.
-	DefaultEtcdFSGroup int64 = 0
+	// --default_etcd_fs_group flag. A value less than 0 means don't set FSGroup
+	// at all.
+	DefaultEtcdFSGroup int64 = -1
 
 	// DefaultEtcdImage is the image to use for etcd when the CRD doesn't specify.
 	// This value can be configured at operator startup time with the

--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -56,7 +56,6 @@ const (
 	// Gi is the scale factor for Gibi (2**30)
 	Gi = 1 << 30
 
-	defaultEtcdImage               = "quay.io/coreos/etcd:v3.3.13"
 	defaultEtcdStorageRequestBytes = 1 * Gi
 	defaultEtcdCPUMillis           = 100
 	defaultEtcdMemoryBytes         = 256 * Mi
@@ -94,18 +93,8 @@ const (
 	defaultVitessLiteImage = "vitess/lite:v7.0.0"
 )
 
-/*
-defaultVitessImages are the default images used for this API Version (planetscale.com/v2).
-
-As discussed in the comment at the top of this file, we cannot change these
-after planetscale.com/v2 is released. Anyone using the operator in production
-should set these images explicitly in the CRD anyway, so they know what they're
-getting and when they need to upgrade.
-
-These API-level defaults exist merely to support a friendly "kick the tires"
-experience when trying out the operator.
-*/
-var defaultVitessImages = &VitessImages{
+// DefaultImages are a set of images to use when the CRD doesn't specify.
+var DefaultImages = &VitessImages{
 	Vtctld:   defaultVitessLiteImage,
 	Vtgate:   defaultVitessLiteImage,
 	Vttablet: defaultVitessLiteImage,
@@ -147,4 +136,9 @@ var (
 	// Vitess components. This value can be configured at operator startup time
 	// with the --default_vitess_fs_group flag.
 	DefaultVitessFSGroup int64 = 999
+
+	// DefaultEtcdImage is the image to use for etcd when the CRD doesn't specify.
+	// This value can be configured at operator startup time with the
+	// --default_etcd_image flag.
+	DefaultEtcdImage = "quay.io/coreos/etcd:v3.3.13"
 )

--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -137,6 +137,16 @@ var (
 	// with the --default_vitess_fs_group flag.
 	DefaultVitessFSGroup int64 = 999
 
+	// DefaultEtcdRunAsUser is the UID to use by default for etcd Pods.
+	// This value can be configured at operator startup time with the
+	// --default_etcd_run_as_user flag.
+	DefaultEtcdRunAsUser int64 = 0
+
+	// DefaultEtcdFSGroup is the GID to use by default for etcd Pods.
+	// This value can be configured at operator startup time with the
+	// --default_etcd_fs_group flag.
+	DefaultEtcdFSGroup int64 = 0
+
 	// DefaultEtcdImage is the image to use for etcd when the CRD doesn't specify.
 	// This value can be configured at operator startup time with the
 	// --default_etcd_image flag.

--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -127,6 +127,11 @@ var (
 	// at operator startup time with the --default_vitess_priority_class flag.
 	DefaultVitessPriorityClass = "vitess"
 
+	// DefaultVitessServiceAccount is the name of the ServiceAccount to use by
+	// default for Pods that run Vitess components. This value can be configured
+	// at operator startup time with the --default_vitess_service_account flag.
+	DefaultVitessServiceAccount = ""
+
 	// DefaultVitessRunAsUser is the UID to use by default for Pods that run
 	// Vitess components. This value can be configured at operator startup time
 	// with the --default_vitess_run_as_user flag.
@@ -136,6 +141,11 @@ var (
 	// Vitess components. This value can be configured at operator startup time
 	// with the --default_vitess_fs_group flag.
 	DefaultVitessFSGroup int64 = 999
+
+	// DefaultEtcdServiceAccount is the name of the ServiceAccount to use by
+	// default for etcd Pods. This value can be configured at operator startup
+	// time with the --default_etcd_service_account flag.
+	DefaultEtcdServiceAccount = ""
 
 	// DefaultEtcdRunAsUser is the UID to use by default for etcd Pods.
 	// This value can be configured at operator startup time with the

--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -135,6 +135,16 @@ var defaultVitessImages = &VitessImages{
 var (
 	// DefaultVitessPriorityClass is the name of the PriorityClass to use by
 	// default for Pods that run Vitess components. This value can be configured
-	// at operator startup time with the -default_vitess_priority_class flag.
+	// at operator startup time with the --default_vitess_priority_class flag.
 	DefaultVitessPriorityClass = "vitess"
+
+	// DefaultVitessRunAsUser is the UID to use by default for Pods that run
+	// Vitess components. This value can be configured at operator startup time
+	// with the --default_vitess_run_as_user flag.
+	DefaultVitessRunAsUser int64 = 999
+
+	// DefaultVitessFSGroup is the GID to use by default for Pods that run
+	// Vitess components. This value can be configured at operator startup time
+	// with the --default_vitess_fs_group flag.
+	DefaultVitessFSGroup int64 = 999
 )

--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -131,3 +131,10 @@ var defaultVitessImages = &VitessImages{
 
 	MysqldExporter: "prom/mysqld-exporter:v0.11.0",
 }
+
+var (
+	// DefaultVitessPriorityClass is the name of the PriorityClass to use by
+	// default for Pods that run Vitess components. This value can be configured
+	// at operator startup time with the -default_vitess_priority_class flag.
+	DefaultVitessPriorityClass = "vitess"
+)

--- a/pkg/apis/planetscale/v2/etcdlockserver_defaults.go
+++ b/pkg/apis/planetscale/v2/etcdlockserver_defaults.go
@@ -32,7 +32,7 @@ func DefaultEtcdLockserverSpec(ls *EtcdLockserverSpec) {
 
 func DefaultEtcdLockserverTemplate(ls *EtcdLockserverTemplate) {
 	if ls.Image == "" {
-		ls.Image = defaultEtcdImage
+		ls.Image = DefaultEtcdImage
 	}
 	if len(ls.DataVolumeClaimTemplate.AccessModes) == 0 {
 		ls.DataVolumeClaimTemplate.AccessModes = []corev1.PersistentVolumeAccessMode{

--- a/pkg/apis/planetscale/v2/vitesscluster_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_defaults.go
@@ -25,7 +25,7 @@ import (
 // DefaultVitessCluster fills in default values for unspecified fields.
 func DefaultVitessCluster(vt *VitessCluster) {
 	defaultGlobalLockserver(vt)
-	DefaultVitessImages(&vt.Spec.Images, defaultVitessImages)
+	DefaultVitessImages(&vt.Spec.Images, DefaultImages)
 	DefaultVitessDashboard(&vt.Spec.VitessDashboard)
 	DefaultVitessKeyspaceTemplates(vt.Spec.Keyspaces)
 	defaultClusterBackup(vt.Spec.Backup)

--- a/pkg/operator/environment/environment.go
+++ b/pkg/operator/environment/environment.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
 )
 
 var (
@@ -34,7 +36,11 @@ var (
 // FlagSet returns the FlagSet for the operator.
 func FlagSet() *pflag.FlagSet {
 	operatorFlagSet := pflag.NewFlagSet("operator", pflag.ExitOnError)
+
 	operatorFlagSet.DurationVar(&reconcileTimeout, "reconcile_timeout", 10*time.Minute, "Maximum time that any controller will spend trying to reconcile a single object before giving up.")
+
+	operatorFlagSet.StringVar(&planetscalev2.DefaultVitessPriorityClass, "default_vitess_priority_class", planetscalev2.DefaultVitessPriorityClass, "Default PriorityClass to use for Pods that run Vitess components. An empty value means don't use any PriorityClass.")
+
 	return operatorFlagSet
 }
 

--- a/pkg/operator/environment/environment.go
+++ b/pkg/operator/environment/environment.go
@@ -43,6 +43,9 @@ func FlagSet() *pflag.FlagSet {
 	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessRunAsUser, "default_vitess_run_as_user", planetscalev2.DefaultVitessRunAsUser, "Default UID to use for Pods that run Vitess components.")
 	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessFSGroup, "default_vitess_fs_group", planetscalev2.DefaultVitessFSGroup, "Default GID to use for Pods that run Vitess components.")
 
+	operatorFlagSet.StringVar(&planetscalev2.DefaultEtcdImage, "default_etcd_image", planetscalev2.DefaultEtcdImage, "Default etcd image to use when not specified in the CRD.")
+	operatorFlagSet.StringVar(&planetscalev2.DefaultImages.MysqldExporter, "default_mysqld_exporter_image", planetscalev2.DefaultImages.MysqldExporter, "Default mysqld-exporter image to use when not specified in the CRD.")
+
 	return operatorFlagSet
 }
 

--- a/pkg/operator/environment/environment.go
+++ b/pkg/operator/environment/environment.go
@@ -40,8 +40,11 @@ func FlagSet() *pflag.FlagSet {
 	operatorFlagSet.DurationVar(&reconcileTimeout, "reconcile_timeout", 10*time.Minute, "Maximum time that any controller will spend trying to reconcile a single object before giving up.")
 
 	operatorFlagSet.StringVar(&planetscalev2.DefaultVitessPriorityClass, "default_vitess_priority_class", planetscalev2.DefaultVitessPriorityClass, "Default PriorityClass to use for Pods that run Vitess components. An empty value means don't use any PriorityClass.")
+	operatorFlagSet.StringVar(&planetscalev2.DefaultVitessServiceAccount, "default_vitess_service_account", planetscalev2.DefaultVitessServiceAccount, "Default ServiceAccount to use for Pods that run Vitess components. An empty value means let Kubernetes fill in a default.")
 	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessRunAsUser, "default_vitess_run_as_user", planetscalev2.DefaultVitessRunAsUser, "Default UID to use for Pods that run Vitess components.")
 	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessFSGroup, "default_vitess_fs_group", planetscalev2.DefaultVitessFSGroup, "Default GID to use for Pods that run Vitess components.")
+
+	operatorFlagSet.StringVar(&planetscalev2.DefaultEtcdServiceAccount, "default_etcd_service_account", planetscalev2.DefaultEtcdServiceAccount, "Default ServiceAccount to use for etcd Pods. An empty value means let Kubernetes fill in a default.")
 	operatorFlagSet.Int64Var(&planetscalev2.DefaultEtcdRunAsUser, "default_etcd_run_as_user", planetscalev2.DefaultEtcdRunAsUser, "Default UID to use for etcd Pods.")
 	operatorFlagSet.Int64Var(&planetscalev2.DefaultEtcdFSGroup, "default_etcd_fs_group", planetscalev2.DefaultEtcdFSGroup, "Default GID to use for etcd Pods.")
 

--- a/pkg/operator/environment/environment.go
+++ b/pkg/operator/environment/environment.go
@@ -41,12 +41,12 @@ func FlagSet() *pflag.FlagSet {
 
 	operatorFlagSet.StringVar(&planetscalev2.DefaultVitessPriorityClass, "default_vitess_priority_class", planetscalev2.DefaultVitessPriorityClass, "Default PriorityClass to use for Pods that run Vitess components. An empty value means don't use any PriorityClass.")
 	operatorFlagSet.StringVar(&planetscalev2.DefaultVitessServiceAccount, "default_vitess_service_account", planetscalev2.DefaultVitessServiceAccount, "Default ServiceAccount to use for Pods that run Vitess components. An empty value means let Kubernetes fill in a default.")
-	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessRunAsUser, "default_vitess_run_as_user", planetscalev2.DefaultVitessRunAsUser, "Default UID to use for Pods that run Vitess components.")
-	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessFSGroup, "default_vitess_fs_group", planetscalev2.DefaultVitessFSGroup, "Default GID to use for Pods that run Vitess components.")
+	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessRunAsUser, "default_vitess_run_as_user", planetscalev2.DefaultVitessRunAsUser, "Default UID to use for Pods that run Vitess components. A value less than 0 means don't set runAsUser at all.")
+	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessFSGroup, "default_vitess_fs_group", planetscalev2.DefaultVitessFSGroup, "Default GID to use for Pods that run Vitess components. A value less than 0 means don't set fsGroup at all.")
 
 	operatorFlagSet.StringVar(&planetscalev2.DefaultEtcdServiceAccount, "default_etcd_service_account", planetscalev2.DefaultEtcdServiceAccount, "Default ServiceAccount to use for etcd Pods. An empty value means let Kubernetes fill in a default.")
-	operatorFlagSet.Int64Var(&planetscalev2.DefaultEtcdRunAsUser, "default_etcd_run_as_user", planetscalev2.DefaultEtcdRunAsUser, "Default UID to use for etcd Pods.")
-	operatorFlagSet.Int64Var(&planetscalev2.DefaultEtcdFSGroup, "default_etcd_fs_group", planetscalev2.DefaultEtcdFSGroup, "Default GID to use for etcd Pods.")
+	operatorFlagSet.Int64Var(&planetscalev2.DefaultEtcdRunAsUser, "default_etcd_run_as_user", planetscalev2.DefaultEtcdRunAsUser, "Default UID to use for etcd Pods. A value less than 0 means don't set runAsUser at all.")
+	operatorFlagSet.Int64Var(&planetscalev2.DefaultEtcdFSGroup, "default_etcd_fs_group", planetscalev2.DefaultEtcdFSGroup, "Default GID to use for etcd Pods. A value less than 0 means don't set fsGroup at all.")
 
 	operatorFlagSet.StringVar(&planetscalev2.DefaultEtcdImage, "default_etcd_image", planetscalev2.DefaultEtcdImage, "Default etcd image to use when not specified in the CRD.")
 	operatorFlagSet.StringVar(&planetscalev2.DefaultImages.MysqldExporter, "default_mysqld_exporter_image", planetscalev2.DefaultImages.MysqldExporter, "Default mysqld-exporter image to use when not specified in the CRD.")

--- a/pkg/operator/environment/environment.go
+++ b/pkg/operator/environment/environment.go
@@ -40,6 +40,8 @@ func FlagSet() *pflag.FlagSet {
 	operatorFlagSet.DurationVar(&reconcileTimeout, "reconcile_timeout", 10*time.Minute, "Maximum time that any controller will spend trying to reconcile a single object before giving up.")
 
 	operatorFlagSet.StringVar(&planetscalev2.DefaultVitessPriorityClass, "default_vitess_priority_class", planetscalev2.DefaultVitessPriorityClass, "Default PriorityClass to use for Pods that run Vitess components. An empty value means don't use any PriorityClass.")
+	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessRunAsUser, "default_vitess_run_as_user", planetscalev2.DefaultVitessRunAsUser, "Default UID to use for Pods that run Vitess components.")
+	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessFSGroup, "default_vitess_fs_group", planetscalev2.DefaultVitessFSGroup, "Default GID to use for Pods that run Vitess components.")
 
 	return operatorFlagSet
 }

--- a/pkg/operator/environment/environment.go
+++ b/pkg/operator/environment/environment.go
@@ -42,6 +42,8 @@ func FlagSet() *pflag.FlagSet {
 	operatorFlagSet.StringVar(&planetscalev2.DefaultVitessPriorityClass, "default_vitess_priority_class", planetscalev2.DefaultVitessPriorityClass, "Default PriorityClass to use for Pods that run Vitess components. An empty value means don't use any PriorityClass.")
 	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessRunAsUser, "default_vitess_run_as_user", planetscalev2.DefaultVitessRunAsUser, "Default UID to use for Pods that run Vitess components.")
 	operatorFlagSet.Int64Var(&planetscalev2.DefaultVitessFSGroup, "default_vitess_fs_group", planetscalev2.DefaultVitessFSGroup, "Default GID to use for Pods that run Vitess components.")
+	operatorFlagSet.Int64Var(&planetscalev2.DefaultEtcdRunAsUser, "default_etcd_run_as_user", planetscalev2.DefaultEtcdRunAsUser, "Default UID to use for etcd Pods.")
+	operatorFlagSet.Int64Var(&planetscalev2.DefaultEtcdFSGroup, "default_etcd_fs_group", planetscalev2.DefaultEtcdFSGroup, "Default GID to use for etcd Pods.")
 
 	operatorFlagSet.StringVar(&planetscalev2.DefaultEtcdImage, "default_etcd_image", planetscalev2.DefaultEtcdImage, "Default etcd image to use when not specified in the CRD.")
 	operatorFlagSet.StringVar(&planetscalev2.DefaultImages.MysqldExporter, "default_mysqld_exporter_image", planetscalev2.DefaultImages.MysqldExporter, "Default mysqld-exporter image to use when not specified in the CRD.")

--- a/pkg/operator/etcd/pod.go
+++ b/pkg/operator/etcd/pod.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
 	"planetscale.dev/vitess-operator/pkg/operator/contenthash"
 	"planetscale.dev/vitess-operator/pkg/operator/k8s"
 	"planetscale.dev/vitess-operator/pkg/operator/update"
@@ -49,9 +50,8 @@ const (
 	//          having different sizes for different EtcdLockserver objects.
 	NumReplicas = 3
 
-	etcdContainerName     = "etcd"
-	etcdCommand           = "/usr/local/bin/etcd"
-	etcdPriorityClassName = "vitess"
+	etcdContainerName = "etcd"
+	etcdCommand       = "/usr/local/bin/etcd"
 
 	dataVolumeName      = "data"
 	dataVolumeMountPath = "/var/etcd"
@@ -284,8 +284,11 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		}
 	}
 
-	// Use the PriorityClass we defined for etcd in deploy/priority.yaml.
-	obj.Spec.PriorityClassName = etcdPriorityClassName
+	// Use the PriorityClass we defined for etcd in deploy/priority.yaml,
+	// or a custom value if overridden in the operator command line.
+	if planetscalev2.DefaultVitessPriorityClass != "" {
+		obj.Spec.PriorityClassName = planetscalev2.DefaultVitessPriorityClass
+	}
 
 	// Make a final list of desired containers and init containers before merging.
 	initContainers := spec.InitContainers

--- a/pkg/operator/etcd/pod.go
+++ b/pkg/operator/etcd/pod.go
@@ -242,6 +242,10 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		obj.Spec.SecurityContext.FSGroup = pointer.Int64Ptr(planetscalev2.DefaultEtcdFSGroup)
 	}
 
+	if planetscalev2.DefaultEtcdServiceAccount != "" {
+		obj.Spec.ServiceAccountName = planetscalev2.DefaultEtcdServiceAccount
+	}
+
 	// In both the case of the user injecting their own affinity and the default, we
 	// simply override the pod's existing affinity configuration.
 	if spec.Affinity != nil {

--- a/pkg/operator/etcd/pod.go
+++ b/pkg/operator/etcd/pod.go
@@ -165,7 +165,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 	update.VolumeMounts(&volumeMounts, spec.ExtraVolumeMounts)
 
 	var securityContext *corev1.SecurityContext
-	if planetscalev2.DefaultEtcdRunAsUser > 0 {
+	if planetscalev2.DefaultEtcdRunAsUser >= 0 {
 		securityContext = &corev1.SecurityContext{
 			RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultEtcdRunAsUser),
 		}
@@ -235,7 +235,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 	obj.Spec.Subdomain = PeerServiceName(spec.LockserverName)
 	obj.Spec.ImagePullSecrets = spec.ImagePullSecrets
 
-	if planetscalev2.DefaultEtcdFSGroup > 0 {
+	if planetscalev2.DefaultEtcdFSGroup >= 0 {
 		if obj.Spec.SecurityContext == nil {
 			obj.Spec.SecurityContext = &corev1.PodSecurityContext{}
 		}

--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -133,6 +133,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 	// that should actually be treated like maps (update items by the .Name field).
 	obj.Spec.Template.Spec.ImagePullSecrets = spec.ImagePullSecrets
 	obj.Spec.Template.Spec.PriorityClassName = planetscalev2.DefaultVitessPriorityClass
+	obj.Spec.Template.Spec.ServiceAccountName = planetscalev2.DefaultVitessServiceAccount
 	update.Volumes(&obj.Spec.Template.Spec.Volumes, spec.ExtraVolumes)
 
 	update.PodTemplateContainers(&obj.Spec.Template.Spec.InitContainers, spec.InitContainers)

--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -34,8 +34,7 @@ import (
 )
 
 const (
-	containerName     = "vtctld"
-	priorityClassName = "vitess"
+	containerName = "vtctld"
 
 	command    = "/vt/bin/vtctld"
 	webDir     = "/vt/src/vitess.io/vitess/web/vtctld"
@@ -134,7 +133,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 	// Use functions from the `operator/update` package for lists
 	// that should actually be treated like maps (update items by the .Name field).
 	obj.Spec.Template.Spec.ImagePullSecrets = spec.ImagePullSecrets
-	obj.Spec.Template.Spec.PriorityClassName = priorityClassName
+	obj.Spec.Template.Spec.PriorityClassName = planetscalev2.DefaultVitessPriorityClass
 	update.Volumes(&obj.Spec.Template.Spec.Volumes, spec.ExtraVolumes)
 
 	update.PodTemplateContainers(&obj.Spec.Template.Spec.InitContainers, spec.InitContainers)

--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -40,7 +40,6 @@ const (
 	webDir     = "/vt/src/vitess.io/vitess/web/vtctld"
 	webDir2    = "/vt/src/vitess.io/vitess/web/vtctld2/app"
 	serviceMap = "grpc-vtctl"
-	runAsUser  = 999
 )
 
 // DeploymentName returns the name of the vtctld Deployment for a given cell.
@@ -159,7 +158,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 			},
 			Resources: spec.Resources,
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: pointer.Int64Ptr(runAsUser),
+				RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
 			},
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{

--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -136,6 +136,11 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 	obj.Spec.Template.Spec.ServiceAccountName = planetscalev2.DefaultVitessServiceAccount
 	update.Volumes(&obj.Spec.Template.Spec.Volumes, spec.ExtraVolumes)
 
+	securityContext := &corev1.SecurityContext{}
+	if planetscalev2.DefaultVitessRunAsUser >= 0 {
+		securityContext.RunAsUser = pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser)
+	}
+
 	update.PodTemplateContainers(&obj.Spec.Template.Spec.InitContainers, spec.InitContainers)
 	update.PodTemplateContainers(&obj.Spec.Template.Spec.Containers, spec.SidecarContainers)
 	update.PodTemplateContainers(&obj.Spec.Template.Spec.Containers, []corev1.Container{
@@ -157,10 +162,8 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 					ContainerPort: planetscalev2.DefaultGrpcPort,
 				},
 			},
-			Resources: spec.Resources,
-			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
-			},
+			Resources:       spec.Resources,
+			SecurityContext: securityContext,
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/operator/vtgate/deployment.go
+++ b/pkg/operator/vtgate/deployment.go
@@ -125,6 +125,8 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 	// Pod template options.
 	obj.Spec.Template.Spec.ImagePullSecrets = spec.Cell.ImagePullSecrets
 	obj.Spec.Template.Spec.PriorityClassName = planetscalev2.DefaultVitessPriorityClass
+	obj.Spec.Template.Spec.ServiceAccountName = planetscalev2.DefaultVitessServiceAccount
+
 	if spec.Affinity != nil {
 		obj.Spec.Template.Spec.Affinity = spec.Affinity
 	} else if spec.Cell.Zone != "" {

--- a/pkg/operator/vtgate/deployment.go
+++ b/pkg/operator/vtgate/deployment.go
@@ -156,6 +156,11 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 	update.GOMAXPROCS(&env, spec.Resources)
 	update.Env(&env, spec.ExtraEnv)
 
+	securityContext := &corev1.SecurityContext{}
+	if planetscalev2.DefaultVitessRunAsUser >= 0 {
+		securityContext.RunAsUser = pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser)
+	}
+
 	// Start building the main Container to put in the Pod template.
 	vtgateContainer := &corev1.Container{
 		Name:            containerName,
@@ -179,10 +184,8 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 				ContainerPort: planetscalev2.DefaultMysqlPort,
 			},
 		},
-		Resources: spec.Resources,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
-		},
+		Resources:       spec.Resources,
+		SecurityContext: securityContext,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/operator/vtgate/deployment.go
+++ b/pkg/operator/vtgate/deployment.go
@@ -35,8 +35,7 @@ import (
 )
 
 const (
-	containerName     = "vtgate"
-	priorityClassName = "vitess"
+	containerName = "vtgate"
 
 	command    = "/vt/bin/vtgate"
 	serviceMap = "grpc-vtgateservice"
@@ -126,7 +125,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 
 	// Pod template options.
 	obj.Spec.Template.Spec.ImagePullSecrets = spec.Cell.ImagePullSecrets
-	obj.Spec.Template.Spec.PriorityClassName = priorityClassName
+	obj.Spec.Template.Spec.PriorityClassName = planetscalev2.DefaultVitessPriorityClass
 	if spec.Affinity != nil {
 		obj.Spec.Template.Spec.Affinity = spec.Affinity
 	} else if spec.Cell.Zone != "" {

--- a/pkg/operator/vtgate/deployment.go
+++ b/pkg/operator/vtgate/deployment.go
@@ -39,7 +39,6 @@ const (
 
 	command    = "/vt/bin/vtgate"
 	serviceMap = "grpc-vtgateservice"
-	runAsUser  = 999
 
 	tabletTypesToWait     = "MASTER,REPLICA"
 	gatewayImplementation = "discoverygateway"
@@ -180,7 +179,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 		},
 		Resources: spec.Resources,
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: pointer.Int64Ptr(runAsUser),
+			RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
 		},
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{

--- a/pkg/operator/vttablet/constants.go
+++ b/pkg/operator/vttablet/constants.go
@@ -41,8 +41,6 @@ const (
 	mysqldExporterMemoryLimitBytes   = 128 * (1 << 20) // 128 MiB
 
 	serviceMap          = "grpc-queryservice,grpc-tabletmanager,grpc-updatestream"
-	runAsUser           = 999
-	fsGroup             = 999
 	healthCheckInterval = 5 * time.Second
 
 	// terminationGracePeriodSeconds is how long Kubernetes will wait for the

--- a/pkg/operator/vttablet/constants.go
+++ b/pkg/operator/vttablet/constants.go
@@ -21,8 +21,6 @@ import (
 )
 
 const (
-	vttabletPriorityClassName = "vitess"
-
 	vttabletContainerName = "vttablet"
 	vttabletCommand       = "/vt/bin/vttablet"
 

--- a/pkg/operator/vttablet/mysqlctld.go
+++ b/pkg/operator/vttablet/mysqlctld.go
@@ -65,14 +65,17 @@ func init() {
 	tabletInitContainers.Add(func(s lazy.Spec) []corev1.Container {
 		spec := s.(*Spec)
 
+		securityContext := &corev1.SecurityContext{}
+		if planetscalev2.DefaultVitessRunAsUser >= 0 {
+			securityContext.RunAsUser = pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser)
+		}
+
 		// Use an init container to copy only the files we need from the Vitess image.
 		// Note specifically that we don't even copy init_db.sql to avoid accidentally using it.
 		initContainers := []corev1.Container{
 			{
-				Name: "init-vt-root",
-				SecurityContext: &corev1.SecurityContext{
-					RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
-				},
+				Name:            "init-vt-root",
+				SecurityContext: securityContext,
 				Image:           spec.Images.Vttablet,
 				ImagePullPolicy: spec.ImagePullPolicies.Vttablet,
 				VolumeMounts: []corev1.VolumeMount{
@@ -92,10 +95,8 @@ func init() {
 		// deployed before we started customizing the UNIX socket location.
 		if spec.DataVolumePVCSpec != nil {
 			initContainers = append(initContainers, corev1.Container{
-				Name: "init-mysql-socket",
-				SecurityContext: &corev1.SecurityContext{
-					RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
-				},
+				Name:            "init-mysql-socket",
+				SecurityContext: securityContext,
 				Image:           spec.Images.Vttablet,
 				ImagePullPolicy: spec.ImagePullPolicies.Vttablet,
 				VolumeMounts: []corev1.VolumeMount{

--- a/pkg/operator/vttablet/mysqlctld.go
+++ b/pkg/operator/vttablet/mysqlctld.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
 	"planetscale.dev/vitess-operator/pkg/operator/lazy"
 )
 
@@ -70,7 +71,7 @@ func init() {
 			{
 				Name: "init-vt-root",
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser: pointer.Int64Ptr(runAsUser),
+					RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
 				},
 				Image:           spec.Images.Vttablet,
 				ImagePullPolicy: spec.ImagePullPolicies.Vttablet,
@@ -93,7 +94,7 @@ func init() {
 			initContainers = append(initContainers, corev1.Container{
 				Name: "init-mysql-socket",
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser: pointer.Int64Ptr(runAsUser),
+					RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
 				},
 				Image:           spec.Images.Vttablet,
 				ImagePullPolicy: spec.ImagePullPolicies.Vttablet,

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -341,6 +341,10 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 	if planetscalev2.DefaultVitessPriorityClass != "" {
 		obj.Spec.PriorityClassName = planetscalev2.DefaultVitessPriorityClass
 	}
+
+	if planetscalev2.DefaultVitessServiceAccount != "" {
+		obj.Spec.ServiceAccountName = planetscalev2.DefaultVitessServiceAccount
+	}
 }
 
 // AliasFromPod returns a TabletAlias corresponding to a vttablet Pod.

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -336,8 +336,11 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		}
 	}
 
-	// Use the PriorityClass we defined for vttablets in deploy/priority.yaml.
-	obj.Spec.PriorityClassName = vttabletPriorityClassName
+	// Use the PriorityClass we defined for vttablets in deploy/priority.yaml,
+	// or a custom value if overridden on the operator command line.
+	if planetscalev2.DefaultVitessPriorityClass != "" {
+		obj.Spec.PriorityClassName = planetscalev2.DefaultVitessPriorityClass
+	}
 }
 
 // AliasFromPod returns a TabletAlias corresponding to a vttablet Pod.

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -132,7 +132,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		},
 		Resources: spec.Vttablet.Resources,
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: pointer.Int64Ptr(runAsUser),
+			RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
 		},
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
@@ -181,7 +181,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 			},
 			Resources: spec.Mysqld.Resources,
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: pointer.Int64Ptr(runAsUser),
+				RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
 			},
 			// TODO(enisoc): Add readiness and liveness probes that make sense for mysqld.
 			Env:          env,
@@ -215,7 +215,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: pointer.Int64Ptr(runAsUser),
+				RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
 			},
 			VolumeMounts: mysqldMounts,
 			Resources: corev1.ResourceRequirements{
@@ -280,7 +280,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 	if obj.Spec.SecurityContext == nil {
 		obj.Spec.SecurityContext = &corev1.PodSecurityContext{}
 	}
-	obj.Spec.SecurityContext.FSGroup = pointer.Int64Ptr(fsGroup)
+	obj.Spec.SecurityContext.FSGroup = pointer.Int64Ptr(planetscalev2.DefaultVitessFSGroup)
 
 	obj.Spec.TerminationGracePeriodSeconds = pointer.Int64Ptr(terminationGracePeriodSeconds)
 

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -111,6 +111,11 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 	update.VolumeMounts(&mysqldMounts, spec.ExtraVolumeMounts)
 	update.VolumeMounts(&vttabletMounts, spec.ExtraVolumeMounts)
 
+	securityContext := &corev1.SecurityContext{}
+	if planetscalev2.DefaultVitessRunAsUser >= 0 {
+		securityContext.RunAsUser = pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser)
+	}
+
 	// Build the containers.
 	vttabletContainer := &corev1.Container{
 		Name:            vttabletContainerName,
@@ -130,10 +135,8 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 				ContainerPort: planetscalev2.DefaultGrpcPort,
 			},
 		},
-		Resources: spec.Vttablet.Resources,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
-		},
+		Resources:       spec.Vttablet.Resources,
+		SecurityContext: securityContext,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
@@ -179,10 +182,8 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 					ContainerPort: planetscalev2.DefaultMysqlPort,
 				},
 			},
-			Resources: spec.Mysqld.Resources,
-			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
-			},
+			Resources:       spec.Mysqld.Resources,
+			SecurityContext: securityContext,
 			// TODO(enisoc): Add readiness and liveness probes that make sense for mysqld.
 			Env:          env,
 			VolumeMounts: mysqldMounts,
@@ -214,10 +215,8 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 					ContainerPort: mysqldExporterPort,
 				},
 			},
-			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
-			},
-			VolumeMounts: mysqldMounts,
+			SecurityContext: securityContext,
+			VolumeMounts:    mysqldMounts,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewMilliQuantity(mysqldExporterCPURequestMillis, resource.DecimalSI),
@@ -280,7 +279,9 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 	if obj.Spec.SecurityContext == nil {
 		obj.Spec.SecurityContext = &corev1.PodSecurityContext{}
 	}
-	obj.Spec.SecurityContext.FSGroup = pointer.Int64Ptr(planetscalev2.DefaultVitessFSGroup)
+	if planetscalev2.DefaultVitessFSGroup >= 0 {
+		obj.Spec.SecurityContext.FSGroup = pointer.Int64Ptr(planetscalev2.DefaultVitessFSGroup)
+	}
 
 	obj.Spec.TerminationGracePeriodSeconds = pointer.Int64Ptr(terminationGracePeriodSeconds)
 

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -118,6 +118,15 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec) *corev1.Pod {
 	volumeMounts = append(volumeMounts, tabletVolumeMounts.Get(tabletSpec)...)
 	volumeMounts = append(volumeMounts, vttabletVolumeMounts.Get(tabletSpec)...)
 
+	podSecurityContext := &corev1.PodSecurityContext{}
+	if planetscalev2.DefaultVitessFSGroup >= 0 {
+		podSecurityContext.FSGroup = pointer.Int64Ptr(planetscalev2.DefaultVitessFSGroup)
+	}
+	securityContext := &corev1.SecurityContext{}
+	if planetscalev2.DefaultVitessRunAsUser >= 0 {
+		securityContext.RunAsUser = pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser)
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   key.Namespace,
@@ -129,15 +138,11 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec) *corev1.Pod {
 			ImagePullSecrets: tabletSpec.ImagePullSecrets,
 			RestartPolicy:    corev1.RestartPolicyOnFailure,
 			Volumes:          tabletVolumes.Get(tabletSpec),
-			SecurityContext: &corev1.PodSecurityContext{
-				FSGroup: pointer.Int64Ptr(planetscalev2.DefaultVitessFSGroup),
-			},
+			SecurityContext:  podSecurityContext,
 			InitContainers: []corev1.Container{
 				{
-					Name: "init-vt-root",
-					SecurityContext: &corev1.SecurityContext{
-						RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
-					},
+					Name:            "init-vt-root",
+					SecurityContext: securityContext,
 					// We only use the vtbackup image to steal the vtbackup binary.
 					// When we actually run it, we run inside the mysqld image.
 					Image:           tabletSpec.Images.Vtbackup,
@@ -161,11 +166,9 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec) *corev1.Pod {
 					Command:         []string{vtbackupCommand},
 					Args:            vtbackupFlags.Get(backupSpec).FormatArgs(),
 					Resources:       tabletSpec.Mysqld.Resources,
-					SecurityContext: &corev1.SecurityContext{
-						RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
-					},
-					Env:          env,
-					VolumeMounts: volumeMounts,
+					SecurityContext: securityContext,
+					Env:             env,
+					VolumeMounts:    volumeMounts,
 				},
 			},
 		},

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -130,13 +130,13 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec) *corev1.Pod {
 			RestartPolicy:    corev1.RestartPolicyOnFailure,
 			Volumes:          tabletVolumes.Get(tabletSpec),
 			SecurityContext: &corev1.PodSecurityContext{
-				FSGroup: pointer.Int64Ptr(fsGroup),
+				FSGroup: pointer.Int64Ptr(planetscalev2.DefaultVitessFSGroup),
 			},
 			InitContainers: []corev1.Container{
 				{
 					Name: "init-vt-root",
 					SecurityContext: &corev1.SecurityContext{
-						RunAsUser: pointer.Int64Ptr(runAsUser),
+						RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
 					},
 					// We only use the vtbackup image to steal the vtbackup binary.
 					// When we actually run it, we run inside the mysqld image.
@@ -162,7 +162,7 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec) *corev1.Pod {
 					Args:            vtbackupFlags.Get(backupSpec).FormatArgs(),
 					Resources:       tabletSpec.Mysqld.Resources,
 					SecurityContext: &corev1.SecurityContext{
-						RunAsUser: pointer.Int64Ptr(runAsUser),
+						RunAsUser: pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser),
 					},
 					Env:          env,
 					VolumeMounts: volumeMounts,

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -171,6 +171,10 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec) *corev1.Pod {
 		},
 	}
 
+	if planetscalev2.DefaultVitessServiceAccount != "" {
+		pod.Spec.ServiceAccountName = planetscalev2.DefaultVitessServiceAccount
+	}
+
 	update.PodContainers(&pod.Spec.InitContainers, backupSpec.TabletSpec.InitContainers)
 	update.PodContainers(&pod.Spec.Containers, backupSpec.TabletSpec.SidecarContainers)
 	return pod


### PR DESCRIPTION
This makes various defaults that were previously hard-coded configurable via command-line flags. The default defaults remain the same as they were before if the new flags are left unset.

These particular values are ones that we've found may need to be overridden when running in OpenShift as opposed to pure Kubernetes.