### PR TITLE
Bug: Fix vtadmin resources

### DIFF
--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -107,6 +107,27 @@ function checkPodStatusWithTimeout() {
   exit 1
 }
 
+# ensurePodResourcesSet:
+# $1: regex used to match pod names
+function ensurePodResourcesSet() {
+  regex=$1
+
+  baseCmd='kubectl get pods -o custom-columns="NAME:metadata.name,CONTAINERS:spec.containers[*].name,RESOURCE:spec.containers[*].resources'
+
+  # We don't check for .limits.cpu because it is usually unset
+  for resource in '.limits.memory"' '.requests.cpu"' '.requests.memory"' ; do
+    cmd=${baseCmd}${resource}
+    out=$(eval "$cmd")
+
+    numContainers=$(echo "$out" | grep -E "$regex" | awk '{print $2}' | awk -F ',' '{print NF}')
+    numContainersWithResources=$(echo "$out" | grep -E "$regex" | awk '{print $3}' | awk -F ',' '{print NF}')
+    if [ $numContainers != $numContainersWithResources ]; then
+      echo "one or more containers in pods with $regex do not have $resource set"
+      exit 1
+    fi
+  done
+}
+
 function insertWithRetry() {
   for i in {1..600} ; do
     mysql --table < ../common/delete_commerce_data.sql && mysql --table < ../common/insert_commerce_data.sql

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -18,6 +18,8 @@ function get_started_vtorc_vtadmin() {
     checkPodStatusWithTimeout "example-zone1-vtadmin(.*)2/2(.*)Running(.*)"
     checkPodStatusWithTimeout "example-commerce-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
+    ensurePodResourcesSet "example-zone1-vtadmin"
+
     sleep 10
     echo "Creating vschema and commerce SQL schema"
 


### PR DESCRIPTION
Currently, the resources requests/limits for the vtadmin component is not reflected in the spec for vtadmin

This is because the resource spec is copied to a local variable and discarded instead of the actual container spec

Signed-off-by: Teh Nian Fei <tehnianfei@gmail.com>