### PR TITLE
Remove removed flag in vttablet

### DIFF
--- a/pkg/operator/vttablet/flags.go
+++ b/pkg/operator/vttablet/flags.go
@@ -67,8 +67,7 @@ func init() {
 			"init_shard":       spec.KeyRange.String(),
 			"init_tablet_type": spec.Type.InitTabletType(),
 
-			"health_check_interval":         healthCheckInterval,
-			"binlog_use_v3_resharding_mode": true,
+			"health_check_interval": healthCheckInterval,
 
 			"queryserver-config-max-result-size":  queryserverConfigMaxResultSize,
 			"queryserver-config-query-timeout":    queryserverConfigQueryTimeout,


### PR DESCRIPTION
## Description

Yesterday the PR https://github.com/vitessio/vitess/pull/10278 was merged on Vitess and it removed a flag that was being used in the vitess operator. This PR removes that flags usage.