### PR TITLE
Complete the Reshard before deleting the shard

### DIFF
--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -163,6 +163,14 @@ COrder
 +----------+-------------+----------+-------+
 EOF
 
+  # Complete the reshard process
+  vtctldclient LegacyVtctlCommand -- Reshard Complete customer.cust2cust
+  if [ $? -ne 0 ]; then
+    echo "Reshard Complete failed"
+    printMysqlErrorFiles
+    exit 1
+  fi
+
   kubectl apply -f 306_down_shard_0.yaml
   checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 9
   waitForKeyspaceToBeServing customer -80 2


### PR DESCRIPTION
### Description

We should complete the reshard process before deleting the shard. If we don't then the workflow remains to be seen in the `vtctlclient Workflow customer listall` command and Completing it after deleting the shards fails with following error -

```
Reshard Error: rpc error: code = Unknown desc = node doesn't exist: /vitess/example/global/keyspaces/customer/shards/-/Shard
E0508 17:32:26.613887   52392 main.go:105] remote error: rpc error: code = Unknown desc = node doesn't exist: /vitess/example/global/keyspaces/customer/shards/-/Shard
```

This PR fixes the test to complete the workflow first.