### PR TITLE
Add arm64 container build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ build:
 release-build:
 	docker build -f build/Dockerfile.release -t $(IMAGE_NAME):$(IMAGE_TAG) .
 
+release-build.arm64:
+	docker buildx build --platform linux/arm64 --build-arg GOOS=linux --build-arg GOARCH=arm64 -f build/Dockerfile.release -t $(IMAGE_NAME):$(IMAGE_TAG) .
+
 unit-test:
 	pkgs="$$(go list ./... | grep -v '/test/integration/')" && \
 		go test -i $${pkgs} && \


### PR DESCRIPTION
This is not going to be of much use until a Vitess lite arm64 docker image is available; but baby steps.

Note that your docker build environment probably needs to be cross-compilation enabled using something like https://github.com/tonistiigi/binfmt for this build to work (assuming you are running this on linux/amd64)

Signed-off-by: Jacques Grove <aquarapid@gmail.com>