### PR TITLE
Operator changes to remove `enable_semi_sync` 

### DIFF
--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -1023,8 +1023,6 @@ spec:
                                       type: object
                                     replication:
                                       properties:
-                                        enforceSemiSync:
-                                          type: boolean
                                         initializeBackup:
                                           type: boolean
                                         initializeMaster:
@@ -1376,8 +1374,6 @@ spec:
                                     type: object
                                   replication:
                                     properties:
-                                      enforceSemiSync:
-                                        type: boolean
                                       initializeBackup:
                                         type: boolean
                                       initializeMaster:

--- a/deploy/crds/planetscale.com_vitesskeyspaces.yaml
+++ b/deploy/crds/planetscale.com_vitesskeyspaces.yaml
@@ -259,8 +259,6 @@ spec:
                                 type: object
                               replication:
                                 properties:
-                                  enforceSemiSync:
-                                    type: boolean
                                   initializeBackup:
                                     type: boolean
                                   initializeMaster:
@@ -612,8 +610,6 @@ spec:
                               type: object
                             replication:
                               properties:
-                                enforceSemiSync:
-                                  type: boolean
                                 initializeBackup:
                                   type: boolean
                                 initializeMaster:

--- a/deploy/crds/planetscale.com_vitessshards.yaml
+++ b/deploy/crds/planetscale.com_vitessshards.yaml
@@ -242,8 +242,6 @@ spec:
                 type: string
               replication:
                 properties:
-                  enforceSemiSync:
-                    type: boolean
                   initializeBackup:
                     type: boolean
                   initializeMaster:

--- a/deploy/example.yaml
+++ b/deploy/example.yaml
@@ -36,8 +36,6 @@ spec:
           databaseInitScriptSecret:
             name: example-cluster-config
             key: init_db.sql
-          replication:
-            enforceSemiSync: true
           tabletPools:
           - cell: gcpuswest1b
             type: replica

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -5800,7 +5800,7 @@ VitessOrchestratorSpec
 <td>
 <p>VitessOrchestrator deploys a set of Vitess Orchestrator (vtorc) servers for the Keyspace.
 It is highly recommended that you set disable_active_reparents=true
-and enable_semi_sync=false for the vtablets if enabling vtorc.</p>
+for the vttablets if enabling vtorc.</p>
 </td>
 </tr>
 <tr>
@@ -6196,29 +6196,6 @@ string
 </tr>
 </thead>
 <tbody>
-<tr>
-<td>
-<code>enforceSemiSync</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>EnforceSemiSync means Vitess will configure MySQL to require semi-sync
-acknowledgement of all transactions while forbidding fallback to
-asynchronous replication under any circumstance.</p>
-<p>Note that this is different from merely <em>enabling</em> semi-sync, which in
-its default configuration allows fallback to asynchronous replication
-if no replicas are connected or if they don&rsquo;t respond after a few seconds.
-Enforced semi-sync is a mode that prefers master unavailability when
-durability cannot be ensured, rather than risking the loss of data that
-was already reported to clients as committed.</p>
-<p>WARNING: Do not enable this if the shard has fewer than 3 master-eligible
-replicas, as that may lead to master unavailability during routine
-maintenance.</p>
-<p>Default: Semi-sync is not enforced.</p>
-</td>
-</tr>
 <tr>
 <td>
 <code>initializeMaster</code></br>

--- a/docs/release-notes/2_9_0_summary.md
+++ b/docs/release-notes/2_9_0_summary.md
@@ -1,0 +1,7 @@
+## Major Changes
+
+### EnforceSemiSync Removal
+
+The config `enforceSemiSync` is removed from the `VitessReplicationSpec`. This configuration is no longer requied.
+If the users want to configure semi-sync replication, they should set the `durabilityPolicy` config to `semi_sync` in the keyspace specification.
+This change of not using `enforceSemiSync` should be done before upgrading to `2.9.0` version of the operator otherwise the configuration would not be accepted.

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -119,7 +119,7 @@ type VitessKeyspaceTemplate struct {
 
 	// VitessOrchestrator deploys a set of Vitess Orchestrator (vtorc) servers for the Keyspace.
 	// It is highly recommended that you set disable_active_reparents=true
-	// and enable_semi_sync=false for the vtablets if enabling vtorc.
+	// for the vttablets if enabling vtorc.
 	VitessOrchestrator *VitessOrchestratorSpec `json:"vitessOrchestrator,omitempty"`
 
 	// Partitionings specify how to divide the keyspace up into shards by

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -129,24 +129,6 @@ type VitessShardTemplate struct {
 
 // VitessReplicationSpec specifies how Vitess will set up MySQL replication.
 type VitessReplicationSpec struct {
-	// EnforceSemiSync means Vitess will configure MySQL to require semi-sync
-	// acknowledgement of all transactions while forbidding fallback to
-	// asynchronous replication under any circumstance.
-	//
-	// Note that this is different from merely *enabling* semi-sync, which in
-	// its default configuration allows fallback to asynchronous replication
-	// if no replicas are connected or if they don't respond after a few seconds.
-	// Enforced semi-sync is a mode that prefers master unavailability when
-	// durability cannot be ensured, rather than risking the loss of data that
-	// was already reported to clients as committed.
-	//
-	// WARNING: Do not enable this if the shard has fewer than 3 master-eligible
-	// replicas, as that may lead to master unavailability during routine
-	// maintenance.
-	//
-	// Default: Semi-sync is not enforced.
-	EnforceSemiSync bool `json:"enforceSemiSync,omitempty"`
-
 	// InitializeMaster specifies whether to choose an initial master for a
 	// new or restored shard that has no master yet.
 	//

--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -329,7 +329,6 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 				KeyspaceName:              keyspaceName,
 				DatabaseName:              vts.Spec.DatabaseName,
 				DatabaseInitScriptSecret:  vts.Spec.DatabaseInitScriptSecret,
-				EnableSemiSync:            vts.Spec.Replication.EnforceSemiSync,
 				Annotations:               annotations,
 				BackupLocation:            backupLocation,
 				BackupEngine:              vts.Spec.BackupEngine,

--- a/pkg/operator/vttablet/datastore.go
+++ b/pkg/operator/vttablet/datastore.go
@@ -18,6 +18,7 @@ package vttablet
 
 import (
 	corev1 "k8s.io/api/core/v1"
+
 	"planetscale.dev/vitess-operator/pkg/operator/lazy"
 	"planetscale.dev/vitess-operator/pkg/operator/secrets"
 	"planetscale.dev/vitess-operator/pkg/operator/vitess"
@@ -90,7 +91,6 @@ func localDatastoreFlags(spec *Spec) vitess.Flags {
 		// TODO: Should this be configurable?
 		"enable_replication_reporter": true,
 
-		"enable_semi_sync":  spec.EnableSemiSync,
 		"mysqlctl_socket":   mysqlctlSocketPath,
 		"mycnf_socket_file": mysqlSocketPath,
 	}

--- a/pkg/operator/vttablet/spec.go
+++ b/pkg/operator/vttablet/spec.go
@@ -47,7 +47,6 @@ type Spec struct {
 	DataVolumePVCName         string
 	GlobalLockserver          planetscalev2.VitessLockserverParams
 	DatabaseInitScriptSecret  planetscalev2.SecretSource
-	EnableSemiSync            bool
 	Annotations               map[string]string
 	ExtraLabels               map[string]string
 	BackupLocation            *planetscalev2.VitessBackupLocation

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -2179,8 +2179,6 @@ spec:
                                         type: object
                                       replication:
                                         properties:
-                                          enforceSemiSync:
-                                            type: boolean
                                           initializeBackup:
                                             type: boolean
                                           initializeMaster:
@@ -2532,8 +2530,6 @@ spec:
                                       type: object
                                     replication:
                                       properties:
-                                        enforceSemiSync:
-                                          type: boolean
                                         initializeBackup:
                                           type: boolean
                                         initializeMaster:
@@ -3743,8 +3739,6 @@ spec:
                                   type: object
                                 replication:
                                   properties:
-                                    enforceSemiSync:
-                                      type: boolean
                                     initializeBackup:
                                       type: boolean
                                     initializeMaster:
@@ -4096,8 +4090,6 @@ spec:
                                 type: object
                               replication:
                                 properties:
-                                  enforceSemiSync:
-                                    type: boolean
                                   initializeBackup:
                                     type: boolean
                                   initializeMaster:
@@ -4981,8 +4973,6 @@ spec:
                   type: string
                 replication:
                   properties:
-                    enforceSemiSync:
-                      type: boolean
                     initializeBackup:
                       type: boolean
                     initializeMaster:


### PR DESCRIPTION
### Description. 

The PR https://github.com/vitessio/vitess/pull/12083 on Vitess removed the `enable_semi_sync` flag. Correspondingly, this PR removes the `enforceSemiSync` configuration since it is no longer required. The upgrade process and the requirements for backward compatibility are listed in the newly introduced summary for the release-notes, just like the main Vitess repo.
 