### PR TITLE
Keep Security Context

### DIFF
--- a/pkg/operator/update/podspec.go
+++ b/pkg/operator/update/podspec.go
@@ -188,6 +188,10 @@ func SecurityContext(dst **corev1.SecurityContext, src *corev1.SecurityContext) 
 
 	// Save some original values.
 	dstProcMount := (*dst).ProcMount
+	dstAllowPrivilegeEscalation := (*dst).AllowPrivilegeEscalation
+	dstCapabilities := (*dst).Capabilities
+	dstReadOnlyRootFilesystem := (*dst).ReadOnlyRootFilesystem
+	dstRunAsGroup := (*dst).RunAsGroup
 
 	// Copy everything else.
 	**dst = *src
@@ -195,6 +199,18 @@ func SecurityContext(dst **corev1.SecurityContext, src *corev1.SecurityContext) 
 	// Restore saved values if the src didn't set them.
 	if (*dst).ProcMount == nil {
 		(*dst).ProcMount = dstProcMount
+	}
+	if (*dst).AllowPrivilegeEscalation == nil {
+		(*dst).AllowPrivilegeEscalation = dstAllowPrivilegeEscalation
+	}
+	if (*dst).Capabilities == nil {
+		(*dst).Capabilities = dstCapabilities
+	}
+	if (*dst).ReadOnlyRootFilesystem == nil {
+		(*dst).ReadOnlyRootFilesystem = dstReadOnlyRootFilesystem
+	}
+	if (*dst).RunAsGroup == nil {
+		(*dst).RunAsGroup = dstRunAsGroup
 	}
 }
 


### PR DESCRIPTION
This patch keeps more security context entries from the original pod, if they
are nil.

Some of those values could be set automatically for security reason by tools
like Gatekeeper or LimitRange Resource.
If that happens, the pods are recreated over and over again.

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>