### PR TITLE
[VTAdmin] Change vars from REACT_APP to VITE

### DIFF
--- a/pkg/controller/vitesscluster/reconcile_vtadmin.go
+++ b/pkg/controller/vitesscluster/reconcile_vtadmin.go
@@ -341,12 +341,12 @@ func (r *ReconcileVitessCluster) createWebConfigSecret(ctx context.Context, vt *
 	// Variables to hold the key, value and secret name to use
 	configKey := vtadmin.WebConfigFileName
 	configVal := fmt.Sprintf(`window.env = {
-     'REACT_APP_VTADMIN_API_ADDRESS': "%s",
-     'REACT_APP_FETCH_CREDENTIALS': "omit",
-     'REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS': false,
-     'REACT_APP_BUGSNAG_API_KEY': "",
-     'REACT_APP_DOCUMENT_TITLE': "",
-     'REACT_APP_READONLY_MODE': %s,
+     'VITE_VTADMIN_API_ADDRESS': "%s",
+     'VITE_FETCH_CREDENTIALS': "omit",
+     'VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS': false,
+     'VITE_BUGSNAG_API_KEY': "",
+     'VITE_DOCUMENT_TITLE': "",
+     'VITE_READONLY_MODE': %s,
  };`, apiAddress, convertReadOnlyFieldToString(vt.Spec.VtAdmin.ReadOnly))
 	secretName := vtadmin.WebConfigSecretName(vt.Name, cell.Name)
 


### PR DESCRIPTION
With https://github.com/vitessio/vitess/pull/12831, we're migrating VTAdmin from create-react-app to vite. One of the changes is that all `REACT_APP_*` vars are changed to `VITE_*`