### PR TITLE
docs/api: Fix links to k8s docs.

### DIFF
--- a/docs/api/config.json
+++ b/docs/api/config.json
@@ -17,7 +17,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         }
     ],
     "typeDisplayNamePrefixOverrides": {

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -68,7 +68,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -177,7 +177,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -258,7 +258,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -314,7 +314,7 @@ images defined in the &lsquo;images&rsquo; field.</p>
 <td>
 <code>imagePullSecrets</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
 </a>
 </em>
@@ -703,7 +703,7 @@ int64
 <td>
 <code>available</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -761,7 +761,7 @@ Default: Let the operator choose.</p>
 <td>
 <code>imagePullPolicy</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#pullpolicy-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
 </a>
 </em>
@@ -774,7 +774,7 @@ Kubernetes core/v1.PullPolicy
 <td>
 <code>imagePullSecrets</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
 </a>
 </em>
@@ -788,7 +788,7 @@ etcd Pods.</p>
 <td>
 <code>resources</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#resourcerequirements-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
 </a>
 </em>
@@ -802,7 +802,7 @@ Default: Let the operator choose.</p>
 <td>
 <code>dataVolumeClaimTemplate</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#persistentvolumeclaimspec-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#persistentvolumeclaimspec-v1-core">
 Kubernetes core/v1.PersistentVolumeClaimSpec
 </a>
 </em>
@@ -836,7 +836,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 <td>
 <code>extraEnv</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#envvar-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
 </a>
 </em>
@@ -850,7 +850,7 @@ set by the operator, or pass additional environment variables.</p>
 <td>
 <code>extraVolumes</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volume-v1-core">
 []Kubernetes core/v1.Volume
 </a>
 </em>
@@ -867,7 +867,7 @@ should be mounted.</p>
 <td>
 <code>extraVolumeMounts</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volumemount-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
 </a>
 </em>
@@ -882,7 +882,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 <td>
 <code>initContainers</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#container-v1-core">
 []Kubernetes core/v1.Container
 </a>
 </em>
@@ -896,7 +896,7 @@ that will be run to completion one after another before any app containers are s
 <td>
 <code>sidecarContainers</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#container-v1-core">
 []Kubernetes core/v1.Container
 </a>
 </em>
@@ -910,7 +910,7 @@ that run alongside the main containers.</p>
 <td>
 <code>affinity</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#affinity-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#affinity-v1-core">
 Kubernetes core/v1.Affinity
 </a>
 </em>
@@ -1165,7 +1165,7 @@ SecretSource
 <td>
 <code>allowResourceChanges</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#resourcename-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#resourcename-v1-core">
 []Kubernetes core/v1.ResourceName
 </a>
 </em>
@@ -1414,7 +1414,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MariaDB103&rdquo; flavor setting.
 <td>
 <code>resources</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#resourcerequirements-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
 </a>
 </em>
@@ -1817,7 +1817,7 @@ int32
 <td>
 <code>latestCompleteBackupTime</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -2038,7 +2038,7 @@ AzblobBackupLocation
 <td>
 <code>volume</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volumesource-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volumesource-v1-core">
 Kubernetes core/v1.VolumeSource
 </a>
 </em>
@@ -2093,7 +2093,7 @@ that need access to this backup storage location.</p>
 <td>
 <code>startTime</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -2106,7 +2106,7 @@ Kubernetes meta/v1.Time
 <td>
 <code>finishedTime</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -2201,7 +2201,7 @@ cluster.</p>
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -2355,7 +2355,7 @@ just like a Deployment can manage Pods that run on multiple Nodes.</p>
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -2453,7 +2453,7 @@ VitessImagePullPolicies
 <td>
 <code>imagePullSecrets</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
 </a>
 </em>
@@ -2535,7 +2535,7 @@ int32
 <td>
 <code>resources</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#resourcerequirements-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
 </a>
 </em>
@@ -2589,7 +2589,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 <td>
 <code>extraEnv</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#envvar-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
 </a>
 </em>
@@ -2603,7 +2603,7 @@ set by the operator, or pass additional environment variables.</p>
 <td>
 <code>extraVolumes</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volume-v1-core">
 []Kubernetes core/v1.Volume
 </a>
 </em>
@@ -2620,7 +2620,7 @@ should be mounted.</p>
 <td>
 <code>extraVolumeMounts</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volumemount-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
 </a>
 </em>
@@ -2635,7 +2635,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 <td>
 <code>initContainers</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#container-v1-core">
 []Kubernetes core/v1.Container
 </a>
 </em>
@@ -2649,7 +2649,7 @@ that will be run to completion one after another before any app containers are s
 <td>
 <code>sidecarContainers</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#container-v1-core">
 []Kubernetes core/v1.Container
 </a>
 </em>
@@ -2663,7 +2663,7 @@ that run alongside the main containers.</p>
 <td>
 <code>affinity</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#affinity-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#affinity-v1-core">
 Kubernetes core/v1.Affinity
 </a>
 </em>
@@ -2737,7 +2737,7 @@ ServiceOverrides
 <td>
 <code>available</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -2890,7 +2890,7 @@ VitessImagePullPolicies
 <td>
 <code>imagePullSecrets</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
 </a>
 </em>
@@ -3000,7 +3000,7 @@ when the difference matters.</p>
 <td>
 <code>idle</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -3121,7 +3121,7 @@ applied the next time a rolling update allows.</p>
 <td>
 <code>gatewayAvailable</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -3324,7 +3324,7 @@ images defined in the &lsquo;images&rsquo; field.</p>
 <td>
 <code>imagePullSecrets</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
 </a>
 </em>
@@ -3723,7 +3723,7 @@ int32
 <td>
 <code>resources</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#resourcerequirements-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
 </a>
 </em>
@@ -3751,7 +3751,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 <td>
 <code>extraEnv</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#envvar-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
 </a>
 </em>
@@ -3765,7 +3765,7 @@ set by the operator, or pass additional environment variables.</p>
 <td>
 <code>extraVolumes</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volume-v1-core">
 []Kubernetes core/v1.Volume
 </a>
 </em>
@@ -3782,7 +3782,7 @@ should be mounted.</p>
 <td>
 <code>extraVolumeMounts</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volumemount-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
 </a>
 </em>
@@ -3797,7 +3797,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 <td>
 <code>initContainers</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#container-v1-core">
 []Kubernetes core/v1.Container
 </a>
 </em>
@@ -3811,7 +3811,7 @@ that will be run to completion one after another before any app containers are s
 <td>
 <code>sidecarContainers</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#container-v1-core">
 []Kubernetes core/v1.Container
 </a>
 </em>
@@ -3825,7 +3825,7 @@ that run alongside the main containers.</p>
 <td>
 <code>affinity</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#affinity-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#affinity-v1-core">
 Kubernetes core/v1.Affinity
 </a>
 </em>
@@ -3899,7 +3899,7 @@ ServiceOverrides
 <td>
 <code>available</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -4114,7 +4114,7 @@ SecretSource
 <td>
 <code>vtctld</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#pullpolicy-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
 </a>
 </em>
@@ -4127,7 +4127,7 @@ Kubernetes core/v1.PullPolicy
 <td>
 <code>vtgate</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#pullpolicy-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
 </a>
 </em>
@@ -4140,7 +4140,7 @@ Kubernetes core/v1.PullPolicy
 <td>
 <code>vttablet</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#pullpolicy-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
 </a>
 </em>
@@ -4153,7 +4153,7 @@ Kubernetes core/v1.PullPolicy
 <td>
 <code>vtbackup</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#pullpolicy-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
 </a>
 </em>
@@ -4166,7 +4166,7 @@ Kubernetes core/v1.PullPolicy
 <td>
 <code>mysqld</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#pullpolicy-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
 </a>
 </em>
@@ -4179,7 +4179,7 @@ Kubernetes core/v1.PullPolicy
 <td>
 <code>mysqldExporter</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#pullpolicy-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
 </a>
 </em>
@@ -4348,7 +4348,7 @@ various VitessCells.</p>
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -4435,7 +4435,7 @@ VitessImagePullPolicies
 <td>
 <code>imagePullSecrets</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
 </a>
 </em>
@@ -4570,7 +4570,7 @@ VitessKeyspaceConditionType
 <td>
 <code>status</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -4584,7 +4584,7 @@ Can be True, False, Unknown.</p>
 <td>
 <code>lastTransitionTime</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -4920,7 +4920,7 @@ in the format Vitess uses for shard names.</p>
 <td>
 <code>servingWrites</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -4956,7 +4956,7 @@ Check the per-shard status for full details.</p>
 <td>
 <code>hasMaster</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -4970,7 +4970,7 @@ reflects a master for this shard.</p>
 <td>
 <code>servingWrites</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -5137,7 +5137,7 @@ VitessImagePullPolicies
 <td>
 <code>imagePullSecrets</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
 </a>
 </em>
@@ -5294,7 +5294,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 <td>
 <code>idle</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -5639,7 +5639,7 @@ for that shard.</p>
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -5749,7 +5749,7 @@ VitessImagePullPolicies
 <td>
 <code>imagePullSecrets</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
 </a>
 </em>
@@ -5885,7 +5885,7 @@ VitessShardStatus
 <td>
 <code>status</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -5899,7 +5899,7 @@ Can be True, False, Unknown.</p>
 <td>
 <code>lastTransitionTime</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -6045,7 +6045,7 @@ VitessImagePullPolicies
 <td>
 <code>imagePullSecrets</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
 </a>
 </em>
@@ -6214,7 +6214,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 <td>
 <code>hasMaster</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -6228,7 +6228,7 @@ reflects a master for this shard.</p>
 <td>
 <code>hasInitialBackup</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -6242,7 +6242,7 @@ has been seeded for the shard.</p>
 <td>
 <code>servingWrites</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -6258,7 +6258,7 @@ the target of a resharding operation that is still in progress.</p>
 <td>
 <code>idle</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -6389,7 +6389,7 @@ which will scale the pool down to 0 tablets.</p>
 <td>
 <code>dataVolumeClaimTemplate</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#persistentvolumeclaimspec-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#persistentvolumeclaimspec-v1-core">
 Kubernetes core/v1.PersistentVolumeClaimSpec
 </a>
 </em>
@@ -6463,7 +6463,7 @@ You must specify either Mysqld or ExternalDatastore, but not both.</p>
 <td>
 <code>affinity</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#affinity-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#affinity-v1-core">
 Kubernetes core/v1.Affinity
 </a>
 </em>
@@ -6504,7 +6504,7 @@ created for this component.</p>
 <td>
 <code>extraEnv</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#envvar-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
 </a>
 </em>
@@ -6519,7 +6519,7 @@ These values are applied to both the vttablet and mysqld containers.</p>
 <td>
 <code>extraVolumes</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volume-v1-core">
 []Kubernetes core/v1.Volume
 </a>
 </em>
@@ -6537,7 +6537,7 @@ These volumes are available to be mounted by both vttablet and mysqld.</p>
 <td>
 <code>extraVolumeMounts</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volumemount-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
 </a>
 </em>
@@ -6553,7 +6553,7 @@ These values are applied to both the vttablet and mysqld containers.</p>
 <td>
 <code>initContainers</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#container-v1-core">
 []Kubernetes core/v1.Container
 </a>
 </em>
@@ -6567,7 +6567,7 @@ that will be run to completion one after another before any app containers are s
 <td>
 <code>sidecarContainers</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#container-v1-core">
 []Kubernetes core/v1.Container
 </a>
 </em>
@@ -6710,7 +6710,7 @@ int32
 <td>
 <code>running</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -6723,7 +6723,7 @@ Kubernetes core/v1.ConditionStatus
 <td>
 <code>ready</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -6737,7 +6737,7 @@ meaning it&rsquo;s ready to serve queries.</p>
 <td>
 <code>available</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -6751,7 +6751,7 @@ for long enough to be considered stable.</p>
 <td>
 <code>dataVolumeBound</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
 </a>
 </em>
@@ -6807,7 +6807,7 @@ the next time a rolling update allows.</p>
 <td>
 <code>resources</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#resourcerequirements-v1-core">
+<a href="https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
 </a>
 </em>


### PR DESCRIPTION
The v1.13 docs were removed. We should have updated to v1.16 anyway when we updated our operator-sdk version.