### PR TITLE
Fix end to end tests

### DIFF
--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -15,12 +15,12 @@ spec:
           path: /backup
           type: Directory
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v14.0.0-rc1
+    vtgate: vitess/lite:v14.0.0-rc1
+    vttablet: vitess/lite:v14.0.0-rc1
+    vtbackup: vitess/lite:v14.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v14.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/102_keyspace_teardown.yaml
+++ b/test/endtoend/operator/102_keyspace_teardown.yaml
@@ -15,12 +15,12 @@ spec:
           path: /backup
           type: Directory
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v14.0.0-rc1
+    vtgate: vitess/lite:v14.0.0-rc1
+    vttablet: vitess/lite:v14.0.0-rc1
+    vtbackup: vitess/lite:v14.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v14.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v14.0.0-rc1
+    vtgate: vitess/lite:v14.0.0-rc1
+    vttablet: vitess/lite:v14.0.0-rc1
+    vtbackup: vitess/lite:v14.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v14.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/302_new_shards.yaml
+++ b/test/endtoend/operator/302_new_shards.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v14.0.0-rc1
+    vtgate: vitess/lite:v14.0.0-rc1
+    vttablet: vitess/lite:v14.0.0-rc1
+    vtbackup: vitess/lite:v14.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v14.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v14.0.0-rc1
+    vtgate: vitess/lite:v14.0.0-rc1
+    vttablet: vitess/lite:v14.0.0-rc1
+    vtbackup: vitess/lite:v14.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v14.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -8,12 +8,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v14.0.0-rc1
+    vtgate: vitess/lite:v14.0.0-rc1
+    vttablet: vitess/lite:v14.0.0-rc1
+    vtbackup: vitess/lite:v14.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v14.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1


### PR DESCRIPTION
## Description

This PR fixes the end to end tests by changing the Vitess image they use. The tests are currently supposed to test that upgrading from 13.0.0 to the code in release-branch 14.0 is safe and the current version of operator supports it.
To do this, we were earlier using the image tag `latest` because the 14.0 code lived on main. After we cut release-14.0, we should start using the rc-1 images.