### PR TITLE
Updated the compatibility table and `version.go` file following the release of `2.6.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Vitess Operator Version | Recommended Vitess Versions | Recommended Kubernetes V
 `v2.3.*` | `v9.0.*`  | `v1.15.*`, `v1.16.*`, or `v1.17.*`
 `v2.4.*` | `v10.0.*` | `v1.15.*`, `v1.16.*`, or `v1.17.*`
 `v2.5.*` | `v12.0.*` | `v1.17.*`, `v1.18.*`, or `v1.19.*`
-`v2.6.*` | `v12.0.*` | `v1.18.*`, `v1.19.*`, or `v1.20.*`
-`v2.7.*` | `v12.0.*` | `v1.20.*`, `v1.21.*`, or `v1.22.*`
+`v2.6.*` | `v13.0.*` | `v1.20.*`, `v1.21.*`, or `v1.22.*`
 `latest` | `latest`  | `v1.20.*`, `v1.21.*`, or `v1.22.*`
 
 If for some reason you must attempt to use versions outside the recommend

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package version
 
 var (
-	Version = "2.6.0"
+	Version = "2.7.0"
 )


### PR DESCRIPTION
This pull request updates the compatibility table of the README to reflect the new release of vtop (`2.6.0`) and vitess (`13.0.0`).

Additionally, the `version.go` file is updated as instructed in the [`after release` step of the release process](https://github.com/planetscale/vitess-operator/blob/main/docs/release-process.md#after-release).