### PR TITLE
actions: use main as default branch

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -2,10 +2,10 @@ name: integration-test
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 jobs:
   build:
     name: Integration Test

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -2,10 +2,10 @@ name: unit-test
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 jobs:
   build:
     name: Unit Test

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -50,7 +50,7 @@ settings until the new `vitess/lite` image tag is pushed.
 
 ### Update Compatibility Table
 
-Add a new entry for the planned minor version to the [compatibility table](https://github.com/planetscale/vitess-operator/blob/master/README.md#compatibility)
+Add a new entry for the planned minor version to the [compatibility table](https://github.com/planetscale/vitess-operator/blob/main/README.md#compatibility)
 in the README file.
 
 The recommended Kubernetes versions depend on the version of the Kubernetes

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,0 @@
-# Serve generated CRD API docs.
-[[redirects]]
-  from = "/api/"
-  to = "/docs/api/index.html"
-  status = 200


### PR DESCRIPTION
This change prepares the repository to have its default branch changed to `main`.﻿

The netlify configuration was removed because it's handled as part of the PlanetScale documentation repository now.