### PR TITLE
Move relaxing consistency for vtbackup to a separate my.cnf file,

### DIFF
--- a/pkg/operator/vttablet/constants.go
+++ b/pkg/operator/vttablet/constants.go
@@ -122,4 +122,5 @@ var (
 	defaultExtraMyCnf = []string{
 		vtMycnfPath + "/rbr.cnf",
 	}
+	vtbackupExtraMyCnfFile = vtMycnfPath + "/vtbackup.cnf"
 )

--- a/pkg/operator/vttablet/mysqld_config_overrides.go
+++ b/pkg/operator/vttablet/mysqld_config_overrides.go
@@ -41,7 +41,12 @@ func init() {
 		if spec.Mysqld == nil || len(spec.Mysqld.ConfigOverrides) == 0 {
 			return nil
 		}
-		return []string{"/pod-config/mysqld-config-overrides"}
+		// Append an extra config file for vtbackup at the end to override any
+		// settings from the custom ones; will be empty for normal vttablet
+		return []string{
+			"/pod-config/mysqld-config-overrides",
+			vtbackupExtraMyCnfFile,
+		}
 	})
 	tabletVolumes.Add(func(s lazy.Spec) []corev1.Volume {
 		spec := s.(*Spec)

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -42,7 +42,8 @@ else
 fi
 ln -sf /dev/stderr /mnt/vt/config/stderr.symlink
 echo "log-error = /vt/config/stderr.symlink" > /mnt/vt/config/mycnf/log-error.cnf
-echo -e "binlog_format=row\nsync_binlog=0\ninnodb_flush_log_at_trx_commit=0" > /mnt/vt/config/mycnf/rbr.cnf
+echo "binlog_format=row" > /mnt/vt/config/mycnf/rbr.cnf
+echo -e "sync_binlog=0\ninnodb_flush_log_at_trx_commit=0" > /mnt/vt/config/mycnf/vtbackup.cnf
 mkdir -p /mnt/vt/certs
 cp --no-clobber /etc/ssl/certs/ca-certificates.crt /mnt/vt/certs/
 echo "socket = ` + mysqlSocketPath + `" > /mnt/vt/config/mycnf/socket.cnf


### PR DESCRIPTION
applied after any vttablet customizations, which might enable
those consistency settings again in common configs.

Signed-off-by: Jacques Grove <aquarapid@gmail.com>