### PR TITLE
Introduce Durability Policy in VTop

### DIFF
--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -958,6 +958,8 @@ spec:
                       type: object
                     databaseName:
                       type: string
+                    durabilityPolicy:
+                      type: string
                     name:
                       maxLength: 63
                       minLength: 1

--- a/deploy/crds/planetscale.com_vitesskeyspaces.yaml
+++ b/deploy/crds/planetscale.com_vitesskeyspaces.yaml
@@ -153,6 +153,8 @@ spec:
                 type: array
               databaseName:
                 type: string
+              durabilityPolicy:
+                type: string
               extraVitessFlags:
                 additionalProperties:
                   type: string

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -5777,6 +5777,18 @@ this to be the same as the keyspace name to reduce confusion.</p>
 </tr>
 <tr>
 <td>
+<code>durabilityPolicy</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>DurabilityPolicy is the name of the durability policy to use for the keyspace.
+The default, when the field is left empty is the <code>none</code> durability policy.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>vitessOrchestrator</code></br>
 <em>
 <a href="#planetscale.com/v2.VitessOrchestratorSpec">

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -5784,7 +5784,7 @@ string
 </td>
 <td>
 <p>DurabilityPolicy is the name of the durability policy to use for the keyspace.
-The default, when the field is left empty is the <code>none</code> durability policy.</p>
+If unspecified, vtop will not set the durability policy.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/planetscale/v2/vitesscluster_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_defaults.go
@@ -144,6 +144,10 @@ func DefaultVitessKeyspaceTemplate(keyspace *VitessKeyspaceTemplate) {
 		keyspace.TurndownPolicy = VitessKeyspaceTurndownPolicyRequireIdle
 	}
 
+	if keyspace.DurabilityPolicy == "" {
+		keyspace.DurabilityPolicy = "none"
+	}
+
 	for i := range keyspace.Partitionings {
 		partition := &keyspace.Partitionings[i]
 		defaultCustomPartitioning(partition.Custom)

--- a/pkg/apis/planetscale/v2/vitesscluster_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_defaults.go
@@ -144,10 +144,6 @@ func DefaultVitessKeyspaceTemplate(keyspace *VitessKeyspaceTemplate) {
 		keyspace.TurndownPolicy = VitessKeyspaceTurndownPolicyRequireIdle
 	}
 
-	if keyspace.DurabilityPolicy == "" {
-		keyspace.DurabilityPolicy = "none"
-	}
-
 	for i := range keyspace.Partitionings {
 		partition := &keyspace.Partitionings[i]
 		defaultCustomPartitioning(partition.Custom)

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -113,6 +113,10 @@ type VitessKeyspaceTemplate struct {
 	// Default: Add a "vt_" prefix to the keyspace name.
 	DatabaseName string `json:"databaseName,omitempty"`
 
+	// DurabilityPolicy is the name of the durability policy to use for the keyspace.
+	// The default, when the field is left empty is the `none` durability policy.
+	DurabilityPolicy string `json:"durabilityPolicy,omitempty"`
+
 	// VitessOrchestrator deploys a set of Vitess Orchestrator (vtorc) servers for the Keyspace.
 	// It is highly recommended that you set disable_active_reparents=true
 	// and enable_semi_sync=false for the vtablets if enabling vtorc.

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -114,7 +114,7 @@ type VitessKeyspaceTemplate struct {
 	DatabaseName string `json:"databaseName,omitempty"`
 
 	// DurabilityPolicy is the name of the durability policy to use for the keyspace.
-	// The default, when the field is left empty is the `none` durability policy.
+	// If unspecified, vtop will not set the durability policy.
 	DurabilityPolicy string `json:"durabilityPolicy,omitempty"`
 
 	// VitessOrchestrator deploys a set of Vitess Orchestrator (vtorc) servers for the Keyspace.

--- a/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
+++ b/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitesskeyspace
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
+	"vitess.io/vitess/go/vt/topo"
+
+	"planetscale.dev/vitess-operator/pkg/operator/results"
+)
+
+func (r *reconcileHandler) reconcileKeyspaceInformation(ctx context.Context) (reconcile.Result, error) {
+	resultBuilder := &results.Builder{}
+
+	// Initialize the topo server before using it.
+	// This call is idempotent, so it is safe to call each time
+	// before using the topo server.
+	err := r.tsInit(ctx)
+	if err != nil {
+		return resultBuilder.RequeueAfter(topoRequeueDelay)
+	}
+
+	topoServer := r.ts.Server
+	keyspaceName := r.vtk.Spec.Name
+	durabilityPolicy := r.vtk.Spec.DurabilityPolicy
+	keyspaceInfo, err := topoServer.GetKeyspace(ctx, keyspaceName)
+	if err != nil {
+		// The keyspace information record does not exist in the topo server.
+		// We should create the record
+		if !topo.IsErrType(err, topo.NoNode) {
+			// Create a normal keyspace with the requested durability policy
+			_, err := r.wr.VtctldServer().CreateKeyspace(ctx, &vtctldatapb.CreateKeyspaceRequest{
+				Name:             keyspaceName,
+				Type:             topodatapb.KeyspaceType_NORMAL,
+				DurabilityPolicy: durabilityPolicy,
+			})
+			if err != nil {
+				resultBuilder.Error(err)
+			}
+			return resultBuilder.Result()
+		}
+		// GetKeyspace returned a error other than NoNode.
+		// Maybe the topo server is temporarily unreachable
+		// We should retry after some time.
+		r.recorder.Eventf(r.vtk, corev1.EventTypeWarning, "GetKeyspace", "failed to get keyspace %v: %v", keyspaceName, err)
+		return resultBuilder.RequeueAfter(topoRequeueDelay)
+	}
+
+	// DurabilityPolicy doesn't match the one requested by the user
+	// We change the durability policy using the SetKeyspaceDurabilityPolicy rpc
+	if keyspaceInfo.DurabilityPolicy != durabilityPolicy {
+		_, err := r.wr.VtctldServer().SetKeyspaceDurabilityPolicy(ctx, &vtctldatapb.SetKeyspaceDurabilityPolicyRequest{
+			Keyspace:         keyspaceName,
+			DurabilityPolicy: durabilityPolicy,
+		})
+		if err != nil {
+			resultBuilder.Error(err)
+		}
+	}
+	return resultBuilder.Result()
+}

--- a/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
+++ b/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
@@ -68,7 +68,7 @@ func (r *reconcileHandler) reconcileKeyspaceInformation(ctx context.Context) (re
 
 	// DurabilityPolicy doesn't match the one requested by the user
 	// We change the durability policy using the SetKeyspaceDurabilityPolicy rpc
-	if keyspaceInfo.DurabilityPolicy != durabilityPolicy {
+	if durabilityPolicy != "" && keyspaceInfo.DurabilityPolicy != durabilityPolicy {
 		_, err := r.wr.VtctldServer().SetKeyspaceDurabilityPolicy(ctx, &vtctldatapb.SetKeyspaceDurabilityPolicyRequest{
 			Keyspace:         keyspaceName,
 			DurabilityPolicy: durabilityPolicy,

--- a/pkg/controller/vitesskeyspace/vitesskeyspace_controller.go
+++ b/pkg/controller/vitesskeyspace/vitesskeyspace_controller.go
@@ -168,6 +168,10 @@ func (r *ReconcileVitessKeyspace) Reconcile(cctx context.Context, request reconc
 		}
 	}()
 
+	// Create/update keyspace record in the topo server
+	keyspaceInfoRes, err := handler.reconcileKeyspaceInformation(ctx)
+	resultBuilder.Merge(keyspaceInfoRes, err)
+
 	// Create/update desired VitessShards.
 	if err := handler.reconcileShards(ctx); err != nil {
 		resultBuilder.Error(err)

--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -24,6 +24,7 @@ spec:
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1
+    durabilityPolicy: semi_sync
     gateway:
       authentication:
         static:

--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -24,7 +24,6 @@ spec:
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1
-    durabilityPolicy: semi_sync
     gateway:
       authentication:
         static:
@@ -53,6 +52,7 @@ spec:
 
   keyspaces:
   - name: commerce
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
     partitionings:
     - equal:

--- a/test/endtoend/operator/101_initial_cluster_vtadmin.yaml
+++ b/test/endtoend/operator/101_initial_cluster_vtadmin.yaml
@@ -18,6 +18,7 @@ spec:
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1
+    durabilityPolicy: semi_sync
     gateway:
       authentication:
         static:

--- a/test/endtoend/operator/101_initial_cluster_vtadmin.yaml
+++ b/test/endtoend/operator/101_initial_cluster_vtadmin.yaml
@@ -18,7 +18,6 @@ spec:
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1
-    durabilityPolicy: semi_sync
     gateway:
       authentication:
         static:
@@ -69,6 +68,7 @@ spec:
 
   keyspaces:
   - name: commerce
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
     partitionings:
     - equal:

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -41,6 +41,7 @@ spec:
 
   keyspaces:
   - name: commerce
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
     partitionings:
     - equal:
@@ -77,6 +78,7 @@ spec:
                 requests:
                   storage: 10Gi
   - name: customer
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
     partitionings:
     - equal:

--- a/test/endtoend/operator/302_new_shards.yaml
+++ b/test/endtoend/operator/302_new_shards.yaml
@@ -41,6 +41,7 @@ spec:
 
   keyspaces:
   - name: commerce
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
     partitionings:
     - equal:
@@ -77,6 +78,7 @@ spec:
                 requests:
                   storage: 10Gi
   - name: customer
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
     partitionings:
     - equal:

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -41,6 +41,7 @@ spec:
 
   keyspaces:
   - name: commerce
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
     partitionings:
     - equal:
@@ -73,6 +74,7 @@ spec:
                 requests:
                   storage: 10Gi
   - name: customer
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
     partitionings:
     - equal:

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -45,6 +45,7 @@ spec:
 
   keyspaces:
   - name: commerce
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
     partitionings:
     - equal:

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2089,6 +2091,8 @@ spec:
                         type: object
                       databaseName:
                         type: string
+                      durabilityPolicy:
+                        type: string
                       name:
                         maxLength: 63
                         minLength: 1
@@ -3573,6 +3577,8 @@ spec:
                     type: object
                   type: array
                 databaseName:
+                  type: string
+                durabilityPolicy:
                   type: string
                 extraVitessFlags:
                   additionalProperties:

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -170,6 +170,8 @@ function upgradeToLatest() {
   echo "Apply operator-latest.yaml "
   kubectl apply -f operator-latest.yaml
 
+  sleep 2
+
   echo "Upgrade all the other binaries"
   kubectl apply -f cluster_upgrade.yaml
 
@@ -231,9 +233,13 @@ setupKubectlAccessForCI
 get_started "operator.yaml" "101_initial_cluster.yaml"
 verifyVtGateVersion "14.0.0"
 checkSemiSyncSetup
+# Initially no durability policy is specified
+verifyDurabilityPolicy "commerce" ""
 upgradeToLatest
 verifyVtGateVersion "15.0.0"
 checkSemiSyncSetup
+# After upgrading, we set the durability policy to semi_sync
+verifyDurabilityPolicy "commerce" "semi_sync"
 move_tables
 resharding
 

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -123,6 +123,20 @@ function verifyVtGateVersion() {
   fi
 }
 
+
+# verifyDurabilityPolicy verifies the durability policy
+# in the given keyspace
+function verifyDurabilityPolicy() {
+  keyspace=$1
+  durabilityPolicy=$2
+  data=$(vtctlclient GetKeyspace "$keyspace")
+  echo "$data" | grep "\"durability_policy\": \"$durabilityPolicy\"" > /dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo -e "The durability policy in $keyspace is incorrect, got:\n$data"
+    exit 1
+  fi
+}
+
 function waitForKeyspaceToBeServing() {
   ks=$1
   shard=$2


### PR DESCRIPTION
## Description

This PR introduces the durability policy in the Vitess Operator. Durability Policy is introduced as a configuration in the Keyspace specification. 
Furthermore, the reconciliation logic for the same has also been added which ensures that the durability policy configured matches the durability policy in the topo server.

If the durability_policy is left unspecified, then VTop will not set a default or configure it at all. This is required for upgrade considerations. Since the previous version of VTop didn't support this configuration, when VTop is upgraded, it is expected that the durability policy configuration will be empty. If it is, we do not want to presume its value and set a default because that could be different than the durability policy that the user has already set in v14 using SetKeyspaceDurabilityPolicy.
Once VTop is upgraded, the durability policy config can be added and VTop will ensure that it is configured properly henceforth.