### PR TITLE
KeyspaceStatus: Include Partitioning Readiness

### DIFF
--- a/deploy/crds/planetscale.com_vitesskeyspaces.yaml
+++ b/deploy/crds/planetscale.com_vitesskeyspaces.yaml
@@ -911,12 +911,24 @@ spec:
             partitionings:
               items:
                 properties:
+                  desiredTablets:
+                    format: int32
+                    type: integer
+                  readyTablets:
+                    format: int32
+                    type: integer
                   servingWrites:
                     type: string
                   shardNames:
                     items:
                       type: string
                     type: array
+                  tablets:
+                    format: int32
+                    type: integer
+                  updatedTablets:
+                    format: int32
+                    type: integer
                 type: object
               type: array
             resharding:

--- a/deploy/crds/planetscale.com_vitesskeyspaces.yaml
+++ b/deploy/crds/planetscale.com_vitesskeyspaces.yaml
@@ -911,7 +911,13 @@ spec:
             partitionings:
               items:
                 properties:
+                  desiredShards:
+                    format: int32
+                    type: integer
                   desiredTablets:
+                    format: int32
+                    type: integer
+                  readyShards:
                     format: int32
                     type: integer
                   readyTablets:

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4933,6 +4933,55 @@ possible that some shards in this partitioning are serving writes.
 Check the per-shard status for full details.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>desiredTablets</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>DesiredTablets is the number of desired tablets. This is computed from
+information that&rsquo;s already available in the spec, but clients should
+use this value instead of trying to compute shard partitionings on their
+own.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tablets</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Tablets is the number of observed tablets. This could be higher or
+lower than desiredTablets if the state has not yet converged.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyTablets</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyTablets is the number of desired tablets that are Ready.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>updatedTablets</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>UpdatedTablets is the number of desired tablets that are up-to-date
+(have no pending changes).</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.VitessKeyspaceShardStatus">VitessKeyspaceShardStatus

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4982,6 +4982,31 @@ int32
 (have no pending changes).</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>desiredShards</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>DesiredShards is the number of desired shards. This is computed from
+information that&rsquo;s already available in the spec, but clients should
+use this value instead of trying to compute shard partitionings on their
+own.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyShards</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyShards is the number of desired shards that are Ready.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.VitessKeyspaceShardStatus">VitessKeyspaceShardStatus

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -462,7 +462,7 @@ const (
 	// VitessKeyspaceReshardingInSync indicates whether the keyspace has an active
 	// resharding operation whose target shards are ready to serve if traffic is switched.
 	VitessKeyspaceReshardingInSync VitessKeyspaceConditionType = "ReshardingInSync"
-	// VitessKeyspaceReady indicates whether the keyspace's serving partitionings tablets are all ready.
+	// VitessKeyspaceReady indicates whether the tablet Pods of the keyspace's serving partitioning are all Ready.
 	VitessKeyspaceReady VitessKeyspaceConditionType = "Ready"
 )
 

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -414,11 +414,20 @@ type VitessKeyspacePartitioningStatus struct {
 	// UpdatedTablets is the number of desired tablets that are up-to-date
 	// (have no pending changes).
 	UpdatedTablets int32 `json:"updatedTablets,omitempty"`
+	// DesiredShards is the number of desired shards. This is computed from
+	// information that's already available in the spec, but clients should
+	// use this value instead of trying to compute shard partitionings on their
+	// own.
+	DesiredShards int32 `json:"desiredShards,omitempty"`
+	// ReadyShards is the number of desired shards that are Ready.
+	ReadyShards int32 `json:"readyShards,omitempty"`
 }
 
 // NewVitessKeyspacePartitioningStatus creates a new status object with default values.
 func NewVitessKeyspacePartitioningStatus(partitioning *VitessKeyspacePartitioning) VitessKeyspacePartitioningStatus {
 	var desiredTablets int32
+	shards := partitioning.ShardNameSet()
+	desiredShards := int32(shards.Len())
 
 	tabletPools := partitioning.TabletPools()
 	for tpIndex := range tabletPools {
@@ -429,6 +438,7 @@ func NewVitessKeyspacePartitioningStatus(partitioning *VitessKeyspacePartitionin
 		ShardNames:     partitioning.ShardNameSet().List(),
 		ServingWrites:  corev1.ConditionUnknown,
 		DesiredTablets: desiredTablets,
+		DesiredShards:  desiredShards,
 	}
 }
 

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -427,7 +427,6 @@ type VitessKeyspacePartitioningStatus struct {
 func NewVitessKeyspacePartitioningStatus(partitioning *VitessKeyspacePartitioning) VitessKeyspacePartitioningStatus {
 	var desiredTablets int32
 	shards := partitioning.ShardNameSet()
-	desiredShards := int32(shards.Len())
 
 	tabletPools := partitioning.TabletPools()
 	for tpIndex := range tabletPools {
@@ -435,10 +434,10 @@ func NewVitessKeyspacePartitioningStatus(partitioning *VitessKeyspacePartitionin
 	}
 
 	return VitessKeyspacePartitioningStatus{
-		ShardNames:     partitioning.ShardNameSet().List(),
+		ShardNames:     shards.List(),
 		ServingWrites:  corev1.ConditionUnknown,
 		DesiredTablets: desiredTablets,
-		DesiredShards:  desiredShards,
+		DesiredShards:  int32(shards.Len()),
 	}
 }
 

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -378,7 +378,7 @@ type VitessKeyspaceShardStatus struct {
 
 // NewVitessKeyspaceShardStatus creates a new status object with default values.
 func NewVitessKeyspaceShardStatus(spec *VitessKeyspaceKeyRangeShard) VitessKeyspaceShardStatus {
-	desiredTablets := int32(0)
+	var desiredTablets int32
 	for tpIndex := range spec.TabletPools {
 		desiredTablets += spec.TabletPools[tpIndex].Replicas
 	}
@@ -418,7 +418,8 @@ type VitessKeyspacePartitioningStatus struct {
 
 // NewVitessKeyspacePartitioningStatus creates a new status object with default values.
 func NewVitessKeyspacePartitioningStatus(partitioning *VitessKeyspacePartitioning) VitessKeyspacePartitioningStatus {
-	desiredTablets := int32(0)
+	var desiredTablets int32
+
 	tabletPools := partitioning.TabletPools()
 	for tpIndex := range tabletPools {
 		desiredTablets += tabletPools[tpIndex].Replicas

--- a/pkg/controller/vitesscluster/reconcile_keyspaces.go
+++ b/pkg/controller/vitesscluster/reconcile_keyspaces.go
@@ -91,7 +91,7 @@ func (r *ReconcileVitessCluster) reconcileKeyspaces(ctx context.Context, vt *pla
 			cells := map[string]struct{}{}
 
 			for _, shard := range curObj.Status.Shards {
-				if shard.ReadyTablets == shard.Tablets {
+				if shard.ReadyTablets == shard.DesiredTablets {
 					status.ReadyShards++
 				}
 				if shard.UpdatedTablets == shard.Tablets {

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -154,7 +154,7 @@ func (r *reconcileHandler) reconcileShards(ctx context.Context) error {
 		status := &r.vtk.Status.Partitionings[i]
 		status.ServingWrites = allShardsServingWrites(status.ShardNames, r.vtk.Status.Shards)
 		status.Tablets = totalTablets(status.ShardNames, r.vtk.Status.Shards)
-		status.ReadyTablets = totalReadytablets(status.ShardNames, r.vtk.Status.Shards)
+		status.ReadyTablets = totalReadyTablets(status.ShardNames, r.vtk.Status.Shards)
 		status.UpdatedTablets = totalUpdatedTablets(status.ShardNames, r.vtk.Status.Shards)
 
 		if status.ServingWrites == corev1.ConditionTrue {
@@ -199,7 +199,7 @@ func allShardsServingWrites(shardNames []string, shardStatus map[string]planetsc
 	return result
 }
 
-func totalReadytablets(shardNames []string, shardStatus map[string]planetscalev2.VitessKeyspaceShardStatus) int32 {
+func totalReadyTablets(shardNames []string, shardStatus map[string]planetscalev2.VitessKeyspaceShardStatus) int32 {
 	// A partitioning with no shards has no ready tablets.
 	if len(shardNames) == 0 {
 		return 0

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -156,6 +156,7 @@ func (r *reconcileHandler) reconcileShards(ctx context.Context) error {
 		status.Tablets = totalTablets(status.ShardNames, r.vtk.Status.Shards)
 		status.ReadyTablets = totalReadyTablets(status.ShardNames, r.vtk.Status.Shards)
 		status.UpdatedTablets = totalUpdatedTablets(status.ShardNames, r.vtk.Status.Shards)
+		status.ReadyShards = totalReadyShards(status.ShardNames, r.vtk.Status.Shards)
 
 		if status.ServingWrites == corev1.ConditionTrue {
 			foundServingPartitioning = true
@@ -228,6 +229,18 @@ func totalUpdatedTablets(shardNames []string, shardStatus map[string]planetscale
 	}
 
 	return tabletCount
+}
+
+func totalReadyShards(shardNames []string, shardStatus map[string]planetscalev2.VitessKeyspaceShardStatus) int32 {
+	var readyShards int32
+	for _, shardName := range shardNames {
+		shard := shardStatus[shardName]
+		if shard.ReadyTablets == shard.Tablets {
+			readyShards++
+		}
+	}
+
+	return readyShards
 }
 
 // newVitessShard expands a complete VitessShard from a VitessShardTemplate.

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -18,7 +18,6 @@ package vitesskeyspace
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -159,9 +158,9 @@ func (r *reconcileHandler) reconcileShards(ctx context.Context) error {
 
 		if status.ServingWrites == corev1.ConditionTrue {
 			if status.ReadyTablets != status.DesiredTablets {
-				r.setConditionStatus(planetscalev2.VitessKeyspaceReady, corev1.ConditionFalse, "NonReadyServingTablets", fmt.Sprintf("Desired serving tablet count: %d; Ready serving tablet count: %d", status.DesiredTablets, status.ReadyTablets))
+				r.setConditionStatus(planetscalev2.VitessKeyspaceReady, corev1.ConditionFalse, "TabletsNotReady", "Some tablet Pods for the serving partitioning are not Ready.")
 			} else {
-				r.setConditionStatus(planetscalev2.VitessKeyspaceReady, corev1.ConditionTrue, "ServingTabletsReady", "All serving tablets for keyspace are ready")
+				r.setConditionStatus(planetscalev2.VitessKeyspaceReady, corev1.ConditionTrue, "TabletsReady", "All tablet Pods for the serving partitioning are Ready.")
 			}
 		}
 	}

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -235,7 +235,7 @@ func totalReadyShards(shardNames []string, shardStatus map[string]planetscalev2.
 	var readyShards int32
 	for _, shardName := range shardNames {
 		shard := shardStatus[shardName]
-		if shard.ReadyTablets == shard.Tablets {
+		if shard.ReadyTablets == shard.DesiredTablets {
 			readyShards++
 		}
 	}

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -149,6 +149,7 @@ func (r *reconcileHandler) reconcileShards(ctx context.Context) error {
 	}
 
 	// Aggregate per-shard status, grouped by partitioning.
+	var foundServingPartitioning bool
 	for i := range r.vtk.Status.Partitionings {
 		status := &r.vtk.Status.Partitionings[i]
 		status.ServingWrites = allShardsServingWrites(status.ShardNames, r.vtk.Status.Shards)
@@ -157,12 +158,16 @@ func (r *reconcileHandler) reconcileShards(ctx context.Context) error {
 		status.UpdatedTablets = totalUpdatedTablets(status.ShardNames, r.vtk.Status.Shards)
 
 		if status.ServingWrites == corev1.ConditionTrue {
+			foundServingPartitioning = true
 			if status.ReadyTablets != status.DesiredTablets {
 				r.setConditionStatus(planetscalev2.VitessKeyspaceReady, corev1.ConditionFalse, "TabletsNotReady", "Some tablet Pods for the serving partitioning are not Ready.")
 			} else {
 				r.setConditionStatus(planetscalev2.VitessKeyspaceReady, corev1.ConditionTrue, "TabletsReady", "All tablet Pods for the serving partitioning are Ready.")
 			}
 		}
+	}
+	if !foundServingPartitioning {
+		r.setConditionStatus(planetscalev2.VitessKeyspaceReady, corev1.ConditionFalse, "NoServingPartitioning", "No partitioning in this keyspace is serving write traffic.")
 	}
 
 	return nil

--- a/pkg/controller/vitesskeyspace/reconcile_shards.go
+++ b/pkg/controller/vitesskeyspace/reconcile_shards.go
@@ -200,11 +200,6 @@ func allShardsServingWrites(shardNames []string, shardStatus map[string]planetsc
 }
 
 func totalReadyTablets(shardNames []string, shardStatus map[string]planetscalev2.VitessKeyspaceShardStatus) int32 {
-	// A partitioning with no shards has no ready tablets.
-	if len(shardNames) == 0 {
-		return 0
-	}
-
 	var tabletCount int32
 	for _, shard := range shardNames {
 		tabletCount += shardStatus[shard].ReadyTablets
@@ -214,11 +209,6 @@ func totalReadyTablets(shardNames []string, shardStatus map[string]planetscalev2
 }
 
 func totalTablets(shardNames []string, shardStatus map[string]planetscalev2.VitessKeyspaceShardStatus) int32 {
-	// A partitioning with no shards has no tablets.
-	if len(shardNames) == 0 {
-		return 0
-	}
-
 	var tabletCount int32
 	for _, shard := range shardNames {
 		tabletCount += shardStatus[shard].Tablets
@@ -228,11 +218,6 @@ func totalTablets(shardNames []string, shardStatus map[string]planetscalev2.Vite
 }
 
 func totalUpdatedTablets(shardNames []string, shardStatus map[string]planetscalev2.VitessKeyspaceShardStatus) int32 {
-	// A partitioning with no shards has no updated tablets.
-	if len(shardNames) == 0 {
-		return 0
-	}
-
 	var tabletCount int32
 	for _, shard := range shardNames {
 		tabletCount += shardStatus[shard].UpdatedTablets

--- a/pkg/controller/vitesskeyspace/vitesskeyspace_controller.go
+++ b/pkg/controller/vitesskeyspace/vitesskeyspace_controller.go
@@ -54,6 +54,7 @@ var (
 	keyspaceConditions = map[planetscalev2.VitessKeyspaceConditionType]bool{
 		planetscalev2.VitessKeyspaceReshardingActive: true,
 		planetscalev2.VitessKeyspaceReshardingInSync: true,
+		planetscalev2.VitessKeyspaceReady:            true,
 	}
 )
 


### PR DESCRIPTION
This PR expands the partitioning status section to include readiness information and provides a high-level condition to assess whether the partitioning that is serving writes has a ready tablet count that matches its desired tablet count.