### PR TITLE
Support for VTTablet lifecycle hooks

### DIFF
--- a/deploy/crds/planetscale.com_vitessshards.yaml
+++ b/deploy/crds/planetscale.com_vitessshards.yaml
@@ -505,6 +505,75 @@ spec:
                               type: string
                             type: object
                         type: object
+                      lifecycle:
+                        properties:
+                          postStart:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                  scheme:
+                                    type: string
+                                type: object
+                            type: object
+                          preStop:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                  scheme:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
                     required:
                     - resources
                     type: object

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -7434,6 +7434,19 @@ not have any prefix (just &ldquo;flag&rdquo;, not &ldquo;-flag&rdquo;). To set a
 set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>lifecycle</code></br>
+<em>
+<a href="https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#lifecycle-v1-core">
+Kubernetes core/v1.Lifecycle
+</em>
+</td>
+<td>
+<p>Lifecycle can optionally be used to add container lifecycle hooks to Vttablet container
+</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.WorkflowState">WorkflowState

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -284,6 +284,11 @@ type VttabletSpec struct {
 	// not have any prefix (just "flag", not "-flag"). To set a boolean flag,
 	// set the string value to either "true" or "false".
 	ExtraFlags map[string]string `json:"extraFlags,omitempty"`
+
+	// Lifecycle can optionally be used to add container lifecycle hooks
+	// to vttablet container
+	// *kubebuilder:validation:EmbeddedResource
+	Lifecycle corev1.Lifecycle `json:"lifecycle,omitempty"`
 }
 
 // MysqldSpec configures the local MySQL server within a tablet.

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -109,6 +109,8 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		securityContext.RunAsUser = pointer.Int64Ptr(planetscalev2.DefaultVitessRunAsUser)
 	}
 
+	vttabletLifecycle := &spec.Vttablet.Lifecycle
+
 	// Build the containers.
 	vttabletContainer := &corev1.Container{
 		Name:            vttabletContainerName,
@@ -153,6 +155,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 			InitialDelaySeconds: 300,
 			FailureThreshold:    30,
 		},
+		Lifecycle:    vttabletLifecycle,
 		Env:          vttabletEnv,
 		VolumeMounts: vttabletMounts,
 	}


### PR DESCRIPTION
Adding support for container lifecycle hooks (https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) to VTTablet pods.

My main use case is to issue a `TabletExternallyReparented` command when scheduler decides to kill our primary tablets (unmanaged) - there could be other uses as well.

I'm not familiar with how integration tests are scoped, but I tested on my own cluster:

## Tests:

<img width="518" alt="Screen Shot 2021-04-21 at 19 52 08" src="https://user-images.githubusercontent.com/53193260/115645482-b39fd280-a2dd-11eb-8afc-3486ed8194c7.png">

Logs from vtctld when above container is terminated:

<img width="1178" alt="Screen Shot 2021-04-21 at 20 11 30" src="https://user-images.githubusercontent.com/53193260/115645539-cdd9b080-a2dd-11eb-8c6e-ffde498bdaf8.png">



Signed-off-by: Artem Vovk <avovk@recurly.com>