### PR TITLE
Fix: Sort Tolerations and Volume Names for Deterministic Hash

### DIFF
--- a/pkg/operator/contenthash/tolerations.go
+++ b/pkg/operator/contenthash/tolerations.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -30,8 +31,24 @@ import (
 func Tolerations(in []corev1.Toleration) string {
 	h := md5.New()
 
+	tolStrings := make([]string, 0, len(in))
+	for _, toleration := range in {
+		var tolSec int64
+		if toleration.TolerationSeconds != nil {
+			tolSec = *toleration.TolerationSeconds
+		}
+		tolString := strings.Join([]string{
+			toleration.Key,
+			toleration.Value,
+			string(toleration.Operator),
+			string(toleration.Effect),
+			strconv.FormatInt(tolSec, 10),
+		}, ",")
+		tolStrings = append(tolStrings, tolString)
+	}
+
 	sort.Slice(in, func(i, j int) bool {
-		return in[i].Key < in[j].Key
+		return tolStrings[i] < tolStrings[j]
 	})
 
 	for i := range in {

--- a/pkg/operator/contenthash/tolerations.go
+++ b/pkg/operator/contenthash/tolerations.go
@@ -20,6 +20,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"io"
+	"sort"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,10 @@ import (
 // Tolerations returns a hex-encoded hash of a list of Tolerations.
 func Tolerations(in []corev1.Toleration) string {
 	h := md5.New()
+
+	sort.Slice(in, func(i, j int) bool {
+		return in[i].Key < in[j].Key
+	})
 
 	for i := range in {
 		tol := &in[i]

--- a/pkg/operator/desiredstatehash/builder.go
+++ b/pkg/operator/desiredstatehash/builder.go
@@ -24,6 +24,8 @@ limitations under the License.
 package desiredstatehash
 
 import (
+	"sort"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"planetscale.dev/vitess-operator/pkg/operator/contenthash"
@@ -104,5 +106,6 @@ func (b *Builder) AddVolumeNames(itemName string, vols []corev1.Volume) {
 	for i := range vols {
 		volNames = append(volNames, vols[i].Name)
 	}
+	sort.Strings(volNames)
 	b.AddStringList(itemName, volNames)
 }

--- a/pkg/operator/desiredstatehash/builder_test.go
+++ b/pkg/operator/desiredstatehash/builder_test.go
@@ -53,3 +53,98 @@ func TestEmptyValues(t *testing.T) {
 		t.Errorf("b.String() = %q; want %q", got, want)
 	}
 }
+
+func TestTolerations(t *testing.T) {
+	a := NewBuilder()
+	b := NewBuilder()
+
+	tolerations := []corev1.Toleration{
+		corev1.Toleration{
+			Key:               "key1",
+			Operator:          "",
+			Value:             "",
+			Effect:            "",
+			TolerationSeconds: nil,
+		},
+		corev1.Toleration{
+			Key:               "key2",
+			Operator:          "",
+			Value:             "",
+			Effect:            "",
+			TolerationSeconds: nil,
+		},
+		corev1.Toleration{
+			Key:               "key3",
+			Operator:          "",
+			Value:             "",
+			Effect:            "",
+			TolerationSeconds: nil,
+		},
+	}
+
+	a.AddTolerations("Tolerations1", tolerations)
+	tolerationsDiffOrder := []corev1.Toleration{
+		corev1.Toleration{
+			Key:               "key3",
+			Operator:          "",
+			Value:             "",
+			Effect:            "",
+			TolerationSeconds: nil,
+		},
+		corev1.Toleration{
+			Key:               "key2",
+			Operator:          "",
+			Value:             "",
+			Effect:            "",
+			TolerationSeconds: nil,
+		},
+		corev1.Toleration{
+			Key:               "key1",
+			Operator:          "",
+			Value:             "",
+			Effect:            "",
+			TolerationSeconds: nil,
+		},
+	}
+	b.AddTolerations("Tolerations1", tolerationsDiffOrder)
+
+	if a.String() != b.String() {
+		t.Errorf("tolerations are same, but generating different hashes.")
+	}
+}
+
+func TestAddVolumeNames(t *testing.T) {
+	a := NewBuilder()
+	b := NewBuilder()
+
+	volumes := []corev1.Volume{
+		corev1.Volume{
+			Name: "vol1",
+		},
+		corev1.Volume{
+			Name: "vol2",
+		},
+		corev1.Volume{
+			Name: "vol3",
+		},
+	}
+	a.AddVolumeNames("VolumeNames", volumes)
+
+	volumesReordered := []corev1.Volume{
+		corev1.Volume{
+			Name: "vol2",
+		},
+		corev1.Volume{
+			Name: "vol3",
+		},
+		corev1.Volume{
+			Name: "vol1",
+		},
+	}
+
+	b.AddVolumeNames("VolumeNames", volumesReordered)
+
+	if a.String() != b.String() {
+		t.Errorf("volumes are same, but generating different hashes.")
+	}
+}


### PR DESCRIPTION
I wrote unit tests to catch a bug where we weren't deterministically sorting either tolerations or volumes which would cause a different hash if the order changed. I'm not certain it will fix this issue - we will have to try it out with a real deployment to see.