### PR TITLE
Remove Deprecated flags from VTop

### DIFF
--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -231,7 +231,6 @@ func (spec *Spec) flags() vitess.Flags {
 		"topo_global_root":           spec.GlobalLockserver.RootPath,
 
 		"logtostderr":           true,
-		"enable_queries":        true,
 		"enable_realtime_stats": true,
 
 		"workflow_manager_init":         true,


### PR DESCRIPTION
## Description

This PR removes the flag `enable_queries` removed in Vitess by https://github.com/vitessio/vitess/pull/10646.

Fixes #300