### PR TITLE
Relax consistency during vtbackup "catch up" phase.

### DIFF
--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -42,7 +42,7 @@ else
 fi
 ln -sf /dev/stderr /mnt/vt/config/stderr.symlink
 echo "log-error = /vt/config/stderr.symlink" > /mnt/vt/config/mycnf/log-error.cnf
-echo "binlog_format=row" > /mnt/vt/config/mycnf/rbr.cnf
+echo -e "binlog_format=row\nsync_binlog=0\ninnodb_flush_log_at_trx_commit=0" > /mnt/vt/config/mycnf/rbr.cnf
 mkdir -p /mnt/vt/certs
 cp --no-clobber /etc/ssl/certs/ca-certificates.crt /mnt/vt/certs/
 echo "socket = ` + mysqlSocketPath + `" > /mnt/vt/config/mycnf/socket.cnf


### PR DESCRIPTION
No reason to have strong consistency, since if there
are any errors during the backup, we should discard it
and start from scratch.

This allows fast(er) "catch up" from the binary logs, and
allow the backup to complete in a reasonable time, even
if the upstream write rate is high.

Signed-off-by: Jacques Grove <aquarapid@gmail.com>