### PR TITLE
Update k8s compatibility table and increase memory limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Vitess Operator Version | Recommended Vitess Versions | Recommended Kubernetes V
 `v2.5.*` | `v12.0.*`                   | `v1.17.*`, `v1.18.*`, or `v1.19.*`
 `v2.6.*` | `v12.0.*`, or `v13.0.*`     | `v1.20.*`, `v1.21.*`, or `v1.22.*`
 `v2.7.*` | `v14.0.*`                   | `v1.20.*`, `v1.21.*`, or `v1.22.*`
-`latest` | `latest`                    | `v1.20.*`, `v1.21.*`, or `v1.22.*`
+`v2.8.*` | `v15.0.*`                   | `v1.22.*`, `v1.23.*`, or `v1.24.*`
+`latest` | `latest`                    | `v1.22.*`, `v1.23.*`, or `v1.24.*`
 
 If for some reason you must attempt to use versions outside the recommend
 window, we still welcome bug reports since a workaround might be possible.

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -5620,7 +5620,7 @@ spec:
           name: vitess-operator
           resources:
             limits:
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 100m
               memory: 128Mi

--- a/test/endtoend/operator/operator.yaml
+++ b/test/endtoend/operator/operator.yaml
@@ -5619,7 +5619,7 @@ spec:
           name: vitess-operator
           resources:
             limits:
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
This PR updates the compatibility tables after having run some tests on kubernetes `v1.22`, `v1.23`, `v1.24` and `v1.25`.

Additionally, while doing my tests, i realized that vitess-operator would run out of memory:
```
vitess-operator-66967b4bc4-r8pk8                             0/1     OOMKilled   3 (37s ago)     5m24s
```

This was fixed in `vitessio/vitess` in this PR: https://github.com/vitessio/vitess/pull/11548, this PR simply cherry-pick the change over to this repo.