### PR TITLE
Fix: Copy ResourceRequirements so we aren't sharing pointers.

### DIFF
--- a/pkg/operator/etcd/pod.go
+++ b/pkg/operator/etcd/pod.go
@@ -184,7 +184,6 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 				ContainerPort: PeerPortNumber,
 			},
 		},
-		Resources: spec.Resources,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
@@ -212,6 +211,8 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		Env:          env,
 		VolumeMounts: volumeMounts,
 	}
+	// Make a copy of Resources since it contains pointers.
+	update.ResourceRequirements(&etcdContainer.Resources, &spec.Resources)
 
 	update.Volumes(&obj.Spec.Volumes, []corev1.Volume{
 		{

--- a/pkg/operator/update/podspec.go
+++ b/pkg/operator/update/podspec.go
@@ -210,7 +210,6 @@ func ResourceList(dst, src *corev1.ResourceList) {
 	if *dst == nil {
 		// Allocate a new map to avoid sharing memory with src.
 		*dst = make(corev1.ResourceList)
-		return
 	}
 	for srcKey, srcVal := range *src {
 		(*dst)[srcKey] = srcVal

--- a/pkg/operator/update/podspec.go
+++ b/pkg/operator/update/podspec.go
@@ -208,9 +208,8 @@ func ResourceRequirements(dst, src *corev1.ResourceRequirements) {
 // since those might be set by mutating admission webhooks or other controllers.
 func ResourceList(dst, src *corev1.ResourceList) {
 	if *dst == nil {
-		if len(*src) > 0 {
-			*dst = *src
-		}
+		// Allocate a new map to avoid sharing memory with src.
+		*dst = make(corev1.ResourceList)
 		return
 	}
 	for srcKey, srcVal := range *src {

--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -145,6 +145,9 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 
 	update.PodTemplateContainers(&obj.Spec.Template.Spec.InitContainers, spec.InitContainers)
 	update.PodTemplateContainers(&obj.Spec.Template.Spec.Containers, spec.SidecarContainers)
+	// Make a copy of Resources since it contains pointers.
+	var containerResources corev1.ResourceRequirements
+	update.ResourceRequirements(&containerResources, &spec.Resources)
 	update.PodTemplateContainers(&obj.Spec.Template.Spec.Containers, []corev1.Container{
 		{
 			Name:            containerName,
@@ -164,7 +167,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 					ContainerPort: planetscalev2.DefaultGrpcPort,
 				},
 			},
-			Resources:       spec.Resources,
+			Resources:       containerResources,
 			SecurityContext: securityContext,
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{

--- a/pkg/operator/vtgate/deployment.go
+++ b/pkg/operator/vtgate/deployment.go
@@ -185,7 +185,6 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 				ContainerPort: planetscalev2.DefaultMysqlPort,
 			},
 		},
-		Resources:       spec.Resources,
 		SecurityContext: securityContext,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
@@ -208,6 +207,8 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 		VolumeMounts: spec.ExtraVolumeMounts,
 		Env:          env,
 	}
+	// Make a copy of Resources since it contains pointers.
+	update.ResourceRequirements(&vtgateContainer.Resources, &spec.Resources)
 
 	// Get all the flags that don't need any logic.
 	flags := spec.baseFlags()

--- a/pkg/operator/vtorc/deployment.go
+++ b/pkg/operator/vtorc/deployment.go
@@ -162,7 +162,6 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 				ContainerPort: planetscalev2.DefaultVtorcWebPort,
 			},
 		},
-		Resources:       spec.Resources,
 		SecurityContext: securityContext,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
@@ -187,6 +186,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 		VolumeMounts: spec.ExtraVolumeMounts,
 		Env:          spec.ExtraEnv,
 	}
+	update.ResourceRequirements(&vtorcContainer.Resources, &spec.Resources)
 	updateConfig(spec, flags, vtorcContainer, &obj.Spec.Template.Spec)
 	vtorcContainer.Args = flags.FormatArgs()
 	update.PodTemplateContainers(&obj.Spec.Template.Spec.Containers, []corev1.Container{*vtorcContainer})

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -176,12 +176,13 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 					ContainerPort: planetscalev2.DefaultMysqlPort,
 				},
 			},
-			Resources:       spec.Mysqld.Resources,
 			SecurityContext: securityContext,
 			// TODO(enisoc): Add readiness and liveness probes that make sense for mysqld.
 			Env:          env,
 			VolumeMounts: mysqldMounts,
 		}
+
+		update.ResourceRequirements(&mysqldContainer.Resources, &spec.Mysqld.Resources)
 
 		// TODO: Can/should we still run mysqld_exporter pointing at external mysql?
 		mysqldExporterContainer = &corev1.Container{

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -128,7 +128,6 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 				ContainerPort: planetscalev2.DefaultGrpcPort,
 			},
 		},
-		Resources:       spec.Vttablet.Resources,
 		SecurityContext: securityContext,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
@@ -157,6 +156,8 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		Env:          vttabletEnv,
 		VolumeMounts: vttabletMounts,
 	}
+	// Make a copy of Resources since it contains pointers.
+	update.ResourceRequirements(&vttabletContainer.Resources, &spec.Vttablet.Resources)
 
 	var mysqldContainer *corev1.Container
 	var mysqldExporterContainer *corev1.Container

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -127,6 +127,10 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec) *corev1.Pod {
 		securityContext.RunAsUser = pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser)
 	}
 
+	var containerResources corev1.ResourceRequirements
+	// Make a copy of Resources since it contains pointers.
+	update.ResourceRequirements(&containerResources, &tabletSpec.Mysqld.Resources)
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   key.Namespace,
@@ -167,7 +171,7 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec) *corev1.Pod {
 					ImagePullPolicy: tabletSpec.ImagePullPolicies.Mysqld,
 					Command:         []string{vtbackupCommand},
 					Args:            vtbackupFlags.Get(backupSpec).FormatArgs(),
-					Resources:       tabletSpec.Mysqld.Resources,
+					Resources:       containerResources,
 					SecurityContext: securityContext,
 					Env:             env,
 					VolumeMounts:    volumeMounts,


### PR DESCRIPTION
ResourcesRequirements internally holds maps, which are pointers. We found that this can create a bug if resource requirements gets mutated by another party. This PR tries to resolve that by copying resource requirements everywhere we set it to avoid shared memory issues.