### PR TITLE
Upgrade test to expect the latest image to be of version 16

### DIFF
--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -102,7 +102,7 @@ const (
 	// DefaultMysqlPortName is the name for the MySQL port.
 	DefaultMysqlPortName = "mysql"
 
-	defaultVitessLiteImage = "vitess/lite:v14.0.0"
+	defaultVitessLiteImage = "vitess/lite:latest"
 )
 
 // DefaultImages are a set of images to use when the CRD doesn't specify.

--- a/test/endtoend/backup_restore_test.sh
+++ b/test/endtoend/backup_restore_test.sh
@@ -103,7 +103,7 @@ killall kubectl
 setupKubectlAccessForCI
 
 get_started "operator-latest.yaml" "101_initial_cluster_backup.yaml"
-verifyVtGateVersion "15.0.0"
+verifyVtGateVersion "16.0.0"
 checkSemiSyncSetup
 takeBackup "commerce/-"
 takedownShard

--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -11,6 +11,7 @@ spec:
     vtctld: vitess/lite:v15.0.0-rc1
     vtgate: vitess/lite:v15.0.0-rc1
     vttablet: vitess/lite:v15.0.0-rc1
+    vtorc: vitess/lite:v15.0.0-rc1
     vtbackup: vitess/lite:v15.0.0-rc1
     mysqld:
       mysql56Compatible: vitess/lite:v15.0.0-rc1
@@ -45,7 +46,17 @@ spec:
 
   keyspaces:
   - name: commerce
+    durabilityPolicy: semi_sync
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
     partitionings:
     - equal:
         parts: 1
@@ -53,8 +64,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica

--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -8,12 +8,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v14.0.0
-    vtgate: vitess/lite:v14.0.0
-    vttablet: vitess/lite:v14.0.0
-    vtbackup: vitess/lite:v14.0.0
+    vtctld: vitess/lite:v15.0.0-rc1
+    vtgate: vitess/lite:v15.0.0-rc1
+    vttablet: vitess/lite:v15.0.0-rc1
+    vtbackup: vitess/lite:v15.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:v14.0.0
+      mysql56Compatible: vitess/lite:v15.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -18,6 +18,7 @@ spec:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
     vttablet: vitess/lite:latest
+    vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
       mysql56Compatible: vitess/lite:latest
@@ -54,6 +55,15 @@ spec:
   - name: commerce
     durabilityPolicy: semi_sync
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
     partitionings:
     - equal:
         parts: 1
@@ -61,8 +71,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica

--- a/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
+++ b/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
@@ -87,8 +87,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica

--- a/test/endtoend/operator/102_keyspace_teardown.yaml
+++ b/test/endtoend/operator/102_keyspace_teardown.yaml
@@ -18,6 +18,7 @@ spec:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
     vttablet: vitess/lite:latest
+    vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
       mysql56Compatible: vitess/lite:latest

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -7,6 +7,7 @@ spec:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
     vttablet: vitess/lite:latest
+    vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
       mysql56Compatible: vitess/lite:latest
@@ -43,6 +44,15 @@ spec:
   - name: commerce
     durabilityPolicy: semi_sync
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
     partitionings:
     - equal:
         parts: 1
@@ -50,8 +60,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica
@@ -80,6 +88,15 @@ spec:
   - name: customer
     durabilityPolicy: semi_sync
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
     partitionings:
     - equal:
         parts: 1
@@ -87,8 +104,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica

--- a/test/endtoend/operator/302_new_shards.yaml
+++ b/test/endtoend/operator/302_new_shards.yaml
@@ -7,6 +7,7 @@ spec:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
     vttablet: vitess/lite:latest
+    vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
       mysql56Compatible: vitess/lite:latest
@@ -43,6 +44,15 @@ spec:
   - name: commerce
     durabilityPolicy: semi_sync
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
     partitionings:
     - equal:
         parts: 1
@@ -50,8 +60,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica
@@ -80,6 +88,15 @@ spec:
   - name: customer
     durabilityPolicy: semi_sync
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
     partitionings:
     - equal:
         parts: 1
@@ -87,8 +104,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica
@@ -120,8 +135,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -7,6 +7,7 @@ spec:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
     vttablet: vitess/lite:latest
+    vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
       mysql56Compatible: vitess/lite:latest
@@ -42,6 +43,15 @@ spec:
   keyspaces:
   - name: commerce
     durabilityPolicy: semi_sync
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
     turndownPolicy: Immediate
     partitionings:
     - equal:
@@ -50,8 +60,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica
@@ -75,6 +83,15 @@ spec:
                   storage: 10Gi
   - name: customer
     durabilityPolicy: semi_sync
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
     turndownPolicy: Immediate
     partitionings:
     - equal:
@@ -83,8 +100,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -11,6 +11,7 @@ spec:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
     vttablet: vitess/lite:latest
+    vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
       mysql56Compatible: vitess/lite:latest
@@ -47,6 +48,15 @@ spec:
   - name: commerce
     durabilityPolicy: semi_sync
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
     partitionings:
     - equal:
         parts: 1
@@ -54,8 +64,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: zone1
             type: replica

--- a/test/endtoend/operator/operator.yaml
+++ b/test/endtoend/operator/operator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -286,6 +287,7 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -345,6 +347,7 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -471,6 +474,8 @@ spec:
                           type: string
                         endpoint:
                           type: string
+                        forcePathStyle:
+                          type: boolean
                         keyPrefix:
                           maxLength: 256
                           pattern: ^[^\r\n]*$
@@ -515,6 +520,7 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -770,6 +776,8 @@ spec:
                       type: string
                     mysqldExporter:
                       type: string
+                    vtadmin:
+                      type: string
                     vtbackup:
                       type: string
                     vtctld:
@@ -795,6 +803,8 @@ spec:
                   type: object
                 lockserver:
                   properties:
+                    cellInfoAddress:
+                      type: string
                     etcd:
                       properties:
                         advertisePeerURLs:
@@ -1120,6 +1130,7 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1254,6 +1265,8 @@ spec:
                                 type: string
                               endpoint:
                                 type: string
+                              forcePathStyle:
+                                type: boolean
                               keyPrefix:
                                 maxLength: 256
                                 pattern: ^[^\r\n]*$
@@ -1482,6 +1495,8 @@ spec:
                         type: object
                       lockserver:
                         properties:
+                          cellInfoAddress:
+                            type: string
                           etcd:
                             properties:
                               advertisePeerURLs:
@@ -1759,6 +1774,8 @@ spec:
                   type: object
                 globalLockserver:
                   properties:
+                    cellInfoAddress:
+                      type: string
                     etcd:
                       properties:
                         advertisePeerURLs:
@@ -2016,6 +2033,8 @@ spec:
                       type: string
                     mysqldExporter:
                       type: string
+                    vtadmin:
+                      type: string
                     vtbackup:
                       type: string
                     vtctld:
@@ -2049,6 +2068,8 @@ spec:
                       type: object
                     mysqldExporter:
                       type: string
+                    vtadmin:
+                      type: string
                     vtbackup:
                       type: string
                     vtctld:
@@ -2068,6 +2089,8 @@ spec:
                           type: string
                         type: object
                       databaseName:
+                        type: string
+                      durabilityPolicy:
                         type: string
                       name:
                         maxLength: 63
@@ -2427,6 +2450,7 @@ spec:
                               properties:
                                 parts:
                                   format: int32
+                                  maximum: 65536
                                   minimum: 1
                                   type: integer
                                 shardTemplate:
@@ -2778,17 +2802,6 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
-                          configSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
                           extraEnv:
                             items:
                               properties:
@@ -2913,8 +2926,6 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                           tolerations:
                             x-kubernetes-preserve-unknown-fields: true
-                        required:
-                          - configSecret
                         type: object
                     required:
                       - name
@@ -3104,6 +3115,184 @@ spec:
                     tolerations:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                vtadmin:
+                  properties:
+                    affinity:
+                      x-kubernetes-preserve-unknown-fields: true
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    apiAddresses:
+                      items:
+                        type: string
+                      type: array
+                    apiResources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    cells:
+                      items:
+                        type: string
+                      type: array
+                    extraEnv:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    extraFlags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraVolumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    extraVolumes:
+                      x-kubernetes-preserve-unknown-fields: true
+                    initContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    rbac:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                        volumeName:
+                          type: string
+                      required:
+                        - key
+                      type: object
+                    readOnly:
+                      type: boolean
+                    replicas:
+                      format: int32
+                      type: integer
+                    service:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clusterIP:
+                          type: string
+                      type: object
+                    sidecarContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    tolerations:
+                      x-kubernetes-preserve-unknown-fields: true
+                    webResources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                  required:
+                    - apiAddresses
+                  type: object
               required:
                 - cells
               type: object
@@ -3202,6 +3391,13 @@ spec:
                     serviceName:
                       type: string
                   type: object
+                vtadmin:
+                  properties:
+                    available:
+                      type: string
+                    serviceName:
+                      type: string
+                  type: object
               type: object
           type: object
       served: true
@@ -3214,6 +3410,7 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3347,6 +3544,8 @@ spec:
                             type: string
                           endpoint:
                             type: string
+                          forcePathStyle:
+                            type: boolean
                           keyPrefix:
                             maxLength: 256
                             pattern: ^[^\r\n]*$
@@ -3365,6 +3564,8 @@ spec:
                     type: object
                   type: array
                 databaseName:
+                  type: string
+                durabilityPolicy:
                   type: string
                 extraVitessFlags:
                   additionalProperties:
@@ -3388,6 +3589,8 @@ spec:
                     mysqld:
                       type: string
                     mysqldExporter:
+                      type: string
+                    vtadmin:
                       type: string
                     vtbackup:
                       type: string
@@ -3787,6 +3990,7 @@ spec:
                         properties:
                           parts:
                             format: int32
+                            maximum: 65536
                             minimum: 1
                             type: integer
                           shardTemplate:
@@ -4172,17 +4376,6 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
-                    configSecret:
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                        volumeName:
-                          type: string
-                      required:
-                        - key
-                      type: object
                     extraEnv:
                       items:
                         properties:
@@ -4307,8 +4500,6 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     tolerations:
                       x-kubernetes-preserve-unknown-fields: true
-                  required:
-                    - configSecret
                   type: object
                 zoneMap:
                   additionalProperties:
@@ -4450,6 +4641,7 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4583,6 +4775,8 @@ spec:
                             type: string
                           endpoint:
                             type: string
+                          forcePathStyle:
+                            type: boolean
                           keyPrefix:
                             maxLength: 256
                             pattern: ^[^\r\n]*$
@@ -4635,6 +4829,8 @@ spec:
                     mysqld:
                       type: string
                     mysqldExporter:
+                      type: string
+                    vtadmin:
                       type: string
                     vtbackup:
                       type: string
@@ -5038,17 +5234,6 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
-                    configSecret:
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                        volumeName:
-                          type: string
-                      required:
-                        - key
-                      type: object
                     extraEnv:
                       items:
                         properties:
@@ -5173,8 +5358,6 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     tolerations:
                       x-kubernetes-preserve-unknown-fields: true
-                  required:
-                    - configSecret
                   type: object
                 zoneMap:
                   additionalProperties:
@@ -5432,7 +5615,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: planetscale/vitess-operator:v2.7.1
+          image: planetscale/vitess-operator:v2.8.0-rc1
           name: vitess-operator
           resources:
             limits:

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -236,7 +236,7 @@ checkSemiSyncSetup
 # Initially no durability policy is specified
 verifyDurabilityPolicy "commerce" ""
 upgradeToLatest
-verifyVtGateVersion "15.0.0"
+verifyVtGateVersion "16.0.0"
 checkSemiSyncSetup
 # After upgrading, we set the durability policy to semi_sync
 verifyDurabilityPolicy "commerce" "semi_sync"

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -231,7 +231,7 @@ killall kubectl
 setupKubectlAccessForCI
 
 get_started "operator.yaml" "101_initial_cluster.yaml"
-verifyVtGateVersion "14.0.0"
+verifyVtGateVersion "15.0.0"
 checkSemiSyncSetup
 # Initially no durability policy is specified
 verifyDurabilityPolicy "commerce" ""

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -7,6 +7,7 @@ function move_tables() {
   echo "Apply 201_customer_tablets.yaml"
   kubectl apply -f 201_customer_tablets.yaml > /dev/null
   checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 6
+  checkPodStatusWithTimeout "example-customer-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
   killall kubectl
   ./pf.sh > /dev/null 2>&1 &
@@ -80,6 +81,8 @@ function resharding() {
   echo "Apply 302_new_shards.yaml"
   kubectl apply -f 302_new_shards.yaml
   checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 12
+  checkPodStatusWithTimeout "example-customer-80-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
+  checkPodStatusWithTimeout "example-customer-x-80-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
   killall kubectl
   ./pf.sh > /dev/null 2>&1 &
@@ -180,6 +183,7 @@ function upgradeToLatest() {
   checkPodStatusWithTimeout "example-zone1-vtgate(.*)1/1(.*)Running(.*)"
   checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
   checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
+  checkPodStatusWithTimeout "example-commerce-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
   killall kubectl
   ./pf.sh > /dev/null 2>&1 &
@@ -233,12 +237,12 @@ setupKubectlAccessForCI
 get_started "operator.yaml" "101_initial_cluster.yaml"
 verifyVtGateVersion "15.0.0"
 checkSemiSyncSetup
-# Initially no durability policy is specified
-verifyDurabilityPolicy "commerce" ""
+# Initially too durability policy should be specified
+verifyDurabilityPolicy "commerce" "semi_sync"
 upgradeToLatest
 verifyVtGateVersion "16.0.0"
 checkSemiSyncSetup
-# After upgrading, we set the durability policy to semi_sync
+# After upgrading, we verify that the durability policy is still semi_sync
 verifyDurabilityPolicy "commerce" "semi_sync"
 move_tables
 resharding

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -215,6 +215,7 @@ function get_started() {
     checkPodStatusWithTimeout "example-zone1-vtgate(.*)1/1(.*)Running(.*)"
     checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
+    checkPodStatusWithTimeout "example-commerce-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
     sleep 10
     echo "Creating vschema and commerce SQL schema"

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -123,7 +123,7 @@ function verifyVtGateVersion() {
   data=$(mysql -e "select @@version")
   echo "$data" | grep "$version" > /dev/null 2>&1
   if [ $? -ne 0 ]; then
-    echo -e "The data in $shard's tables is incorrect, got:\n$data"
+    echo -e "The vtgate version is incorrect, expected: $version, got:\n$data"
     exit 1
   fi
 }

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -214,7 +214,7 @@ killall kubectl
 setupKubectlAccessForCI
 
 get_started_vtorc_vtadmin
-verifyVtGateVersion "15.0.0"
+verifyVtGateVersion "16.0.0"
 checkSemiSyncSetup
 
 # Check Vtadmin is setup


### PR DESCRIPTION
### Description

Since we changed the base version of the `main` branch in Vitess, the `latest` docker image is of version 16 and not of 15 anymore. This PR changes the test expectations to that end.