### PR TITLE
Upgrade the golang version to 1.17 in Dockerfile.release

### DIFF
--- a/build/Dockerfile.release
+++ b/build/Dockerfile.release
@@ -11,7 +11,7 @@
 # without messing up file permissions, since the Docker container doesn't run as
 # your actual user.
 
-FROM golang:1.15 AS build
+FROM golang:1.17 AS build
 
 ENV GO111MODULE=on
 WORKDIR /go/src/planetscale.dev/vitess-operator


### PR DESCRIPTION
This pull request bumps the Golang version we use to build the operator's Docker image to `go1.17`. This allows us to match the version defined in the `go.mod` of this project.