### PR TITLE
deploy, pkg: mount mycnf and vtbackup/vttablet initialization script from configmaps

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -1,0 +1,203 @@
+# These configmaps must be deployed to each namespace where a VitessCluster
+# will be deployed.
+
+apiVersion: apps/v1
+kind: ConfigMap
+metadata:
+  name: vitess-mysqld-extra-mycnf
+data:
+  log-error.cnf:
+    # We want to configure mysqld to log to stderr, so that we can take advantage
+    # of container log rotation.
+    #
+    # Ideally we would just add log-error=/dev/stderr to a cnf file, but there's a
+    # mysql behavior that neccesitates the work-around below.
+    #
+    # See: https://bugs.mysql.com/bug.php?id=57690
+    log-error = /vt/config/stderr.symlink
+  rbr.cnf:
+    binlog_format = row
+  socket.cnf:
+    # Keep in sync with: https://github.com/planetscale/vitess-operator/blob/main/pkg/operator/vttablet/constants.go
+    socket = /vt/socket/mysql.sock
+  vt.cnf:
+    # This file contains cnf settings specific to vtbackup and vttablet.
+    # Currently it is an empty placeholder for future settings.
+  vtbackup.cnf:
+    # This file contains cnf settings specific to vtbackup.
+    sync_binlog = 0
+    innodb_flush_log_at_trx_commit = 0
+  vttablet.cnf:
+    # This file contains cnf settings specific to vttablet.
+    # Currently it is an empty a placeholder for future settings.
+---
+apiVersion: apps/v1
+kind: ConfigMap
+metadata:
+  name: vitess-mysqld-init
+data:
+  init.sh:
+    #!/bin/sh
+
+    ###############################################################################
+    ### The purpose of this script is to prepare a mysqld container, possibly   ###
+    ### from a stock mysql image, with Vitess' binaries, cnf files, and other   ###
+    ### useful things.                                                          ###
+    ###                                                                         ###
+    ### This script is meant to run inside an initContainer running a Vitess    ###
+    ### image, with a mounted EmptyDir volume. The script will copy binaries    ###
+    ### and configs into the EmptyDir volume. Other containers in the same pod  ###
+    ### can then mount the same (no longer empty) volume.                       ###
+    ###############################################################################
+
+    set -e
+
+    COPY_CERTS="${COPY_CERTS:-0}"
+    COPY_MYSQLD="${COPY_MYSQLD:-1}"
+    COPY_VTBACKUP="${COPY_VTBACKUP:-0}"
+
+    # Optional path to extra cnfs volume.
+    EXTRA_MYCNF_VOLUME_PATH="${EXTRA_MYCNF_VOLUME_PATH:-}"
+
+    # The EmptyDir volume is mounted at /mnt$VT_ROOT_PATH.
+    #
+    # The other paths are directories and files under that dir,
+    # mirroring the structure of /vt/**.
+    MNT_BIN_PATH="${MNT_BIN_PATH:-}"
+    MNT_CERTS_PATH="${MNT_CERTS_PATH:-}"
+    MNT_CONFIG_PATH="${MNT_CONFIG_PATH:-}"
+    MNT_DATA_ROOT_PATH="${MNT_DATA_ROOT_PATH:-}"
+    MNT_MYCNF_PATH="${MNT_MYCNF_PATH:-}"
+    MNT_ROOT_PATH="${MNT_ROOT_PATH:-}"
+    MNT_STDERR_SYMLINK_PATH="${MNT_STDERR_SYMLINK_PATH:-}"
+
+    # These correspond to constants in:
+    # https://github.com/planetscale/psdb-operator/blob/main/pkg/operator/vttablet/constants.go
+    MYSQLD_COMMAND="${MYSQLD_COMMAND:-}"
+    VT_BIN_PATH="${VT_BIN_PATH:-}"
+    VT_CONFIG_PATH="${VT_CONFIG_PATH:-}"
+    VT_MYCNF_PATH="${VT_MYCNF_PATH:-}"
+    VTBACKUP_COMMAND="${VTBACKUP_COMMAND:-}"
+
+    # Validate that required environment variables are set.
+    echo "Validating environment variables..."
+    if [ -z "${MNT_BIN_PATH}" ]; then
+      >&2 echo 'Expected MNT_BIN_PATH to be set.'
+      exit 1
+    fi
+    if [ -z "${MNT_CONFIG_PATH}" ]; then
+      >&2 echo 'Expected MNT_CONFIG_PATH to be set.'
+      exit 1
+    fi
+    if [ -z "${MNT_DATA_ROOT_PATH}" ]; then
+      >&2 echo 'Expected MNT_DATA_ROOT_PATH to be set.'
+      exit 1
+    fi
+    if [ -z "${MNT_MYCNF_PATH}" ]; then
+      >&2 echo 'Expected MNT_MYCNF_PATH to be set.'
+      exit 1
+    fi
+    if [ -z "${MNT_ROOT_PATH}" ]; then
+      >&2 echo 'Expected MNT_ROOT_PATH to be set.'
+      exit 1
+    fi
+    if [ -z "${MNT_STDERR_SYMLINK_PATH}" ]; then
+      >&2 echo 'Expected MNT_STDERR_SYMLINK_PATH to be set.'
+      exit 1
+    fi
+    if [ "${COPY_MYSQLD}" = "1" ] && [ -z "${MYSQLD_COMMAND}" ]; then
+      >&2 echo 'Expected MYSQLD_COMMAND to be set.'
+      exit 1
+    fi
+    if [ -z "${VT_BIN_PATH}" ]; then
+      >&2 echo 'Expected VT_BIN_PATH to be set.'
+      exit 1
+    fi
+    if [ -z "${VT_CONFIG_PATH}" ]; then
+      >&2 echo 'Expected VT_CONFIG_PATH to be set.'
+      exit 1
+    fi
+    if [ -z "${VT_MYCNF_PATH}" ]; then
+      >&2 echo 'Expected VT_MYCNF_PATH to be set.'
+      exit 1
+    fi
+    if [ "${COPY_VTBACKUP}" = "1" ] && [ -z "${VTBACKUP_COMMAND}" ]; then
+      >&2 echo 'Expected VTBACKUP_COMMAND to be set.'
+      exit 1
+    fi
+    echo "Environment variables look OK."
+
+    # Assert that the volume root exists.
+    if [ ! -d "${MNT_ROOT_PATH}" ]; then
+      >&2 echo "Expected mounted volume at: '${MNT_ROOT_PATH}'."
+      exit 1
+    fi
+
+    # Create sub-dirs if they don't yet exist.
+    echo "Creating directories..."
+    mkdir -p "${MNT_BIN_PATH}"
+    mkdir -p "${MNT_CONFIG_PATH}"
+    mkdir -p "${MNT_DATA_ROOT_PATH}"
+    mkdir -p "${MNT_MYCNF_PATH}"
+    echo "Created directories."
+
+    # Copy mysqlctld from vitess container to volume.
+    if [ "${COPY_MYSQLD}" = "1" ]; then
+      echo "Copying mysqld executable from ${MYSQLD_COMMAND} to ${MNT_BIN_PATH}..."
+      if [ -f "${MYSQLD_COMMAND}" ]; then
+        cp --no-clobber "${MYSQLD_COMMAND}" "${MNT_BIN_PATH}"
+      else
+        >&2 echo "mysqld executable does not exist or could not be accessed: ${MYSQLD_COMMAND}."
+        exit 1
+      fi
+      echo "Copied mysqld executable."
+    fi
+
+    # Copy vtbackup from vitess container to volume.
+    if [ "${COPY_VTBACKUP}" = "1" ]; then
+      echo "Copying vtbackup executable from ${VTBACKUP_COMMAND} to ${MNT_BIN_PATH}..."
+      if [ -f "${VTBACKUP_COMMAND}" ]; then
+        cp --no-clobber "${VTBACKUP_COMMAND}" "${MNT_BIN_PATH}"
+      else
+        >&2 echo "vtbackup executable does not exist or could not be accessed: ${VTBACKUP_COMMAND}."
+        exit 1
+      fi
+      echo "Copied vtbackup executable."
+    fi
+
+    # Copy cnf files from vitess container to volume.
+    if [ -d "${VT_MYCNF_PATH}" ]; then
+      echo "Copying Vitess mycnf files from ${VT_MYCNF_PATH} to ${MNT_MYCNF_PATH}..."
+      cp --no-clobber -R "${VT_MYCNF_PATH}/." "${MNT_MYCNF_PATH}"
+      echo "Copied Vitess mycnf files."
+    fi
+
+    # Copy any extra cnf files to volume.
+    if [ -n "${EXTRA_MYCNF_VOLUME_PATH}" ]; then
+      echo "Copying extra mycnf files from ${EXTRA_MYCNF_VOLUME_PATH} to ${MNT_MYCNF_PATH}..."
+      if [ -d "${EXTRA_MYCNF_VOLUME_PATH}" ]; then
+        cp --no-clobber -R "${EXTRA_MYCNF_VOLUME_PATH}/." "${MNT_MYCNF_PATH}"
+      else
+        >&2 echo "Extra mycnf volume does not exist or could not be accessed: ${EXTRA_MYCNF_VOLUME_PATH}."
+        exit 1
+      fi
+      echo "Copied extra mycnf files."
+    fi
+
+    # This one is a little weird. We want to configure mysqld to log to stderr,
+    # so that we can take advantage of container log rotation.
+    #
+    # Ideally we would just add log-error=/dev/stderr to a cnf file, but there's a
+    # mysql behavior that neccesitates the work-around below.
+    #
+    # See: https://bugs.mysql.com/bug.php?id=57690
+    echo "Creating symbolic link from /dev/stderr to ${MNT_STDERR_SYMLINK_PATH}..."
+    ln -sf /dev/stderr "${MNT_STDERR_SYMLINK_PATH}"
+    echo "Created symbolic link."
+
+    if [ "${COPY_CERTS}" = "1" ]; then
+      echo "Copying host certificate to ${MNT_CERTS_PATH}..."
+      mkdir -p "${MNT_CERTS_PATH}"
+      cp --no-clobber /etc/ssl/certs/ca-certificates.crt "${MNT_CERTS_PATH}"
+      echo "Copied host certificate."
+    fi

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- configmap.yaml
 - operator.yaml
 - role_binding.yaml
 - role.yaml

--- a/pkg/operator/update/podspec.go
+++ b/pkg/operator/update/podspec.go
@@ -181,8 +181,11 @@ func PodTemplateContainer(dst, src *corev1.Container) {
 // admission webhooks, other controllers, or the API server.
 func SecurityContext(dst **corev1.SecurityContext, src *corev1.SecurityContext) {
 	if *dst == nil || src == nil {
+		// If dst is nil, just use src.
+		if dst == nil {
+			*dst = src
+		}
 		// Only one side is set, so we don't need to merge anything.
-		*dst = src
 		return
 	}
 

--- a/pkg/operator/vttablet/config_maps.go
+++ b/pkg/operator/vttablet/config_maps.go
@@ -1,0 +1,94 @@
+package vttablet
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+type mysqldInitOpts struct {
+	copyCerts    bool
+	copyMysqld   bool
+	copyVtbackup bool
+}
+
+// extraMycnfConfigMapVolume generates a volume that contains a bunch of
+// different MySQL cnf files.
+func extraMycnfConfigMapVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: extraMycnfVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: extraMycnfConfigMapName,
+				},
+			},
+		},
+	}
+}
+
+// mysqldInitConfigMapVolume generates a Volume containing
+// a script that is meant to be run inside an initContainer.
+//
+// The script prepares and EmptyDir volume with binaries and
+// configs so that the volume can be mounted and used inside
+// of a mysqld, vtbackup, or vttablet container.
+func mysqldInitConfigMapVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: mysqldInitVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: mysqldInitConfigMapName,
+				},
+				Items: []corev1.KeyToPath{
+					{
+						Key:  mysqldInitKey,
+						Path: mysqldInitKey,
+						Mode: pointer.Int32(0o777),
+					},
+				},
+			},
+		},
+	}
+}
+
+// mysqldInitEnv generates environment variables that, when
+// passed to the mysqld-init script, controls the actions of
+// that script.
+func mysqldInitEnv(opts mysqldInitOpts) []corev1.EnvVar {
+	env := []corev1.EnvVar{
+		{Name: "EXTRA_MYCNF_VOLUME_PATH", Value: mntExtraMycnfVolumePath},
+		{Name: "MNT_BIN_PATH", Value: mntBinPath},
+		{Name: "MNT_CERTS_PATH", Value: mntCertsPath},
+		{Name: "MNT_CONFIG_PATH", Value: mntConfigPath},
+		{Name: "MNT_DATA_ROOT_PATH", Value: mntDataRootPath},
+		{Name: "MNT_MYCNF_PATH", Value: mntMycnfPath},
+		{Name: "MNT_ROOT_PATH", Value: mntRootVolumePath},
+		{Name: "MNT_STDERR_SYMLINK_PATH", Value: mntStderrSymlinkPath},
+		{Name: "MYSQLD_COMMAND", Value: mysqldCommand},
+		{Name: "VT_BIN_PATH", Value: vtBinPath},
+		{Name: "VT_CONFIG_PATH", Value: vtConfigPath},
+		{Name: "VT_MYCNF_PATH", Value: vtMycnfPath},
+		{Name: "VTBACKUP_COMMAND", Value: vtbackupCommand},
+	}
+
+	if opts.copyCerts {
+		env = append(env, corev1.EnvVar{Name: "COPY_CERTS", Value: "1"})
+	} else {
+		env = append(env, corev1.EnvVar{Name: "COPY_CERTS", Value: "0"})
+	}
+
+	if opts.copyMysqld {
+		env = append(env, corev1.EnvVar{Name: "COPY_MYSQLD", Value: "1"})
+	} else {
+		env = append(env, corev1.EnvVar{Name: "COPY_MYSQLD", Value: "0"})
+	}
+
+	if opts.copyVtbackup {
+		env = append(env, corev1.EnvVar{Name: "COPY_VTBACKUP", Value: "1"})
+	} else {
+		env = append(env, corev1.EnvVar{Name: "COPY_VTBACKUP", Value: "0"})
+	}
+
+	return env
+}

--- a/pkg/operator/vttablet/constants.go
+++ b/pkg/operator/vttablet/constants.go
@@ -21,6 +21,8 @@ import (
 )
 
 const (
+	initContainerName = "init-vt-root"
+
 	vttabletContainerName = "vttablet"
 	vttabletCommand       = "/vt/bin/vttablet"
 
@@ -116,11 +118,58 @@ const (
 	// high because it can take a while to do crash recovery and it's rarely
 	// productive to restart automatically.
 	mysqlctlWaitTime = 2 * time.Hour
+
+	extraMycnfEnvVarName = "EXTRA_MY_CNF"
+
+	// Names for the mysqld-extra-mycnf Volume and ConfigMap
+	extraMycnfConfigMapName = "vitess-mysqld-extra-mycnf"
+	extraMycnfVolumeName    = "mysqld-extra-mycnf"
+
+	// Content keys for the mysqld-extra-mycnf ConfigMap.
+	extraCnfLogErrorKey = "log-error.cnf"
+	extraCnfRbrKey      = "rbr.cnf"
+	extraCnfSocketKey   = "socket.cnf"
+
+	// Other cnf keys found in the mysqld-extra-cnf ConfigMap.
+	extraCnfVtKey       = "vt.cnf"
+	extraCnfVtbackupKey = "vtbackup.cnf"
+	extraCnfVttabletKey = "vttablet.cnf"
+
+	// Absolute paths to mycnf files inside of mysqld containers.
+	logErrorCnfPath = vtMycnfPath + "/" + extraCnfLogErrorKey
+	rbrCnfPath      = vtMycnfPath + "/" + extraCnfRbrKey
+	socketCnfPath   = vtMycnfPath + "/" + extraCnfSocketKey
+	vtCnfPath       = vtMycnfPath + "/" + extraCnfVtKey
+	vtbackupCnfPath = vtMycnfPath + "/" + extraCnfVtbackupKey
+	vttabletCnfPath = vtMycnfPath + "/" + extraCnfVttabletKey
+
+	// Names and content keys for the mysqld-init Volume and ConfigMap.
+	mysqldInitKey           = "init.sh"
+	mysqldInitConfigMapName = "vitess-mysqld-init"
+	mysqldInitVolumeName    = "mysqld-init"
+
+	// An EmptyDir volume is mounted inside the init-vt-root initContainer.
+	mntRootVolumePath = "/mnt" + vtRootPath
+
+	// The mysqld-extra-mycnf, and mysqld-init volumes are also
+	// mounted inside the init-vt-root initContainer.
+	mntExtraMycnfVolumePath = "/mnt/extra-mycnf"
+	mntMysqldInitVolumePath = "/mnt/mysqld-init"
+
+	// Path to mysqld-init/init.sh script inside of the init-vt-root
+	// initContainer.
+	mntMysqldInitCommand = mntMysqldInitVolumePath + "/" + mysqldInitKey
+
+	// Subpaths inside of init-vt-root initContainer which are passed to
+	// by the mysqld-init/init.sh script.
+	mntBinPath           = mntRootVolumePath + "/bin"
+	mntConfigPath        = mntRootVolumePath + "/config"
+	mntCertsPath         = mntRootVolumePath + "/certs"
+	mntDataRootPath      = mntRootVolumePath + "/vtdataroot"
+	mntMycnfPath         = mntConfigPath + "/mycnf"
+	mntStderrSymlinkPath = mntConfigPath + "/stderr.symlink"
 )
 
 var (
-	defaultExtraMyCnf = []string{
-		vtMycnfPath + "/rbr.cnf",
-	}
-	vtbackupExtraMyCnfFile = vtMycnfPath + "/vtbackup.cnf"
+	defaultExtraMyCnf = []string{rbrCnfPath}
 )

--- a/pkg/operator/vttablet/mysqld_config_overrides.go
+++ b/pkg/operator/vttablet/mysqld_config_overrides.go
@@ -37,15 +37,20 @@ func init() {
 		}
 	})
 	extraMyCnf.Add(func(s lazy.Spec) []string {
-		spec := s.(*Spec)
+		var spec *Spec
+		switch v := s.(type) {
+		case *BackupSpec:
+				spec = v.TabletSpec
+		case *Spec:
+				spec = v
+		default:
+				return nil
+		}
 		if spec.Mysqld == nil || len(spec.Mysqld.ConfigOverrides) == 0 {
 			return nil
 		}
-		// Append an extra config file for vtbackup at the end to override any
-		// settings from the custom ones; will be empty for normal vttablet
 		return []string{
 			"/pod-config/mysqld-config-overrides",
-			vtbackupExtraMyCnfFile,
 		}
 	})
 	tabletVolumes.Add(func(s lazy.Spec) []corev1.Volume {


### PR DESCRIPTION
# Background

Currently `vtbackup` and `vttablet` pods run a script from an init container which copies binaries and certs, and creates some extra mycnf files. The contents of this script and these mycnfs are hardcoded in Golang code.

 * [`vtbackup` init script](https://github.com/planetscale/vitess-operator/blob/e092ebf951c45ac138779fe397bd7c5df440ef40/pkg/operator/vttablet/vtbackup_pod.go#L34-L51)
 * [`vttablet` init script](https://github.com/planetscale/vitess-operator/blob/e092ebf951c45ac138779fe397bd7c5df440ef40/pkg/operator/vttablet/mysqlctld.go#L28-L42)

# Issue

The current approach doesn't have any major issues, but it is awkward. Any change to the initialization scripts need to be made in two places. It would be nice if `vtbackup` and `vttablet` pods could share the initialization script and mycnf files.

# Changes

This commit is a refactor which moves the contents of these mycnfs and initialization script into K8s configmaps. The initialization script is shared by vtbackup and vttablet, and parameterized with environment variables.

# Deploy notes

 * Updating the operator image will cause vttablet pods to be recreated.
 * The ConfigMaps must be deployed before updating the operator image, otherwise `vtbackup` and `vttablet` pods won't be able to mount them.
 * The ConfigMaps must be deployed to each namespace where a `VitessCluster` is deployed. This is a departure from the current way of operating vitess-operator.

# Other notes

## `vtbackup.cnf` and `mysqld-config-overrides`

https://github.com/planetscale/vitess-operator/pull/217 introduced `vtbackup.cnf` and configured `vtbackup` pods  to apply that change after `mysqld-config-overrides`.

This commit preserves that file, but changes the order so that `mysqld-config-overrides` are applied _after_ `vtbackup.cnf`. 

The idea behind this inversion is the understanding that `mysqld-config-overrides` give admins a way to apply custom mycnf settings which override operator settings. Can revert this if this understanding isn't right, or if we're worried about causing unnecessary disruptions to users.

## `vttablet` recreation

Currently, any change to the init scripts and mycnf files cause `vttablet` pods to be recreated.

After this change is applied, future changes to these configmaps will not automatically cause `vttablet` pods to be recreated.