### PR TITLE
[release-2.9] Fix mysqld image key for mysql 80 images

### DIFF
--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -14,7 +14,7 @@ spec:
     vtorc: vitess/lite:v15.0.2-mysql80
     vtbackup: vitess/lite:v15.0.2-mysql80
     mysqld:
-      mysql56Compatible: vitess/lite:v15.0.2-mysql80
+      mysql80Compatible: vitess/lite:v15.0.2-mysql80
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
+++ b/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
@@ -15,7 +15,7 @@ spec:
     vtbackup: vitess/lite:v16.0.0-rc1
     vtorc: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:v16.0.0-rc1
+      mysql80Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -10,7 +10,7 @@ spec:
     vtorc: vitess/lite:v16.0.0-rc1
     vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:v16.0.0-rc1
+      mysql80Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/302_new_shards.yaml
+++ b/test/endtoend/operator/302_new_shards.yaml
@@ -10,7 +10,7 @@ spec:
     vtorc: vitess/lite:v16.0.0-rc1
     vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:v16.0.0-rc1
+      mysql80Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -10,7 +10,7 @@ spec:
     vtorc: vitess/lite:v16.0.0-rc1
     vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:v16.0.0-rc1
+      mysql80Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -14,7 +14,7 @@ spec:
     vtorc: vitess/lite:v16.0.0-rc1
     vtbackup: vitess/lite:v16.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:v16.0.0-rc1
+      mysql80Compatible: vitess/lite:v16.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1


### PR DESCRIPTION
### Description

We are now using mysql80 images in our tests and we should use mysql80Compatible header for them.