### PR TITLE
replace calls to deprecated RPC with new one

### DIFF
--- a/pkg/controller/vitessshardreplication/init_restored_shard.go
+++ b/pkg/controller/vitessshardreplication/init_restored_shard.go
@@ -257,7 +257,7 @@ func electInitialShardPrimary(ctx context.Context, keyspaceName, shardName strin
 		wg.Add(1)
 		go func(tablet *topo.TabletInfo) {
 			defer wg.Done()
-			err := wr.TabletManagerClient().SetMaster(ctx, tablet.Tablet, candidatePrimary.tablet.Alias, 0 /* don't try to wait for a reparent journal entry */, "" /* don't wait for any position */, true /* forceStartReplication */)
+			err := wr.TabletManagerClient().SetReplicationSource(ctx, tablet.Tablet, candidatePrimary.tablet.Alias, 0 /* don't try to wait for a reparent journal entry */, "" /* don't wait for any position */, true /* forceStartReplication */)
 			if err != nil {
 				log.Warningf("best-effort configuration of replication for tablet %v failed: %v", tablet.AliasString(), err)
 			}

--- a/pkg/controller/vitessshardreplication/repair_replication.go
+++ b/pkg/controller/vitessshardreplication/repair_replication.go
@@ -297,7 +297,7 @@ func (r *ReconcileVitessShard) repairReplicationLocked(ctx context.Context, vts 
 			// Only force start replication on replicas, not rdonly.
 			// A rdonly might be stopped on purpose for a diff.
 			forceStartReplication := tablet.Type == topodatapb.TabletType_REPLICA
-			err = wr.TabletManagerClient().SetMaster(ctx, tablet, primaryTabletInfo.Alias, 0 /* don't try to wait for a reparent journal entry */, "" /* don't wait for any position */, forceStartReplication)
+			err = wr.TabletManagerClient().SetReplicationSource(ctx, tablet, primaryTabletInfo.Alias, 0 /* don't try to wait for a reparent journal entry */, "" /* don't wait for any position */, forceStartReplication)
 			reparentTabletCount.WithLabelValues(metricLabels(vts, err)...).Inc()
 			if err != nil {
 				// Just log the error instead of failing the process, because fixing replicas is best-effort.


### PR DESCRIPTION
SetMaster is deprecated. It will be removed in the next vitess release.
Replace with SetReplicationSource.