### PR TITLE
Set vttablet init container resource requests and limits

### DIFF
--- a/pkg/operator/vttablet/mysqlctld.go
+++ b/pkg/operator/vttablet/mysqlctld.go
@@ -18,6 +18,7 @@ package vttablet
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 
 	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
@@ -47,6 +48,9 @@ for mycnf in $(find . -mindepth 2 -maxdepth 2 -path './vt_*/my.cnf'); do
   sed -i -e 's,^socket[ \t]*=.*$,socket = ` + mysqlSocketPath + `,' "${mycnf}"
 done
 `
+
+	defaultInitCPURequestMillis   = 100
+	defaultInitMemoryRequestBytes = 32 * (1 << 20) // 32 MiB
 )
 
 func init() {
@@ -86,6 +90,12 @@ func init() {
 				},
 				Command: []string{"bash", "-c"},
 				Args:    []string{vtRootInitScript},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(defaultInitCPURequestMillis, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(defaultInitMemoryRequestBytes, resource.BinarySI),
+					},
+				},
 			},
 		}
 
@@ -108,6 +118,12 @@ func init() {
 				},
 				Command: []string{"bash", "-c"},
 				Args:    []string{mysqlSocketInitScript},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(defaultInitCPURequestMillis, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(defaultInitMemoryRequestBytes, resource.BinarySI),
+					},
+				},
 			})
 		}
 

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -241,9 +241,18 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		}
 	}
 
+	// Set the resource requirements on each of the default vttablet init
+	// containers to the same values as the vttablet container itself in
+	// case the cluster requires them.
+	defaultTabletInitContainers := tabletInitContainers.Get(spec)
+	for i := range defaultTabletInitContainers {
+		c := &defaultTabletInitContainers[i]
+		update.ResourceRequirements(&c.Resources, &spec.Vttablet.Resources)
+	}
+
 	// Make the final list of desired containers and init containers.
 	initContainers := []corev1.Container{}
-	initContainers = append(initContainers, tabletInitContainers.Get(spec)...)
+	initContainers = append(initContainers, defaultTabletInitContainers...)
 	initContainers = append(initContainers, spec.InitContainers...)
 
 	sidecarContainers := []corev1.Container{}


### PR DESCRIPTION
Sets the resource requirements on each of the default vttablet init containers to the same request and limit values as the vttablet container itself.

This fixes the issue reported in #212 where pods would fail to be created on clusters with strict quota requirements because no limit was set on the init containers.

## History

This is a reimplementation of #216 with the change that it no longer sets a default resource _limit_.

This fixes the issue reported in #240 and discussed in #244 where the vttablet pod would fail to be created when the user sets a request larger than the default limit without also setting a larger limit. The user's nil limit would not override the default value because `update.ResourceRequirements(dst, src)` won't update `dst` with a nil `src` ([for good reasons](https://github.com/planetscale/vitess-operator/blob/da7efd4c945193864f5996cb793055449c4de97a/pkg/operator/update/podspec.go#L201-L203)).

With this change, users can once again increase the request by itself. If a cluster requires a limit, the user will already need to have set it on for vttablet so we can use the same value to override the init containers' default nil limit.

fixes #212
fixes #240

Signed-off-by: J. Brandt Buckley <brandt@runlevel1.com>