### PR TITLE
Release PR for 2.9.0-rc1

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: vitess-operator
       containers:
       - name: vitess-operator
-        image: planetscale/vitess-operator:latest
+        image: planetscale/vitess-operator:v2.9.0-rc1
         command:
         - vitess-operator
         args:

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.14.3
 	sigs.k8s.io/controller-tools v0.11.3
 	sigs.k8s.io/kustomize v2.0.3+incompatible
-	vitess.io/vitess v0.10.3-0.20230203173311-dbeda0c1e8e2
+	vitess.io/vitess v0.16.0-rc1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -832,5 +832,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ih
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-vitess.io/vitess v0.10.3-0.20230203173311-dbeda0c1e8e2 h1:08LWASgQ8JPnFD7lOD0xdr1J4349z2j3MzCi3xxwYEY=
-vitess.io/vitess v0.10.3-0.20230203173311-dbeda0c1e8e2/go.mod h1:ERhRFB7l0iPZuLu+SuFS10TEsw/pDGuy2fFghzlryns=
+vitess.io/vitess v0.16.0-rc1 h1:gR/rfbR/UsacRriGq41TTsFzaHiZd0XLTZtCnmWSB3s=
+vitess.io/vitess v0.16.0-rc1/go.mod h1:ERhRFB7l0iPZuLu+SuFS10TEsw/pDGuy2fFghzlryns=

--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -102,7 +102,7 @@ const (
 	// DefaultMysqlPortName is the name for the MySQL port.
 	DefaultMysqlPortName = "mysql"
 
-	defaultVitessLiteImage = "vitess/lite:latest"
+	defaultVitessLiteImage = "vitess/lite:v16.0.0-rc1"
 
 	DefaultInitCPURequestMillis   = 100
 	DefaultInitMemoryRequestBytes = 32 * (1 << 20) // 32 MiB

--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -8,13 +8,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v15.0.0-rc1
-    vtgate: vitess/lite:v15.0.0-rc1
-    vttablet: vitess/lite:v15.0.0-rc1
-    vtorc: vitess/lite:v15.0.0-rc1
-    vtbackup: vitess/lite:v15.0.0-rc1
+    vtctld: vitess/lite:v15.0.2
+    vtgate: vitess/lite:v15.0.2
+    vttablet: vitess/lite:v15.0.2
+    vtorc: vitess/lite:v15.0.2
+    vtbackup: vitess/lite:v15.0.2
     mysqld:
-      mysql56Compatible: vitess/lite:v15.0.0-rc1
+      mysql56Compatible: vitess/lite:v15.0.2
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -15,13 +15,13 @@ spec:
           path: /backup
           type: Directory
   images:
-    vtctld: vitess/lite:mysql57
-    vtgate: vitess/lite:mysql57
-    vttablet: vitess/lite:mysql57
-    vtorc: vitess/lite:mysql57
-    vtbackup: vitess/lite:mysql57
+    vtctld: vitess/lite:v16.0.0-rc1
+    vtgate: vitess/lite:v16.0.0-rc1
+    vttablet: vitess/lite:v16.0.0-rc1
+    vtorc: vitess/lite:v16.0.0-rc1
+    vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:mysql57
+      mysql56Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
+++ b/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
@@ -8,14 +8,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtadmin: vitess/vtadmin:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
-    vtorc: vitess/lite:latest
+    vtctld: vitess/lite:v16.0.0-rc1
+    vtadmin: vitess/vtadmin:v16.0.0-rc1
+    vtgate: vitess/lite:v16.0.0-rc1
+    vttablet: vitess/lite:v16.0.0-rc1
+    vtbackup: vitess/lite:v16.0.0-rc1
+    vtorc: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/102_keyspace_teardown.yaml
+++ b/test/endtoend/operator/102_keyspace_teardown.yaml
@@ -15,13 +15,13 @@ spec:
           path: /backup
           type: Directory
   images:
-    vtctld: vitess/lite:mysql57
-    vtgate: vitess/lite:mysql57
-    vttablet: vitess/lite:mysql57
-    vtorc: vitess/lite:mysql57
-    vtbackup: vitess/lite:mysql57
+    vtctld: vitess/lite:v16.0.0-rc1
+    vtgate: vitess/lite:v16.0.0-rc1
+    vttablet: vitess/lite:v16.0.0-rc1
+    vtorc: vitess/lite:v16.0.0-rc1
+    vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:mysql57
+      mysql56Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -4,13 +4,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtorc: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v16.0.0-rc1
+    vtgate: vitess/lite:v16.0.0-rc1
+    vttablet: vitess/lite:v16.0.0-rc1
+    vtorc: vitess/lite:v16.0.0-rc1
+    vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/302_new_shards.yaml
+++ b/test/endtoend/operator/302_new_shards.yaml
@@ -4,13 +4,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtorc: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v16.0.0-rc1
+    vtgate: vitess/lite:v16.0.0-rc1
+    vttablet: vitess/lite:v16.0.0-rc1
+    vtorc: vitess/lite:v16.0.0-rc1
+    vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -4,13 +4,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtorc: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v16.0.0-rc1
+    vtgate: vitess/lite:v16.0.0-rc1
+    vttablet: vitess/lite:v16.0.0-rc1
+    vtorc: vitess/lite:v16.0.0-rc1
+    vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -8,13 +8,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtorc: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v16.0.0-rc1
+    vtgate: vitess/lite:v16.0.0-rc1
+    vttablet: vitess/lite:v16.0.0-rc1
+    vtorc: vitess/lite:v16.0.0-rc1
+    vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/operator.yaml
+++ b/test/endtoend/operator/operator.yaml
@@ -5615,7 +5615,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: planetscale/vitess-operator:v2.8.0-rc1
+          image: planetscale/vitess-operator:v2.9.0-rc1
           name: vitess-operator
           resources:
             limits:

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package version
 
 var (
-	Version = "2.8.0"
+	Version = "2.9.0-rc1"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package version
 
 var (
-	Version = "2.9.0-rc1"
+	Version = "2.9.0"
 )


### PR DESCRIPTION
### Description

This PR updates the Vitess dependency to the tagged release v16.0.0-rc1. It updates the tests and version information, etc for the release of 2.9.0-rc1. 