### PR TITLE
Add LockserverSpec.CellInfoAddress

### DIFF
--- a/deploy/crds/planetscale.com_vitesscells.yaml
+++ b/deploy/crds/planetscale.com_vitesscells.yaml
@@ -279,6 +279,8 @@ spec:
                 type: object
               lockserver:
                 properties:
+                  cellInfoAddress:
+                    type: string
                   etcd:
                     properties:
                       advertisePeerURLs:

--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -363,6 +363,8 @@ spec:
                       type: object
                     lockserver:
                       properties:
+                        cellInfoAddress:
+                          type: string
                         etcd:
                           properties:
                             advertisePeerURLs:
@@ -640,6 +642,8 @@ spec:
                 type: object
               globalLockserver:
                 properties:
+                  cellInfoAddress:
+                    type: string
                   etcd:
                     properties:
                       advertisePeerURLs:

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1348,6 +1348,18 @@ EtcdLockserverTemplate
 <p>Etcd deploys our own etcd cluster as a lockserver.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>cellInfoAddress</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>CellInfoAddress is the host:port of topology service which will be saved to cell info.
+Default: etcd client service.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="planetscale.com/v2.LockserverStatus">LockserverStatus

--- a/pkg/apis/planetscale/v2/vitesscluster_types.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_types.go
@@ -321,6 +321,10 @@ type LockserverSpec struct {
 
 	// Etcd deploys our own etcd cluster as a lockserver.
 	Etcd *EtcdLockserverTemplate `json:"etcd,omitempty"`
+
+	// CellInfoAddress is the host:port of topology service which will be saved to cell info.
+	// Default: etcd client service.
+	CellInfoAddress string `json:"cellInfoAddress,omitempty"`
 }
 
 // LockserverStatus is the lockserver component of status.

--- a/pkg/operator/lockserver/params.go
+++ b/pkg/operator/lockserver/params.go
@@ -38,9 +38,13 @@ func GlobalConnectionParams(lockSpec *planetscalev2.LockserverSpec, namespace, c
 	case lockSpec.External != nil:
 		return lockSpec.External
 	case lockSpec.Etcd != nil:
+		address := lockSpec.CellInfoAddress
+		if len(address) == 0 {
+			address = fmt.Sprintf("%s-client.%s.svc:%d", GlobalEtcdName(clusterName), namespace, EtcdClientPort)
+		}
 		return &planetscalev2.VitessLockserverParams{
 			Implementation: VitessEtcdImplementationName,
-			Address:        fmt.Sprintf("%s-client.%s.svc:%d", GlobalEtcdName(clusterName), namespace, EtcdClientPort),
+			Address:        address,
 			RootPath:       fmt.Sprintf("/vitess/%s/global", clusterName),
 		}
 	default:
@@ -58,10 +62,14 @@ func LocalConnectionParams(globalLockserverSpec, cellLockserverSpec *planetscale
 	case cellLockserverSpec.External != nil:
 		return cellLockserverSpec.External
 	case cellLockserverSpec.Etcd != nil:
-		// Point to the client Service created by the local EtcdCluster.
+		address := cellLockserverSpec.CellInfoAddress
+		if len(address) == 0 {
+			// Point to the client Service created by the local EtcdCluster.
+			address = fmt.Sprintf("%s-client.%s.svc:%d", LocalEtcdName(clusterName, cellName), namespace, EtcdClientPort)
+		}
 		return &planetscalev2.VitessLockserverParams{
 			Implementation: VitessEtcdImplementationName,
-			Address:        fmt.Sprintf("%s-client.%s.svc:%d", LocalEtcdName(clusterName, cellName), namespace, EtcdClientPort),
+			Address:        address,
 			RootPath:       rootPath,
 		}
 	default:


### PR DESCRIPTION
`CellInfoAddress` - allows redefine cell info topology service address. 

This may be necessary for communication between federated Kubernetes clusters without service names resolution. 
For example: we have 2 clusters, each has local etcd topology service and expose it by NodePort service. 