### PR TITLE
Add basic support for setting tolerations

### DIFF
--- a/pkg/apis/planetscale/v2/etcdlockserver_types.go
+++ b/pkg/apis/planetscale/v2/etcdlockserver_types.go
@@ -188,6 +188,13 @@ type EtcdLockserverTemplate struct {
 
 	// PeerService can optionally be used to customize the etcd peer Service.
 	PeerService *ServiceOverrides `json:"peerService,omitempty"`
+
+	// Tolerations allow you to schedule pods onto nodes with matching taints.
+	// WARNING: kubernetes adds default tolerations for node.kubernetes.io/not-ready
+	// and node.kubernetes.io/unreachable, you'll need to include these or the pod will be
+	// endlessly attempt reconcile difference.
+	// +kubebuilder:validation:EmbeddedResource
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // EtcdLockserverStatus defines the observed state of an EtcdLockserver.

--- a/pkg/apis/planetscale/v2/vitesscell_types.go
+++ b/pkg/apis/planetscale/v2/vitesscell_types.go
@@ -185,6 +185,13 @@ type VitessCellGatewaySpec struct {
 
 	// Service can optionally be used to customize the per-cell vtgate Service.
 	Service *ServiceOverrides `json:"service,omitempty"`
+
+	// Tolerations allow you to schedule pods onto nodes with matching taints.
+	// WARNING: kubernetes adds default tolerations for node.kubernetes.io/not-ready
+	// and node.kubernetes.io/unreachable, you'll need to include these or the pod will be
+	// endlessly attempt reconcile difference.
+	// +kubebuilder:validation:EmbeddedResource
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // VitessGatewayAuthentication configures authentication for vtgate in this cell.

--- a/pkg/apis/planetscale/v2/vitesscluster_types.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_types.go
@@ -401,6 +401,13 @@ type VitessDashboardSpec struct {
 
 	// Service can optionally be used to customize the vtctld Service.
 	Service *ServiceOverrides `json:"service,omitempty"`
+
+	// Tolerations allow you to schedule pods onto nodes with matching taints.
+	// WARNING: kubernetes adds default tolerations for node.kubernetes.io/not-ready
+	// and node.kubernetes.io/unreachable, you'll need to include these or the pod will be
+	// endlessly attempt reconcile difference.
+	// +kubebuilder:validation:EmbeddedResource
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // ServiceOverrides allows customization of an arbitrary Service object.

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -256,6 +256,13 @@ type VitessShardTabletPool struct {
 	// that run alongside the main containers.
 	// +kubebuilder:validation:EmbeddedResource
 	SidecarContainers []corev1.Container `json:"sidecarContainers,omitempty"`
+
+	// Tolerations allow you to schedule pods onto nodes with matching taints.
+	// WARNING: kubernetes adds default tolerations for node.kubernetes.io/not-ready
+	// and node.kubernetes.io/unreachable, you'll need to include these or the pod will be
+	// endlessly attempt reconcile difference.
+	// +kubebuilder:validation:EmbeddedResource
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // VttabletSpec configures the vttablet server within a tablet.

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -2282,6 +2282,13 @@ func (in *VitessShardTabletPool) DeepCopyInto(out *VitessShardTabletPool) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -1446,6 +1446,13 @@ func (in *VitessDashboardSpec) DeepCopyInto(out *VitessDashboardSpec) {
 		*out = new(ServiceOverrides)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -935,6 +935,13 @@ func (in *VitessCellGatewaySpec) DeepCopyInto(out *VitessCellGatewaySpec) {
 		*out = new(ServiceOverrides)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -249,6 +249,13 @@ func (in *EtcdLockserverTemplate) DeepCopyInto(out *EtcdLockserverTemplate) {
 		*out = new(ServiceOverrides)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/controller/etcdlockserver/reconcile_members.go
+++ b/pkg/controller/etcdlockserver/reconcile_members.go
@@ -163,6 +163,7 @@ func memberSpecs(ls *planetscalev2.EtcdLockserver, parentLabels map[string]strin
 			Affinity:          ls.Spec.Affinity,
 			Annotations:       ls.Spec.Annotations,
 			AdvertisePeerURLs: ls.Spec.AdvertisePeerURLs,
+			Tolerations:       ls.Spec.Tolerations,
 		})
 	}
 	return members

--- a/pkg/controller/vitesscell/reconcile_vtgate.go
+++ b/pkg/controller/vitesscell/reconcile_vtgate.go
@@ -142,6 +142,7 @@ func (r *ReconcileVitessCell) reconcileVtgate(ctx context.Context, vtc *planetsc
 		SidecarContainers: vtc.Spec.Gateway.SidecarContainers,
 		Annotations:       annotations,
 		ExtraLabels:       vtc.Spec.Gateway.ExtraLabels,
+		Tolerations:       vtc.Spec.Gateway.Tolerations,
 	}
 	key = client.ObjectKey{Namespace: vtc.Namespace, Name: vtgate.DeploymentName(clusterName, vtc.Spec.Name)}
 

--- a/pkg/controller/vitesscluster/reconcile_vtctld.go
+++ b/pkg/controller/vitesscluster/reconcile_vtctld.go
@@ -176,6 +176,7 @@ func (r *ReconcileVitessCluster) vtctldSpecs(vt *planetscalev2.VitessCluster, pa
 			SidecarContainers: vt.Spec.VitessDashboard.SidecarContainers,
 			Annotations:       vt.Spec.VitessDashboard.Annotations,
 			ExtraLabels:       vt.Spec.VitessDashboard.ExtraLabels,
+			Tolerations:       vt.Spec.VitessDashboard.Tolerations,
 		})
 	}
 	return specs

--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -339,6 +339,7 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 				InitContainers:           pool.InitContainers,
 				SidecarContainers:        pool.SidecarContainers,
 				ExtraVolumeMounts:        pool.ExtraVolumeMounts,
+				Tolerations:              pool.Tolerations,
 			})
 		}
 	}

--- a/pkg/operator/etcd/pod.go
+++ b/pkg/operator/etcd/pod.go
@@ -86,6 +86,7 @@ type Spec struct {
 	Annotations       map[string]string
 	ExtraLabels       map[string]string
 	AdvertisePeerURLs []string
+	Tolerations       []corev1.Toleration
 }
 
 // NewPod creates a new etcd Pod.
@@ -302,6 +303,10 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 				},
 			})
 		}
+	}
+
+	if spec.Tolerations != nil {
+		obj.Spec.Tolerations = spec.Tolerations
 	}
 
 	// Use the PriorityClass we defined for etcd in deploy/priority.yaml,

--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -67,6 +67,7 @@ type Spec struct {
 	SidecarContainers []corev1.Container
 	Annotations       map[string]string
 	ExtraLabels       map[string]string
+	Tolerations       []corev1.Toleration
 }
 
 // NewDeployment creates a new Deployment object for vtctld.
@@ -210,6 +211,10 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 		}
 	} else {
 		obj.Spec.Template.Spec.Affinity = nil
+	}
+
+	if spec.Tolerations != nil {
+		obj.Spec.Template.Spec.Tolerations = spec.Tolerations
 	}
 }
 

--- a/pkg/operator/vtgate/deployment.go
+++ b/pkg/operator/vtgate/deployment.go
@@ -78,6 +78,7 @@ type Spec struct {
 	SidecarContainers []corev1.Container
 	Annotations       map[string]string
 	ExtraLabels       map[string]string
+	Tolerations       []corev1.Toleration
 }
 
 // NewDeployment creates a new Deployment object for vtctld.
@@ -149,6 +150,10 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 		}
 	} else {
 		obj.Spec.Template.Spec.Affinity = nil
+	}
+
+        if spec.Tolerations != nil {
+		obj.Spec.Template.Spec.Tolerations = spec.Tolerations
 	}
 
 	env := []corev1.EnvVar{}

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -337,6 +337,10 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		}
 	}
 
+	if spec.Tolerations != nil {
+		obj.Spec.Tolerations = spec.Tolerations
+	}
+
 	// Use the PriorityClass we defined for vttablets in deploy/priority.yaml,
 	// or a custom value if overridden on the operator command line.
 	if planetscalev2.DefaultVitessPriorityClass != "" {

--- a/pkg/operator/vttablet/spec.go
+++ b/pkg/operator/vttablet/spec.go
@@ -58,6 +58,7 @@ type Spec struct {
 	ExtraVolumeMounts        []corev1.VolumeMount
 	InitContainers           []corev1.Container
 	SidecarContainers        []corev1.Container
+	Tolerations              []corev1.Toleration
 }
 
 // localDatabaseName returns the MySQL database name for a tablet Spec in the case of locally managed MySQL.


### PR DESCRIPTION
This adds basic support for setting tolerations. This is important for us to keep pods off of EKS spot nodes and tied to our enduring on-demand nodes.

This works but isn't super satisfying, you'll need to include the existing tolerations that Kubernetes is setting by default or you'll see your pods endlessly recreated as they attempt to reconcile the difference in state. I'm sure there's a better way to handle it but I couldn't figure it out.

Here's an example config with a full affinity and toleration setup:
```
apiVersion: planetscale.com/v2
kind: VitessCluster
metadata:
  name: foo
spec:
  images:
    vtctld: vitess/lite:v6.0.20-20200818
    vtgate: vitess/lite:v6.0.20-20200818
    vttablet: vitess/lite:v6.0.20-20200818
    vtbackup: vitess/lite:v6.0.20-20200818
    mysqld:
      mysql56Compatible: vitess/lite:v6.0.20-20200818
    mysqldExporter: prom/mysqld-exporter:v0.11.0
  cells:
  - name: useast1
    gateway:
      authentication:
        static:
          secret:
            name: foo-cluster-config
            key: users.json
      replicas: 1
      resources:
        requests:
          cpu: 100m
          memory: 256Mi
        limits:
          memory: 256Mi
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: workloads
                operator: In
                values:
                - enduring
      tolerations: # the kubernetes.io tolerations are set by kubernetes, we dupe them here to make the pod match the expected state
      - effect: NoSchedule
        key: enduring
        operator: Equal
        value: "true"
      - effect: NoExecute
        key: node.kubernetes.io/not-ready
        operator: Exists
        tolerationSeconds: 300
      - effect: NoExecute
        key: node.kubernetes.io/unreachable
        operator: Exists
        tolerationSeconds: 300

  globalLockserver:
    etcd:
      resources:
        limits:
          memory: 256Mi
        requests:
          cpu: 100m
      affinity: # these are normally autogenerated by the vitess-operator, but we duped them here and overrode them to support moving workloads to enduring nodes
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels: # can't use etcd.planetscale.com/lockserver: foo-etcd-<id> here, need something more generic
                  planetscale.com/cluster: foo
                  planetscale.com/component: etcd
              topologyKey: kubernetes.io/hostname
            weight: 2
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  planetscale.com/cluster: foo
                  planetscale.com/component: etcd
              topologyKey: failure-domain.beta.kubernetes.io/zone
            weight: 1
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: workloads
                operator: In
                values:
                - enduring
      tolerations: 
      - effect: NoSchedule
        key: enduring
        operator: Equal
        value: "true"
      - effect: NoExecute
        key: node.kubernetes.io/not-ready
        operator: Exists
        tolerationSeconds: 300
      - effect: NoExecute
        key: node.kubernetes.io/unreachable
        operator: Exists
        tolerationSeconds: 300

  vitessDashboard:
    cells:
    - useast1
    extraFlags:
      security_policy: read-only
      proxy_tablets: "true"
    replicas: 1
    resources:
      limits:
        memory: 128Mi
      requests:
        cpu: 100m
        memory: 128Mi
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: workloads
              operator: In
              values:
              - enduring
    tolerations:
    - effect: NoSchedule
      key: enduring
      operator: Equal
      value: "true"
    - effect: NoExecute
      key: node.kubernetes.io/not-ready
      operator: Exists
      tolerationSeconds: 300
    - effect: NoExecute
      key: node.kubernetes.io/unreachable
      operator: Exists
      tolerationSeconds: 300

  keyspaces:
  - name: main
    turndownPolicy: Immediate
    partitionings:
    - custom:
        shards:
        - keyRange: {}
          databaseInitScriptSecret:
            name: foo-cluster-config
            key: init_db.sql
          replication:
            enforceSemiSync: false
          tabletPools:
          - cell: useast1
            type: externalmaster
            replicas: 1
            vttablet:
              extraFlags:
                db_charset: utf8mb4
                queryserver-config-pool-size: "5"
                queryserver-config-stream-pool-size: "5"
                queryserver-config-transaction-cap: "5"
              resources:
                requests:
                  cpu: 250m
                  memory: 256Mi
                limits:
                  memory: 384Mi
            externalDatastore:
              user: admin
              host: foo.cluster.us-east-1.rds.amazonaws.com
              port: 3306
              database: foo_production
              credentialsSecret:
                name: foo-cluster-config
                key: db_creds.json
            affinity: # these are normally autogenerated by the vitess-operator, but we duped them here and overrode them to support moving workloads to enduring nodes
              podAntiAffinity:
                preferredDuringSchedulingIgnoredDuringExecution:
                - podAffinityTerm:
                    labelSelector:
                      matchLabels:
                        planetscale.com/cluster: foo
                        planetscale.com/component: vttablet
                        planetscale.com/keyspace: main
                        planetscale.com/shard: x-x
                    topologyKey: kubernetes.io/hostname
                  weight: 2
                - podAffinityTerm:
                    labelSelector:
                      matchLabels:
                        planetscale.com/cell: useast1
                        planetscale.com/cluster: foo
                        planetscale.com/component: vttablet
                        planetscale.com/keyspace: main
                        planetscale.com/shard: x-x
                        planetscale.com/tablet-type: externalmaster
                    topologyKey: kubernetes.io/hostname
                  weight: 1
              nodeAffinity:
                requiredDuringSchedulingIgnoredDuringExecution:
                  nodeSelectorTerms:
                  - matchExpressions:
                    - key: workloads
                      operator: In
                      values:
                      - enduring
            tolerations:
            - effect: NoSchedule
              key: enduring
              operator: Equal
              value: "true"
            - effect: NoExecute
              key: node.kubernetes.io/not-ready
              operator: Exists
              tolerationSeconds: 300
            - effect: NoExecute
              key: node.kubernetes.io/unreachable
              operator: Exists
              tolerationSeconds: 300
  updateStrategy:
    type: Immediate
```