### PR TITLE
Document WaitForFirstConsumer alternative to per-zone StorageClass

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -824,9 +824,10 @@ Kubernetes core/v1.PersistentVolumeClaimSpec
 <p>DataVolumeClaimTemplate configures the PersistentVolumeClaims that will be created
 for each etcd instance to store its data files.
 This field is required.</p>
-<p>IMPORTANT: For a cell-local lockserver, you must set a storageClassName
-here for a StorageClass that&rsquo;s configured to only provision volumes in
-the Availability Zone that corresponds to the Vitess cell.
+<p>IMPORTANT: For a cell-local lockserver, you have two options. You either should set a storageClassName here for
+a StorageClass that&rsquo;s configured to only provision volumes in the Availability Zone that corresponds to the
+Vitess cell, or instead you may set <code>volumeBindingMode: WaitForFirstConsumer</code> in the StorageClass.
+This allows you to use the same StorageClass for any availability zone.
 Default: Let the operator choose.</p>
 </td>
 </tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -824,10 +824,9 @@ Kubernetes core/v1.PersistentVolumeClaimSpec
 <p>DataVolumeClaimTemplate configures the PersistentVolumeClaims that will be created
 for each etcd instance to store its data files.
 This field is required.</p>
-<p>IMPORTANT: For a cell-local lockserver, you have two options. You either should set a storageClassName here for
-a StorageClass that&rsquo;s configured to only provision volumes in the Availability Zone that corresponds to the
-Vitess cell, or instead you may set <code>volumeBindingMode: WaitForFirstConsumer</code> in the StorageClass.
-This allows you to use the same StorageClass for any availability zone.
+<p>IMPORTANT: For a cell-local lockserver in a Kubernetes cluster that spans
+multiple zones, you should ensure that <code>volumeBindingMode: WaitForFirstConsumer</code>
+is set on the StorageClass specified in the storageClassName field here.
 Default: Let the operator choose.</p>
 </td>
 </tr>
@@ -6589,9 +6588,9 @@ Kubernetes core/v1.PersistentVolumeClaimSpec
 for each tablet to store its database files.
 This field is required for local MySQL, but should be omitted in the case of externally
 managed MySQL.</p>
-<p>IMPORTANT: If your Kubernetes cluster is multi-zone, you must set a
-storageClassName here for a StorageClass that&rsquo;s configured to only
-provision volumes in the same zone as this tablet pool.</p>
+<p>IMPORTANT: For a tablet pool in a Kubernetes cluster that spans multiple
+zones, you should ensure that <code>volumeBindingMode: WaitForFirstConsumer</code>
+is set on the StorageClass specified in the storageClassName field here.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/planetscale/v2/etcdlockserver_types.go
+++ b/pkg/apis/planetscale/v2/etcdlockserver_types.go
@@ -82,10 +82,9 @@ type EtcdLockserverTemplate struct {
 	// for each etcd instance to store its data files.
 	// This field is required.
 	//
-	// IMPORTANT: For a cell-local lockserver, you have two options. You either should set a storageClassName here for
-	// a StorageClass that's configured to only provision volumes in the Availability Zone that corresponds to the
-	// Vitess cell, or instead you may set `volumeBindingMode: WaitForFirstConsumer` in the StorageClass.
-	// This allows you to use the same StorageClass for any availability zone.
+	// IMPORTANT: For a cell-local lockserver in a Kubernetes cluster that spans
+	// multiple zones, you should ensure that `volumeBindingMode: WaitForFirstConsumer`
+	// is set on the StorageClass specified in the storageClassName field here.
 	// Default: Let the operator choose.
 	DataVolumeClaimTemplate corev1.PersistentVolumeClaimSpec `json:"dataVolumeClaimTemplate,omitempty"`
 

--- a/pkg/apis/planetscale/v2/etcdlockserver_types.go
+++ b/pkg/apis/planetscale/v2/etcdlockserver_types.go
@@ -82,9 +82,10 @@ type EtcdLockserverTemplate struct {
 	// for each etcd instance to store its data files.
 	// This field is required.
 	//
-	// IMPORTANT: For a cell-local lockserver, you must set a storageClassName
-	// here for a StorageClass that's configured to only provision volumes in
-	// the Availability Zone that corresponds to the Vitess cell.
+	// IMPORTANT: For a cell-local lockserver, you have two options. You either should set a storageClassName here for
+	// a StorageClass that's configured to only provision volumes in the Availability Zone that corresponds to the
+	// Vitess cell, or instead you may set `volumeBindingMode: WaitForFirstConsumer` in the StorageClass.
+	// This allows you to use the same StorageClass for any availability zone.
 	// Default: Let the operator choose.
 	DataVolumeClaimTemplate corev1.PersistentVolumeClaimSpec `json:"dataVolumeClaimTemplate,omitempty"`
 

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -195,9 +195,9 @@ type VitessShardTabletPool struct {
 	// This field is required for local MySQL, but should be omitted in the case of externally
 	// managed MySQL.
 	//
-	// IMPORTANT: If your Kubernetes cluster is multi-zone, you must set a
-	// storageClassName here for a StorageClass that's configured to only
-	// provision volumes in the same zone as this tablet pool.
+	// IMPORTANT: For a tablet pool in a Kubernetes cluster that spans multiple
+	// zones, you should ensure that `volumeBindingMode: WaitForFirstConsumer`
+	// is set on the StorageClass specified in the storageClassName field here.
 	DataVolumeClaimTemplate *corev1.PersistentVolumeClaimSpec `json:"dataVolumeClaimTemplate,omitempty"`
 
 	// BackupLocationName is the name of the backup location to use for this


### PR DESCRIPTION
This PR Updates local lockserver suggestions in generated docs to include a newer and simpler approach.