### PR TITLE
Resharding: Update VTK Status To Include Copy Progress

### DIFF
--- a/deploy/crds/planetscale.com_vitesskeyspaces.yaml
+++ b/deploy/crds/planetscale.com_vitesskeyspaces.yaml
@@ -921,6 +921,8 @@ spec:
               type: array
             resharding:
               properties:
+                copyProgress:
+                  type: integer
                 sourceShards:
                   items:
                     type: string

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1546,6 +1546,19 @@ WorkflowState
 <p>TargetShards is a list of target shards for the current resharding operation.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>copyProgress</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>CopyProgress will indicate the percentage completion ranging from 0-100 as integer values.
+Once we are past the copy phase, this value will always be 100, and will never be 100 while we
+are still within the copy phase.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.S3BackupLocation">S3BackupLocation

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1556,7 +1556,8 @@ int
 <td>
 <p>CopyProgress will indicate the percentage completion ranging from 0-100 as integer values.
 Once we are past the copy phase, this value will always be 100, and will never be 100 while we
-are still within the copy phase.</p>
+are still within the copy phase.
+If we can not compute the copy progress in a timely fashion, we will report -1 to indicate the progress is unknown.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -318,6 +318,7 @@ type ReshardingStatus struct {
 	// CopyProgress will indicate the percentage completion ranging from 0-100 as integer values.
 	// Once we are past the copy phase, this value will always be 100, and will never be 100 while we
 	// are still within the copy phase.
+	// If we can not compute the copy progress in a timely fashion, we will report -1 to indicate the progress is unknown.
 	CopyProgress int `json:"copyProgress,omitempty"`
 }
 

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -315,6 +315,10 @@ type ReshardingStatus struct {
 	SourceShards []string `json:"sourceShards,omitempty"`
 	// TargetShards is a list of target shards for the current resharding operation.
 	TargetShards []string `json:"targetShards,omitempty"`
+	// CopyProgress will indicate the percentage completion ranging from 0-100 as integer values.
+	// Once we are past the copy phase, this value will always be 100, and will never be 100 while we
+	// are still within the copy phase.
+	CopyProgress int `json:"copyProgress,omitempty"`
 }
 
 // WorkflowState represents the current state for the given Workflow.

--- a/pkg/controller/vitesskeyspace/reconcile_resharding.go
+++ b/pkg/controller/vitesskeyspace/reconcile_resharding.go
@@ -184,8 +184,7 @@ func (r *reconcileHandler) shardsRowCount(ctx context.Context, shardNames []stri
 		if err != nil {
 			return 0, fmt.Errorf("failed to get schema for shard %v: %v", shardName, err)
 		}
-		for i := range schema.TableDefinitions {
-			tabletDef := schema.TableDefinitions[i]
+		for _, tabletDef := range schema.TableDefinitions {
 			rowCount += tabletDef.GetRowCount()
 		}
 	}

--- a/pkg/controller/vitesskeyspace/reconcile_resharding.go
+++ b/pkg/controller/vitesskeyspace/reconcile_resharding.go
@@ -180,7 +180,7 @@ func (r *reconcileHandler) shardsRowCount(ctx context.Context, shardNames []stri
 		if shardInfo.MasterAlias == nil {
 			return 0, fmt.Errorf("could not find master tablet alias for determining row count of shard %v", shardName)
 		}
-		schema, err := r.wr.GetSchema(ctx, shardInfo.MasterAlias, make([]string, 0), make([]string, 0), false)
+		schema, err := r.wr.GetSchema(ctx, shardInfo.MasterAlias, nil, nil, false)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get schema for shard %v: %v", shardName, err)
 		}

--- a/pkg/controller/vitesskeyspace/reconcile_resharding.go
+++ b/pkg/controller/vitesskeyspace/reconcile_resharding.go
@@ -153,6 +153,10 @@ func (r *reconcileHandler) percentCopied(ctx context.Context, sourceShards, targ
 		r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "CopyProgressUnknown", "failed to aggregate row count for source shards: %v", err)
 		return -1
 	}
+	if sourceRowCount == 0 {
+		// If sourceRowCount is zero, then we are just waiting for workflow to transition to Running.
+		return 99
+	}
 	// Aggregate row counts for all target shards.
 	targetRowCount, err := r.shardsRowCount(ctx, targetShards)
 	if err != nil {

--- a/pkg/controller/vitesskeyspace/reconcile_resharding.go
+++ b/pkg/controller/vitesskeyspace/reconcile_resharding.go
@@ -117,29 +117,15 @@ func (r *reconcileHandler) reconcileResharding(ctx context.Context) (reconcile.R
 		}
 	}
 
+	progressCtx, cancel := context.WithTimeout(ctx, topoReconcileTimeout)
+	defer cancel()
 	switch workflowStatus.State {
 	case planetscalev2.WorkflowError:
+		workflowStatus.CopyProgress = r.percentCopied(progressCtx, workflowStatus.SourceShards, workflowStatus.TargetShards)
 		sort.Strings(errorMsgs)
 		r.setConditionStatus(planetscalev2.VitessKeyspaceReshardingInSync, corev1.ConditionFalse, "Error", fmt.Sprintf("VReplication reported an error: %v", errorMsgs[0]))
 	case planetscalev2.WorkflowCopying:
-		// Aggregate row counts for all source shards.
-		sourceRowCount, err := r.shardsRowCount(ctx, workflowStatus.SourceShards)
-		if err != nil {
-			r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "SourceShardsRowCountFailed", "failed to aggregate row count for source shards: %v", err)
-			return resultBuilder.RequeueAfter(topoRequeueDelay)
-		}
-		// Aggregate row counts for all target shards.
-		targetRowCount, err := r.shardsRowCount(ctx, workflowStatus.TargetShards)
-		if err != nil {
-			r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "TargetShardsRowCountFailed", "failed to aggregate row count for target shards: %v", err)
-			return resultBuilder.RequeueAfter(topoRequeueDelay)
-		}
-		percentComplete := int(math.Floor((float64(targetRowCount) / float64(sourceRowCount)) * 100.0))
-		// Row counts are a rough approximation, so this check is to ensure we don't report nonsense values.
-		if percentComplete > 99 {
-			percentComplete = 99
-		}
-		workflowStatus.CopyProgress = percentComplete
+		workflowStatus.CopyProgress = r.percentCopied(progressCtx, workflowStatus.SourceShards, workflowStatus.TargetShards)
 		r.setConditionStatus(planetscalev2.VitessKeyspaceReshardingInSync, corev1.ConditionFalse, "Copying", "Existing data from the source shards is being backfilled on target shards")
 	case planetscalev2.WorkflowRunning:
 		workflowStatus.CopyProgress = 100
@@ -158,7 +144,31 @@ func (r *reconcileHandler) reconcileResharding(ctx context.Context) (reconcile.R
 	return resultBuilder.Result()
 }
 
-func (r reconcileHandler) shardsRowCount(ctx context.Context, shardNames []string) (uint64, error) {
+// percentCopied aggregates row counts for the source and target shards, and tries to compute percent completed as a district integer
+// value ranging from 0-100. If we fail to communicate with underlying topo, we will emit an appropriate event with the error message,
+// and return -1 as an indicator that the copy progress is unknown.
+func (r *reconcileHandler) percentCopied(ctx context.Context, sourceShards, targetShards []string) int {
+	// Aggregate row counts for all source shards.
+	sourceRowCount, err := r.shardsRowCount(ctx, sourceShards)
+	if err != nil {
+		r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "SourceShardsRowCountFailed", "failed to aggregate row count for source shards: %v", err)
+		return -1
+	}
+	// Aggregate row counts for all target shards.
+	targetRowCount, err := r.shardsRowCount(ctx, targetShards)
+	if err != nil {
+		r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "TargetShardsRowCountFailed", "failed to aggregate row count for target shards: %v", err)
+		return -1
+	}
+	percentComplete := int(math.Floor((float64(targetRowCount) / float64(sourceRowCount)) * 100.0))
+	// Row counts are a rough approximation, so this check is to ensure we don't report nonsense values.
+	if percentComplete > 99 {
+		percentComplete = 99
+	}
+	return percentComplete
+}
+
+func (r *reconcileHandler) shardsRowCount(ctx context.Context, shardNames []string) (uint64, error) {
 	var rowCount uint64
 	for _, shardName := range shardNames {
 		tabletMap, err := r.ts.GetTabletMapForShard(ctx, r.vtk.Spec.Name, shardName)

--- a/pkg/controller/vitesskeyspace/reconcile_resharding.go
+++ b/pkg/controller/vitesskeyspace/reconcile_resharding.go
@@ -122,12 +122,13 @@ func (r *reconcileHandler) reconcileResharding(ctx context.Context) (reconcile.R
 		sort.Strings(errorMsgs)
 		r.setConditionStatus(planetscalev2.VitessKeyspaceReshardingInSync, corev1.ConditionFalse, "Error", fmt.Sprintf("VReplication reported an error: %v", errorMsgs[0]))
 	case planetscalev2.WorkflowCopying:
-		// Aggregate tablet maps for all source shards.
+		// Aggregate row counts for all source shards.
 		sourceRowCount, err := r.shardsRowCount(ctx, workflowStatus.SourceShards)
 		if err != nil {
 			r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "SourceShardsRowCountFailed", "failed to aggregate row count for source shards: %v", err)
 			return resultBuilder.RequeueAfter(topoRequeueDelay)
 		}
+		// Aggregate row counts for all target shards.
 		targetRowCount, err := r.shardsRowCount(ctx, workflowStatus.TargetShards)
 		if err != nil {
 			r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "TargetShardsRowCountFailed", "failed to aggregate row count for target shards: %v", err)

--- a/pkg/controller/vitesskeyspace/reconcile_resharding.go
+++ b/pkg/controller/vitesskeyspace/reconcile_resharding.go
@@ -19,7 +19,6 @@ package vitesskeyspace
 import (
 	"context"
 	"fmt"
-	"math"
 	"reflect"
 	"sort"
 
@@ -160,7 +159,7 @@ func (r *reconcileHandler) percentCopied(ctx context.Context, sourceShards, targ
 		r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "CopyProgressUnknown", "failed to aggregate row count for target shards: %v", err)
 		return -1
 	}
-	percentComplete := int(math.Floor((float64(targetRowCount) / float64(sourceRowCount)) * 100.0))
+	percentComplete := int((float64(targetRowCount) / float64(sourceRowCount)) * 100.0)
 	// Row counts are a rough approximation, so this check is to ensure we don't report nonsense values.
 	if percentComplete > 99 {
 		percentComplete = 99

--- a/pkg/controller/vitesskeyspace/reconcile_resharding.go
+++ b/pkg/controller/vitesskeyspace/reconcile_resharding.go
@@ -176,7 +176,7 @@ func (r *reconcileHandler) shardsRowCount(ctx context.Context, shardNames []stri
 	for _, shardName := range shardNames {
 		tabletMap, err := r.ts.GetTabletMapForShard(ctx, r.vtk.Spec.Name, shardName)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("failed to get tablets for shard %v: %v", shardName, err)
 		}
 		// Find the master and get data size from it.
 		var masterTabletAlias *topodata.TabletAlias
@@ -187,11 +187,11 @@ func (r *reconcileHandler) shardsRowCount(ctx context.Context, shardNames []stri
 			}
 		}
 		if masterTabletAlias == nil {
-			return 0, fmt.Errorf("could not find master tablet alias for determining row count")
+			return 0, fmt.Errorf("could not find master tablet alias for determining row count of shard %v", shardName)
 		}
 		schema, err := r.wr.GetSchema(ctx, masterTabletAlias, make([]string, 0), make([]string, 0), false)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("failed to get schema for shard %v: %v", shardName, err)
 		}
 		for i := range schema.TableDefinitions {
 			tabletDef := schema.TableDefinitions[i]

--- a/pkg/controller/vitesskeyspace/reconcile_resharding.go
+++ b/pkg/controller/vitesskeyspace/reconcile_resharding.go
@@ -151,13 +151,13 @@ func (r *reconcileHandler) percentCopied(ctx context.Context, sourceShards, targ
 	// Aggregate row counts for all source shards.
 	sourceRowCount, err := r.shardsRowCount(ctx, sourceShards)
 	if err != nil {
-		r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "SourceShardsRowCountFailed", "failed to aggregate row count for source shards: %v", err)
+		r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "CopyProgressUnknown", "failed to aggregate row count for source shards: %v", err)
 		return -1
 	}
 	// Aggregate row counts for all target shards.
 	targetRowCount, err := r.shardsRowCount(ctx, targetShards)
 	if err != nil {
-		r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "TargetShardsRowCountFailed", "failed to aggregate row count for target shards: %v", err)
+		r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "CopyProgressUnknown", "failed to aggregate row count for target shards: %v", err)
 		return -1
 	}
 	percentComplete := int(math.Floor((float64(targetRowCount) / float64(sourceRowCount)) * 100.0))

--- a/pkg/controller/vitesskeyspace/reconcile_resharding.go
+++ b/pkg/controller/vitesskeyspace/reconcile_resharding.go
@@ -92,6 +92,7 @@ func (r *reconcileHandler) reconcileResharding(ctx context.Context) (reconcile.R
 		State:        planetscalev2.WorkflowUnknown,
 		SourceShards: reshardingWorkflow.SourceLocation.Shards,
 		TargetShards: reshardingWorkflow.TargetLocation.Shards,
+		CopyProgress: -1,
 	}
 
 	// We aggregate status across all the shards for the workflow so we can definitely know if we are in two states:


### PR DESCRIPTION
This PR updates VTK status when resharding to include current copy progress.

Reviewer notes: Can someone check my logic for calculating percentage? Right now I cast both source shard row counts and target shard row counts to floating points for division, but we could be losing information here potentially as we go from uint64 to float64. Do we think this could be problematic? Should we just rely on floor division instead?