### PR TITLE
Add pruneSrvKeyspaces to federated lockserver setup docs

### DIFF
--- a/docs/architecture/federation.md
+++ b/docs/architecture/federation.md
@@ -130,6 +130,7 @@ In particular, the following settings should be disabled:
 - `registerCellsAliases`
 - `pruneCells`
 - `pruneKeyspaces`
+- `pruneSrvKeyspaces` — if you want to query any keyspace from any cell (most importantly this must be disabled in the VitessCell CRD)
 - `pruneShards`
 
 With these features off, you may need to manually clean up Vitess topology when


### PR DESCRIPTION
I say most importantly the `VitessCell` because while you should set it in [all of the applicable CRDs](https://github.com/planetscale/vitess-operator/blob/f9993922ff84e703b4aa39cd11e83ea09ed5f43d/docs/api.md#toporeconcileconfig), the `VitessCell` is the object where that config value is consulted during reconciliation: https://github.com/planetscale/vitess-operator/blob/1aef31a78a616069f7fb31d9aefd5e396de474a7/pkg/controller/vitesscell/reconcile_topo.go#L40-L46


Signed-off-by: Matt Lord <mattalord@gmail.com>