### PR TITLE
pkg/operator/vttablet/datastore.go: Remove logic around recently depr…

### DIFF
--- a/pkg/operator/vttablet/datastore.go
+++ b/pkg/operator/vttablet/datastore.go
@@ -18,7 +18,6 @@ package vttablet
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
 	"planetscale.dev/vitess-operator/pkg/operator/lazy"
 	"planetscale.dev/vitess-operator/pkg/operator/secrets"
 	"planetscale.dev/vitess-operator/pkg/operator/vitess"

--- a/pkg/operator/vttablet/datastore.go
+++ b/pkg/operator/vttablet/datastore.go
@@ -130,9 +130,5 @@ func externalDatastoreFlags(spec *Spec) vitess.Flags {
 		"vreplication_tablet_type":    vreplicationTabletType,
 	}
 
-	if spec.Type == planetscalev2.ExternalMasterPoolType {
-		flags["demote_master_type"] = "SPARE"
-	}
-
 	return flags
 }


### PR DESCRIPTION
…ecated demote_master_type flag

https://github.com/vitessio/vitess/pull/8511 removes the `demote_master_type` flag, which is breaking pools of `type: externalmaster`:
```
flag provided but not defined: -demote_master_type
Usage of /vt/bin/vttablet:
  -allowed_tablet_types value
    	Specifies the tablet types this vtgate is allowed to route queries to
```

Signed-off-by: Gary Edgar <gary@planetscale.com>