### PR TITLE
Augment VTAdmin test to also test VTOrc setup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,9 +47,9 @@ steps:
     - tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz
     - export PATH=$PATH:/usr/local/go/bin
     - rm go1.18.3.linux-amd64.tar.gz
-    - make vtadmin-test
+    - make vtorc-vtadmin-test
     concurrency: 1
-    concurrency_group: 'vtop/vtadmin-test'
+    concurrency_group: 'vtop/vtorc-vtadmin-test'
     timeout_in_minutes: 60
     plugins:
       - docker#v3.12.0:

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,6 @@ backup-restore-test: build e2e-test-setup
 	echo "Running Backup-Restore test"
 	test/endtoend/backup_restore_test.sh
 
-vtadmin-test: build e2e-test-setup
-	echo "Running VtAdmin test"
-	test/endtoend/vtadmin_test.sh
+vtorc-vtadmin-test: build e2e-test-setup
+	echo "Running VTOrc and VtAdmin test"
+	test/endtoend/vtorc_vtadmin_test.sh

--- a/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
+++ b/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
@@ -13,6 +13,7 @@ spec:
     vtgate: vitess/lite:latest
     vttablet: vitess/lite:latest
     vtbackup: vitess/lite:latest
+    vtorc: vitess/lite:latest
     mysqld:
       mysql56Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.11.0
@@ -70,6 +71,16 @@ spec:
   - name: commerce
     durabilityPolicy: semi_sync
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      configSecret:
+        name: example-cluster-config
+        key: orc_config.json
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
     partitionings:
     - equal:
         parts: 1
@@ -85,6 +96,7 @@ spec:
             replicas: 3
             vttablet:
               extraFlags:
+                disable_active_reparents: "true"
                 db_charset: utf8mb4
               resources:
                 limits:
@@ -203,11 +215,11 @@ stringData:
 
     # User for Orchestrator (https://github.com/openark/orchestrator).
     # TODO: Reenable when the password is randomly generated.
-    #CREATE USER 'orc_client_user'@'%' IDENTIFIED BY 'orc_client_user_password';
-    #GRANT SUPER, PROCESS, REPLICATION SLAVE, RELOAD
-    #  ON *.* TO 'orc_client_user'@'%';
-    #GRANT SELECT
-    #  ON _vt.* TO 'orc_client_user'@'%';
+    CREATE USER 'orc_client_user'@'%' IDENTIFIED BY 'orc_client_user_password';
+    GRANT SUPER, PROCESS, REPLICATION SLAVE, RELOAD
+      ON *.* TO 'orc_client_user'@'%';
+    GRANT SELECT
+      ON _vt.* TO 'orc_client_user'@'%';
 
     FLUSH PRIVILEGES;
 
@@ -230,3 +242,12 @@ stringData:
       subjects: ["*"]
       clusters:
         - "local"
+  orc_config.json: |
+    {
+      "Debug": true,
+      "MySQLTopologyUser": "orc_client_user",
+      "MySQLTopologyPassword": "orc_client_user_password",
+      "MySQLReplicaUser": "vt_repl",
+      "MySQLReplicaPassword": "",
+      "RecoveryPeriodBlockSeconds": 5
+    }

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -20,6 +20,11 @@ function checkSemiSyncSetup() {
   done
 }
 
+# getAllReplicaTablets returns the list of all the replica tablets as a space separated list
+function getAllReplicaTablets() {
+  vtctlclient ListAllTablets | grep "replica" | awk '{print $1}' | tr '\n' ' '
+}
+
 function printMysqlErrorFiles() {
   for vttablet in $(kubectl get pods --no-headers -o custom-columns=":metadata.name" | grep "vttablet") ; do
     echo "Finding error.log file in $vttablet"

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -3,19 +3,20 @@
 source ./tools/test.env
 source ./test/endtoend/utils.sh
 
-# get_started_vtadmin:
-function get_started_vtadmin() {
+# get_started_vtorc_vtadmin:
+function get_started_vtorc_vtadmin() {
     echo "Apply latest operator-latest.yaml"
     kubectl apply -f "operator-latest.yaml"
     checkPodStatusWithTimeout "vitess-operator(.*)1/1(.*)Running(.*)"
 
-    echo "Apply 101_initial_cluster_vtadmin.yaml"
-    kubectl apply -f "101_initial_cluster_vtadmin.yaml"
+    echo "Apply 101_initial_cluster_vtorc_vtadmin.yaml"
+    kubectl apply -f "101_initial_cluster_vtorc_vtadmin.yaml"
     checkPodStatusWithTimeout "example-zone1-vtctld(.*)1/1(.*)Running(.*)"
     checkPodStatusWithTimeout "example-zone1-vtgate(.*)1/1(.*)Running(.*)"
     checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-zone1-vtadmin(.*)2/2(.*)Running(.*)"
+    checkPodStatusWithTimeout "example-commerce-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
     sleep 10
     echo "Creating vschema and commerce SQL schema"
@@ -111,6 +112,19 @@ function verifyVtadminSetup() {
   chromiumHeadlessRequest "http://localhost:14000/keyspace/example/commerce/shards" "commerce/-"
 }
 
+# verifyVTOrcSetup verifies that VTOrc is running and repairing things that we mess up
+function verifyVTOrcSetup() {
+  # Stop replication using the vtctld and wait for VTOrc to repair
+  allReplicaTablets=$(getAllReplicaTablets)
+  for replica in $(echo "$allReplicaTablets") ; do
+    vtctlclient StopReplication "$replica"
+  done
+  # Now that we have stopped replication on both the tablets, we know that this will
+  # only succeed if VTOrc is able to fix it since we are running vttablet with disable active reparent
+  # and semi-sync durability policy
+  mysql -e "insert into customer(email) values('newemail@domain.com');"
+}
+
 function chromiumHeadlessRequest() {
   url=$1
   dataToAssert=$2
@@ -199,14 +213,16 @@ cd "$PWD/test/endtoend/operator"
 killall kubectl
 setupKubectlAccessForCI
 
-get_started_vtadmin
+get_started_vtorc_vtadmin
 verifyVtGateVersion "15.0.0"
 checkSemiSyncSetup
 
 # Check Vtadmin is setup
-# In get_started_vtadmin we verify that the pod for vtadmin exists and is healthy
+# In get_started_vtorc_vtadmin we verify that the pod for vtadmin exists and is healthy
 # We now try and query the vtadmin api
 verifyVtadminSetup
+# Next we check that VTOrc is running properly and is able to fix issues as they come up
+verifyVTOrcSetup
 
 # Teardown
 echo "Deleting Kind cluster. This also deletes the volume associated with it"


### PR DESCRIPTION
## Description

This PR augments the VTAdmin end-to-end test to also test VTOrc. The initial cluster-setup file is changed to also launch VTOrc. After verifying that VTAdmin is working as expected, we also go on to verify that VTOrc runs as expected. This is done by stopping replication on all the valid replicas. Following this, we try and write to the primary, which only succeeds if VTOrc can fix the failure and repair replication. 
An additional flag `disable-active-reparent` has been added to the vttablet in the test setup, just as how we recommend users to run. Furthermore, VTop only repairs replication if the source set on a tablet doesn't match the primary information. All of these pieces together mean that our test for the VTOrc setup is correct.
I have also manually verified that if VTOrc is not running, the writes are stalled indefinitely. 

There is a scope for improving the test to timeout after some time. Currently, that part is left to the CI timeout configured to 1 hour in the BuildKite pipeline configuration.