### PR TITLE
Use at least go1.15.11 and remove unused cache step from workflows

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -13,20 +13,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
       id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
-
-    - name: Go module cache
-      id: go-mod-cache
-      uses: actions/cache@v1
-      with:
-        path: ~/go/pkg/mod
-        key: go-mod-cache
 
     - name: Integration Test
       run: make integration-test

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -13,20 +13,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
       id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
-
-    - name: Go module cache
-      id: go-mod-cache
-      uses: actions/cache@v1
-      with:
-        path: ~/go/pkg/mod
-        key: go-mod-cache
 
     - name: Build
       run: go install -v ./...


### PR DESCRIPTION
actions/setup-go v2 contains fixes for version matching and logging of go env

Also, rather than relying on whatever latest Go version is cached on the runner, explicitly ask for Go 1.15.11 or newer patch release

For example, currently the Github runner image only has go1.15.10, so this forces the usage of go1.15.11 now.

If go1.15.12 is released, it would automatically upgrade as soon as https://github.com/actions/go-versions/blob/main/versions-manifest.json is updated or if a new runner image is released with it pre-isntalled.

The `go-mod-cache` doesn't actually do anything, so removing it too.