### PR TITLE
Externalmaster failover

### DIFF
--- a/pkg/apis/planetscale/v2/vitessshard_methods.go
+++ b/pkg/apis/planetscale/v2/vitessshard_methods.go
@@ -35,6 +35,11 @@ func (t *VitessTabletStatus) IsRunning() bool {
 	return t.Running == corev1.ConditionTrue
 }
 
+// IsAvailable indicates whether the tablet is known to be Available.
+func (t *VitessTabletStatus) IsAvailable() bool {
+	return t.Available == corev1.ConditionTrue
+}
+
 // InitTabletType returns a string representing what the initial tablet
 // type should be for a tablet in this type of pool.
 func (t *VitessTabletPoolType) InitTabletType() string {

--- a/pkg/controller/vitessshardreplication/tablet_externally_reparent.go
+++ b/pkg/controller/vitessshardreplication/tablet_externally_reparent.go
@@ -53,14 +53,6 @@ func (r *ReconcileVitessShard) tabletExternallyReparent(ctx context.Context, vts
 	ctx, cancel := context.WithTimeout(ctx, externallyReparentTimeout)
 	defer cancel()
 
-	// Check actual shard record in case we are out of sync
-	// and bail if shard record says we have a master already.
-	keyspaceName := vts.Labels[planetscalev2.KeyspaceLabel]
-	shard, err := wr.TopoServer().GetShard(ctx, keyspaceName, vts.Name)
-	if err == nil && shard.HasMaster() {
-		return resultBuilder.Result()
-	}
-
 	// Find the first external master that's running, if any.
 	var masterCandidateAlias *topodatapb.TabletAlias
 	for name, tablet := range vts.Status.Tablets {


### PR DESCRIPTION
s/already/always returns a node error from the first commit message