### PR TITLE
Fix Vitess Upgrade Workflow to also run `go mod tidy`

### DIFF
--- a/.github/workflows/upgrade-vitess-dependency.yaml
+++ b/.github/workflows/upgrade-vitess-dependency.yaml
@@ -20,7 +20,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Go Get latest Vitess Dependency
-        run: go get -d vitess.io/vitess@main
+        run: |
+          go get -d vitess.io/vitess@main
+          go mod tidy
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
## Description

In a PR created by the vitess-dependency upgrade workflow at https://github.com/planetscale/vitess-operator/pull/317 it was noticed that `go mod tidy` should also be run after upgrading the dependency.

This PR adds this command to the workflow.