### PR TITLE
vtgate: Don't hard-code the default gateway implementation.

### DIFF
--- a/pkg/operator/vtgate/deployment.go
+++ b/pkg/operator/vtgate/deployment.go
@@ -40,8 +40,7 @@ const (
 	command    = "/vt/bin/vtgate"
 	serviceMap = "grpc-vtgateservice"
 
-	tabletTypesToWait     = "MASTER,REPLICA"
-	gatewayImplementation = "discoverygateway"
+	tabletTypesToWait = "MASTER,REPLICA"
 
 	bufferMasterTrafficDuringFailover = true
 	bufferMinTimeBetweenFailovers     = "20s"
@@ -245,10 +244,9 @@ func (spec *Spec) baseFlags() vitess.Flags {
 	}
 
 	return vitess.Flags{
-		"cell":                   spec.Cell.Name,
-		"cells_to_watch":         strings.Join(cellsToWatch, ","),
-		"tablet_types_to_wait":   tabletTypesToWait,
-		"gateway_implementation": gatewayImplementation,
+		"cell":                 spec.Cell.Name,
+		"cells_to_watch":       strings.Join(cellsToWatch, ","),
+		"tablet_types_to_wait": tabletTypesToWait,
 
 		"enable_buffer":                     bufferMasterTrafficDuringFailover,
 		"buffer_min_time_between_failovers": bufferMinTimeBetweenFailovers,


### PR DESCRIPTION
We shouldn't set this at the operator level because the recommended default value of this flag is different for different Vitess versions. Instead, we should allow the default from upstream Vitess to take effect if the user doesn't set this flag explicitly.