### PR TITLE
Remove enable_realtime_stats flag since it is removed

### DIFF
--- a/pkg/operator/vtctld/deployment.go
+++ b/pkg/operator/vtctld/deployment.go
@@ -241,8 +241,7 @@ func (spec *Spec) flags() vitess.Flags {
 		"topo_global_server_address": spec.GlobalLockserver.Address,
 		"topo_global_root":           spec.GlobalLockserver.RootPath,
 
-		"logtostderr":           true,
-		"enable_realtime_stats": true,
+		"logtostderr": true,
 	}
 	if spec.BackupLocation == nil {
 		return flags


### PR DESCRIPTION
### Description

This PR removes the `enable_realtime_stats` flag from being used by the operator since it is removed in Vitess by https://github.com/vitessio/vitess/pull/11851