### PR TITLE
Update PodDisruptionBudget to policy/v1

### DIFF
--- a/pkg/controller/etcdlockserver/etcdlockserver_controller.go
+++ b/pkg/controller/etcdlockserver/etcdlockserver_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -58,7 +58,7 @@ var watchResources = []client.Object{
 	&corev1.Pod{},
 	&corev1.Service{},
 	&corev1.PersistentVolumeClaim{},
-	&policyv1beta1.PodDisruptionBudget{},
+	&policyv1.PodDisruptionBudget{},
 }
 
 // Add creates a new EtcdLockserver Controller and adds it to the Manager. The Manager will set fields on the Controller

--- a/pkg/controller/etcdlockserver/reconcile_pdb.go
+++ b/pkg/controller/etcdlockserver/reconcile_pdb.go
@@ -19,7 +19,7 @@ package etcdlockserver
 import (
 	"context"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -50,13 +50,13 @@ func (r *ReconcileEtcdLockserver) reconcilePodDisruptionBudget(ctx context.Conte
 		Name:      etcd.PDBName(lockserverName),
 	}
 	err := r.reconciler.ReconcileObject(ctx, ls, key, labels, true, reconciler.Strategy{
-		Kind: &policyv1beta1.PodDisruptionBudget{},
+		Kind: &policyv1.PodDisruptionBudget{},
 
 		New: func(key client.ObjectKey) runtime.Object {
 			return etcd.NewPDB(key, labels)
 		},
 		UpdateInPlace: func(key client.ObjectKey, obj runtime.Object) {
-			curObj := obj.(*policyv1beta1.PodDisruptionBudget)
+			curObj := obj.(*policyv1.PodDisruptionBudget)
 			etcd.UpdatePDBInPlace(curObj, labels)
 		},
 	})

--- a/pkg/operator/etcd/pdb.go
+++ b/pkg/operator/etcd/pdb.go
@@ -17,7 +17,7 @@ limitations under the License.
 package etcd
 
 import (
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,18 +37,18 @@ func PDBName(lockserverName string) string {
 }
 
 // NewPDB creates a new PDB.
-func NewPDB(key client.ObjectKey, labels map[string]string) *policyv1beta1.PodDisruptionBudget {
+func NewPDB(key client.ObjectKey, labels map[string]string) *policyv1.PodDisruptionBudget {
 	// This tells `kubectl drain` not to delete one of the members unless the
 	// number of remaining members will still be at least QuorumSize.
 	minAvailable := intstr.FromInt(QuorumSize)
 
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: key.Namespace,
 			Name:      key.Name,
 			Labels:    labels,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
@@ -58,7 +58,7 @@ func NewPDB(key client.ObjectKey, labels map[string]string) *policyv1beta1.PodDi
 }
 
 // UpdatePDBInPlace updates an existing PDB in-place.
-func UpdatePDBInPlace(obj *policyv1beta1.PodDisruptionBudget, labels map[string]string) {
+func UpdatePDBInPlace(obj *policyv1.PodDisruptionBudget, labels map[string]string) {
 	// Update labels, but ignore existing ones we don't set.
 	update.Labels(&obj.Labels, labels)
 }

--- a/tools/get-kube-binaries.sh
+++ b/tools/get-kube-binaries.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # The integration test framework expects these binaries to be found in the PATH.
 
 # This is the kube-apiserver version to test against.
-KUBE_VERSION="${KUBE_VERSION:-v1.19.1}"
+KUBE_VERSION="${KUBE_VERSION:-v1.20.0}"
 KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL:-https://dl.k8s.io}"
 
 # This should be the etcd version downloaded by kubernetes/hack/lib/etcd.sh


### PR DESCRIPTION
policy/v1beta1 is deprecated in v1.21.0+ and
unavailable in v1.25+.