### PR TITLE
Include namespace in etcd client service address.

### DIFF
--- a/pkg/controller/vitesscluster/reconcile_cells.go
+++ b/pkg/controller/vitesscluster/reconcile_cells.go
@@ -134,7 +134,7 @@ func newVitessCell(key client.ObjectKey, vt *planetscalev2.VitessCluster, parent
 		},
 		Spec: planetscalev2.VitessCellSpec{
 			VitessCellTemplate:     *template,
-			GlobalLockserver:       *lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name),
+			GlobalLockserver:       *lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Namespace, vt.Name),
 			AllCells:               allCells,
 			Images:                 images,
 			ImagePullPolicies:      vt.Spec.ImagePullPolicies,

--- a/pkg/controller/vitesscluster/reconcile_keyspaces.go
+++ b/pkg/controller/vitesscluster/reconcile_keyspaces.go
@@ -172,7 +172,7 @@ func newVitessKeyspace(key client.ObjectKey, vt *planetscalev2.VitessCluster, pa
 		},
 		Spec: planetscalev2.VitessKeyspaceSpec{
 			VitessKeyspaceTemplate: *template,
-			GlobalLockserver:       *lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name),
+			GlobalLockserver:       *lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Namespace, vt.Name),
 			Images:                 images,
 			ImagePullPolicies:      vt.Spec.ImagePullPolicies,
 			ImagePullSecrets:       vt.Spec.ImagePullSecrets,

--- a/pkg/controller/vitesscluster/reconcile_topo.go
+++ b/pkg/controller/vitesscluster/reconcile_topo.go
@@ -46,7 +46,7 @@ func (r *ReconcileVitessCluster) reconcileTopology(ctx context.Context, vt *plan
 	resultBuilder := &results.Builder{}
 
 	// Connect to the global lockserver.
-	globalParams := lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name)
+	globalParams := lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Namespace, vt.Name)
 	if globalParams == nil {
 		// This is an invalid config. There's no reason to request a retry. Just wait for the next mutation to trigger us.
 		r.recorder.Event(vt, corev1.EventTypeWarning, "TopoInvalid", "no global lockserver is defined")

--- a/pkg/controller/vitesscluster/reconcile_vtctld.go
+++ b/pkg/controller/vitesscluster/reconcile_vtctld.go
@@ -141,7 +141,7 @@ func (r *ReconcileVitessCluster) vtctldSpecs(vt *planetscalev2.VitessCluster, pa
 		}
 	}
 
-	glsParams := lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Name)
+	glsParams := lockserver.GlobalConnectionParams(&vt.Spec.GlobalLockserver, vt.Namespace, vt.Name)
 
 	// Make a vtctld Deployment spec for each cell.
 	specs := make([]*vtctld.Spec, 0, len(cells))


### PR DESCRIPTION
This allows the operator to still talk to the VitessCluster's etcd, even if the operator is in a different namespace.