### PR TITLE
Allow configuring subPath for volume-based backup targets

### DIFF
--- a/deploy/crds/planetscale.com_vitessbackupstorages.yaml
+++ b/deploy/crds/planetscale.com_vitessbackupstorages.yaml
@@ -121,6 +121,8 @@ spec:
                 volume:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                volumeSubPath:
+                  type: string
               type: object
             subcontroller:
               properties:

--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -129,6 +129,8 @@ spec:
                       volume:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      volumeSubPath:
+                        type: string
                     type: object
                   minItems: 1
                   type: array

--- a/deploy/crds/planetscale.com_vitesskeyspaces.yaml
+++ b/deploy/crds/planetscale.com_vitesskeyspaces.yaml
@@ -128,6 +128,8 @@ spec:
                   volume:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  volumeSubPath:
+                    type: string
                 type: object
               type: array
             databaseName:

--- a/deploy/crds/planetscale.com_vitessshards.yaml
+++ b/deploy/crds/planetscale.com_vitessshards.yaml
@@ -128,6 +128,8 @@ spec:
                   volume:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  volumeSubPath:
+                    type: string
                 type: object
               type: array
             databaseInitScriptSecret:

--- a/pkg/apis/planetscale/v2/vitessbackupstorage_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupstorage_types.go
@@ -85,6 +85,9 @@ type VitessBackupLocation struct {
 	// a shared host path for local testing.
 	// +kubebuilder:validation:EmbeddedResource
 	Volume *corev1.VolumeSource `json:"volume,omitempty"`
+	// VolumeSubPath gives the subpath in the volume to mount to the backups target.
+	// Only used for Volume-backed backup storage, ignored otherwise.
+	VolumeSubPath string `json:"volumeSubPath,omitempty"`
 	// Annotations can optionally be used to attach custom annotations to Pods
 	// that need access to this backup storage location.
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/pkg/operator/vitessbackup/storage.go
+++ b/pkg/operator/vitessbackup/storage.go
@@ -75,7 +75,7 @@ func StorageVolumeMounts(backupLocation *planetscalev2.VitessBackupLocation) []c
 	case backupLocation.Azblob != nil:
 		return azblobBackupVolumeMounts(backupLocation.Azblob)
 	case backupLocation.Volume != nil:
-		return fileBackupVolumeMounts()
+		return fileBackupVolumeMounts(backupLocation.VolumeSubPath)
 	}
 	return nil
 }

--- a/pkg/operator/vitessbackup/storage_file.go
+++ b/pkg/operator/vitessbackup/storage_file.go
@@ -37,11 +37,12 @@ func fileBackupVolumes(volume *corev1.VolumeSource) []corev1.Volume {
 	}
 }
 
-func fileBackupVolumeMounts() []corev1.VolumeMount {
+func fileBackupVolumeMounts(subPath string) []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
 			Name:      fileBackupStorageVolumeName,
 			MountPath: fileBackupStorageMountPath,
+			SubPath:   subPath,
 		},
 	}
 }


### PR DESCRIPTION
When using a Volume as a backup target, which might be a clustered or other network filesystem, it is sometimes helpful to restrict the backups for a particular VitessCluster into a subfolder of this volume. For example, if multiple VitessClusters are using the same shared storage for backups, using subPath can avoid any risk of different clusters trampling (or seeing) each other's backups.

This makes it possible to set the `SubPath` for a `VitessBackupLocation`. I've tested it with glusterfs, which works great 👍 
