### PR TITLE
New release 2.10.0-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Vitess Operator Version | Recommended Vitess Versions | Recommended Kubernetes V
 `v2.7.*` | `v14.0.*`                   | `v1.20.*`, `v1.21.*`, or `v1.22.*`
 `v2.8.*` | `v15.0.*`                   | `v1.22.*`, `v1.23.*`, or `v1.24.*`
 `v2.9.*` | `v16.0.*`                   | `v1.22.*`, `v1.23.*`, or `v1.24.*`
+`v2.10.*` | `v17.0.*`                   | `v1.22.*`, `v1.23.*`, `v1.24.*`, or `v1.25.*`
 `latest` | `latest`                    | `v1.22.*`, `v1.23.*`, `v1.24.*`, or `v1.25.*`
 
 If for some reason you must attempt to use versions outside the recommend

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.14.3
 	sigs.k8s.io/controller-tools v0.11.3
 	sigs.k8s.io/kustomize v2.0.3+incompatible
-	vitess.io/vitess v0.10.3-0.20230601181117-ea38d23c5ce1
+	vitess.io/vitess v0.17.0-rc1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1143,5 +1143,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ih
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-vitess.io/vitess v0.10.3-0.20230601181117-ea38d23c5ce1 h1:f/wApT8/cfCQiwWt/9/GcNmKbnOpAHSNk+761ONajNo=
-vitess.io/vitess v0.10.3-0.20230601181117-ea38d23c5ce1/go.mod h1:tDMssuiKwPKDFyisllKJKqjW3OZkGQ0Qztp1CIoK39A=
+vitess.io/vitess v0.17.0-rc1 h1:KE+CGZKwTE8JTO0tpMlUX8KMJ4WZi+A6+PttMiDoqEw=
+vitess.io/vitess v0.17.0-rc1/go.mod h1:tDMssuiKwPKDFyisllKJKqjW3OZkGQ0Qztp1CIoK39A=

--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -102,7 +102,7 @@ const (
 	// DefaultMysqlPortName is the name for the MySQL port.
 	DefaultMysqlPortName = "mysql"
 
-	defaultVitessLiteImage = "vitess/lite:latest"
+	defaultVitessLiteImage = "vitess/lite:v17.0.0-rc1"
 
 	DefaultInitCPURequestMillis   = 100
 	DefaultInitMemoryRequestBytes = 32 * (1 << 20) // 32 MiB

--- a/test/endtoend/backup_restore_test.sh
+++ b/test/endtoend/backup_restore_test.sh
@@ -103,7 +103,7 @@ killall kubectl
 setupKubectlAccessForCI
 
 get_started "operator-latest.yaml" "101_initial_cluster_backup.yaml"
-verifyVtGateVersion "18.0.0"
+verifyVtGateVersion "17.0.0"
 checkSemiSyncSetup
 takeBackup "commerce/-"
 verifyListBackupsOutput

--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -8,13 +8,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v16.0.0
-    vtgate: vitess/lite:v16.0.0
-    vttablet: vitess/lite:v16.0.0
-    vtorc: vitess/lite:v16.0.0
-    vtbackup: vitess/lite:v16.0.0
+    vtctld: vitess/lite:v16.0.2
+    vtgate: vitess/lite:v16.0.2
+    vttablet: vitess/lite:v16.0.2
+    vtorc: vitess/lite:v16.0.2
+    vtbackup: vitess/lite:v16.0.2
     mysqld:
-      mysql80Compatible: vitess/lite:v16.0.0
+      mysql80Compatible: vitess/lite:v16.0.2
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -15,13 +15,13 @@ spec:
           path: /backup
           type: Directory
   images:
-    vtctld: vitess/lite:mysql57
-    vtgate: vitess/lite:mysql57
-    vttablet: vitess/lite:mysql57
-    vtorc: vitess/lite:mysql57
-    vtbackup: vitess/lite:mysql57
+    vtctld: vitess/lite:v17.0.0-rc1-mysql57
+    vtgate: vitess/lite:v17.0.0-rc1-mysql57
+    vttablet: vitess/lite:v17.0.0-rc1-mysql57
+    vtorc: vitess/lite:v17.0.0-rc1-mysql57
+    vtbackup: vitess/lite:v17.0.0-rc1-mysql57
     mysqld:
-      mysql56Compatible: vitess/lite:mysql57
+      mysql56Compatible: vitess/lite:v17.0.0-rc1-mysql57
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
+++ b/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
@@ -8,14 +8,14 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtadmin: vitess/vtadmin:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
-    vtorc: vitess/lite:latest
+    vtctld: vitess/lite:v17.0.0-rc1
+    vtadmin: vitess/vtadmin:v17.0.0-rc1
+    vtgate: vitess/lite:v17.0.0-rc1
+    vttablet: vitess/lite:v17.0.0-rc1
+    vtbackup: vitess/lite:v17.0.0-rc1
+    vtorc: vitess/lite:v17.0.0-rc1
     mysqld:
-      mysql80Compatible: vitess/lite:latest
+      mysql80Compatible: vitess/lite:v17.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/102_keyspace_teardown.yaml
+++ b/test/endtoend/operator/102_keyspace_teardown.yaml
@@ -15,13 +15,13 @@ spec:
           path: /backup
           type: Directory
   images:
-    vtctld: vitess/lite:mysql57
-    vtgate: vitess/lite:mysql57
-    vttablet: vitess/lite:mysql57
-    vtorc: vitess/lite:mysql57
-    vtbackup: vitess/lite:mysql57
+    vtctld: vitess/lite:v17.0.0-rc1
+    vtgate: vitess/lite:v17.0.0-rc1
+    vttablet: vitess/lite:v17.0.0-rc1
+    vtorc: vitess/lite:v17.0.0-rc1
+    vtbackup: vitess/lite:v17.0.0-rc1
     mysqld:
-      mysql56Compatible: vitess/lite:mysql57
+      mysql56Compatible: vitess/lite:v17.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -4,13 +4,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtorc: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v17.0.0-rc1
+    vtgate: vitess/lite:v17.0.0-rc1
+    vttablet: vitess/lite:v17.0.0-rc1
+    vtorc: vitess/lite:v17.0.0-rc1
+    vtbackup: vitess/lite:v17.0.0-rc1
     mysqld:
-      mysql80Compatible: vitess/lite:latest
+      mysql80Compatible: vitess/lite:v17.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/302_new_shards.yaml
+++ b/test/endtoend/operator/302_new_shards.yaml
@@ -4,13 +4,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtorc: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v17.0.0-rc1
+    vtgate: vitess/lite:v17.0.0-rc1
+    vttablet: vitess/lite:v17.0.0-rc1
+    vtorc: vitess/lite:v17.0.0-rc1
+    vtbackup: vitess/lite:v17.0.0-rc1
     mysqld:
-      mysql80Compatible: vitess/lite:latest
+      mysql80Compatible: vitess/lite:v17.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -4,13 +4,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtorc: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v17.0.0-rc1
+    vtgate: vitess/lite:v17.0.0-rc1
+    vttablet: vitess/lite:v17.0.0-rc1
+    vtorc: vitess/lite:v17.0.0-rc1
+    vtbackup: vitess/lite:v17.0.0-rc1
     mysqld:
-      mysql80Compatible: vitess/lite:latest
+      mysql80Compatible: vitess/lite:v17.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -8,13 +8,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtorc: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v17.0.0-rc1
+    vtgate: vitess/lite:v17.0.0-rc1
+    vttablet: vitess/lite:v17.0.0-rc1
+    vtorc: vitess/lite:v17.0.0-rc1
+    vtbackup: vitess/lite:v17.0.0-rc1
     mysqld:
-      mysql80Compatible: vitess/lite:latest
+      mysql80Compatible: vitess/lite:v17.0.0-rc1
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -245,12 +245,12 @@ killall kubectl
 setupKubectlAccessForCI
 
 get_started "operator.yaml" "101_initial_cluster.yaml"
-verifyVtGateVersion "16.0.0"
+verifyVtGateVersion "16.0.2"
 checkSemiSyncSetup
 # Initially too durability policy should be specified
 verifyDurabilityPolicy "commerce" "semi_sync"
 upgradeToLatest
-verifyVtGateVersion "18.0.0"
+verifyVtGateVersion "17.0.0"
 checkSemiSyncSetup
 # After upgrading, we verify that the durability policy is still semi_sync
 verifyDurabilityPolicy "commerce" "semi_sync"

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -242,7 +242,7 @@ killall kubectl
 setupKubectlAccessForCI
 
 get_started_vtorc_vtadmin
-verifyVtGateVersion "18.0.0"
+verifyVtGateVersion "17.0.0"
 checkSemiSyncSetup
 
 # Check Vtadmin is setup

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package version
 
 var (
-	Version = "2.10.0"
+	Version = "2.10.0-rc1"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package version
 
 var (
-	Version = "2.10.0-rc1"
+	Version = "2.10.0"
 )


### PR DESCRIPTION
Release new version of Vitess Operator to go with the new Vitess v17.0.0-rc1 release. 