### PR TITLE
Add a new field called "index" to VitessShardTabletPool as part of x-kubernetes-list-map-keys

### DIFF
--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -1461,6 +1461,11 @@ spec:
                                             type: array
                                           extraVolumes:
                                             x-kubernetes-preserve-unknown-fields: true
+                                          index:
+                                            default: 0
+                                            format: int32
+                                            minimum: 0
+                                            type: integer
                                           initContainers:
                                             x-kubernetes-preserve-unknown-fields: true
                                           mysqld:
@@ -1571,6 +1576,7 @@ spec:
                                       x-kubernetes-list-map-keys:
                                       - type
                                       - cell
+                                      - index
                                       x-kubernetes-list-type: map
                                   required:
                                   - databaseInitScriptSecret
@@ -1856,6 +1862,11 @@ spec:
                                           type: array
                                         extraVolumes:
                                           x-kubernetes-preserve-unknown-fields: true
+                                        index:
+                                          default: 0
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
                                         initContainers:
                                           x-kubernetes-preserve-unknown-fields: true
                                         mysqld:
@@ -1966,6 +1977,7 @@ spec:
                                     x-kubernetes-list-map-keys:
                                     - type
                                     - cell
+                                    - index
                                     x-kubernetes-list-type: map
                                 required:
                                 - databaseInitScriptSecret

--- a/deploy/crds/planetscale.com_vitesskeyspaces.yaml
+++ b/deploy/crds/planetscale.com_vitesskeyspaces.yaml
@@ -509,6 +509,11 @@ spec:
                                       type: array
                                     extraVolumes:
                                       x-kubernetes-preserve-unknown-fields: true
+                                    index:
+                                      default: 0
+                                      format: int32
+                                      minimum: 0
+                                      type: integer
                                     initContainers:
                                       x-kubernetes-preserve-unknown-fields: true
                                     mysqld:
@@ -619,6 +624,7 @@ spec:
                                 x-kubernetes-list-map-keys:
                                 - type
                                 - cell
+                                - index
                                 x-kubernetes-list-type: map
                             required:
                             - databaseInitScriptSecret
@@ -904,6 +910,11 @@ spec:
                                     type: array
                                   extraVolumes:
                                     x-kubernetes-preserve-unknown-fields: true
+                                  index:
+                                    default: 0
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
                                   initContainers:
                                     x-kubernetes-preserve-unknown-fields: true
                                   mysqld:
@@ -1014,6 +1025,7 @@ spec:
                               x-kubernetes-list-map-keys:
                               - type
                               - cell
+                              - index
                               x-kubernetes-list-type: map
                           required:
                           - databaseInitScriptSecret

--- a/deploy/crds/planetscale.com_vitessshards.yaml
+++ b/deploy/crds/planetscale.com_vitessshards.yaml
@@ -492,6 +492,11 @@ spec:
                       type: array
                     extraVolumes:
                       x-kubernetes-preserve-unknown-fields: true
+                    index:
+                      default: 0
+                      format: int32
+                      minimum: 0
+                      type: integer
                     initContainers:
                       x-kubernetes-preserve-unknown-fields: true
                     mysqld:
@@ -602,6 +607,7 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 - cell
+                - index
                 x-kubernetes-list-type: map
               topologyReconciliation:
                 properties:

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -7066,6 +7066,20 @@ VitessTabletPoolType
 </tr>
 <tr>
 <td>
+<code>index</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Index is the pool&rsquo;s index within the (cell,type) pair.
+This field is optional, and defaults to 0.
+Assigning different numbers to this field enables the existence of multiple pools with a specific tablet type in a given cell,
+which can be beneficial for unmanaged tablets.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>replicas</code></br>
 <em>
 int32
@@ -7329,7 +7343,7 @@ specify how to spread vttablet pods among the given topology</p>
 <td>
 <p>TabletPools specify groups of tablets in a given cell with a certain
 tablet type and a shared configuration template.</p>
-<p>There must be at most one pool in this list for each (cell,type) pair.
+<p>There must be at most one pool in this list for each (cell,type,index) set.
 Each shard must have at least one &ldquo;replica&rdquo; pool (in at least one cell)
 in order to be able to serve.</p>
 </td>

--- a/pkg/apis/planetscale/v2/labels.go
+++ b/pkg/apis/planetscale/v2/labels.go
@@ -35,6 +35,8 @@ const (
 	TabletUidLabel = LabelPrefix + "/" + "tablet-uid"
 	// TabletTypeLabel is the key for identifying the Vitess target tablet type for a Pod.
 	TabletTypeLabel = LabelPrefix + "/" + "tablet-type"
+	// TabletTypeLabel is the key for identifying the Vitess target pool index within the (cell,type) pair.
+	TabletPoolIndexLabel = LabelPrefix + "/" + "pool-index"
 	// TabletIndexLabel is the key for identifying the index of a Vitess tablet within its pool.
 	TabletIndexLabel = LabelPrefix + "/" + "tablet-index"
 

--- a/pkg/apis/planetscale/v2/vitessshard_methods.go
+++ b/pkg/apis/planetscale/v2/vitessshard_methods.go
@@ -58,9 +58,9 @@ func (t *VitessTabletPoolType) InitTabletType() string {
 	}
 }
 
-// IsMatch indicates whether a tablet pool matches another tablet pool's type and cell.
+// IsMatch indicates whether a tablet pool matches another tablet pool's type, cell and index.
 func (t *VitessShardTabletPool) IsMatch(inputPool *VitessShardTabletPool) bool {
-	return t.Type == inputPool.Type && t.Cell == inputPool.Cell
+	return t.Type == inputPool.Type && t.Cell == inputPool.Cell && t.Index == inputPool.Index
 }
 
 // UsingExternalDatastore indicates whether the VitessShard Spec is using

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -105,7 +105,7 @@ type VitessShardTemplate struct {
 	// TabletPools specify groups of tablets in a given cell with a certain
 	// tablet type and a shared configuration template.
 	//
-	// There must be at most one pool in this list for each (cell,type) pair.
+	// There must be at most one pool in this list for each (cell,type,index) set.
 	// Each shard must have at least one "replica" pool (in at least one cell)
 	// in order to be able to serve.
 	// +patchMergeKey=type
@@ -113,6 +113,7 @@ type VitessShardTemplate struct {
 	// +listType=map
 	// +listMapKey=type
 	// +listMapKey=cell
+	// +listMapKey=index
 	TabletPools []VitessShardTabletPool `json:"tabletPools,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// DatabaseInitScriptSecret specifies the init_db.sql script file to use for this shard.
@@ -169,6 +170,14 @@ type VitessShardTabletPool struct {
 	//   * externalrdonly - tablets pointed at an external, read-only MySQL endpoint that serve batch/analytical (OLAP) workloads
 	// +kubebuilder:validation:Enum=replica;rdonly;externalmaster;externalreplica;externalrdonly
 	Type VitessTabletPoolType `json:"type"`
+
+	// Index is the pool's index within the (cell,type) pair.
+	// This field is optional, and defaults to 0.
+	// Assigning different numbers to this field enables the existence of multiple pools with a specific tablet type in a given cell,
+	// which can be beneficial for unmanaged tablets.
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Minimum=0
+	Index int32 `json:"index,omitempty"`
 
 	// Replicas is the number of tablets to deploy in this pool.
 	// This field is required, although it may be set to 0,

--- a/pkg/controller/vitessshard/reconcile_disk.go
+++ b/pkg/controller/vitessshard/reconcile_disk.go
@@ -53,6 +53,9 @@ func (r *ReconcileVitessShard) reconcileDisk(ctx context.Context, vts *planetsca
 			continue
 		}
 
+		// In cases where there are multiple pools with the same tablet type in a given cell,
+		// there is a possibility of processing the same tablet multiple times.
+		// We permit this to occur as it is practically harmless and simplifies implementation.
 		poolTablets, err := tabletKeysForPool(vts, tabletPool.Cell, tabletPool.Type)
 		if err != nil {
 			return resultBuilder.Error(err)
@@ -129,6 +132,8 @@ func (r *ReconcileVitessShard) claimForTabletPod(ctx context.Context, pod *v1.Po
 	return pvc, nil
 }
 
+// tabletKeysForPool returns the list of targetKeys for a given pool type and cell.
+// Note that this function does not care about the pool's index assignment.
 func tabletKeysForPool(vts *planetscalev2.VitessShard, poolCell string, poolType planetscalev2.VitessTabletPoolType) ([]string, error) {
 	tabletKeys := vts.Status.TabletAliases()
 

--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -284,6 +284,11 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 				Uid:  vttablet.UID(pool.Cell, keyspaceName, vts.Spec.KeyRange, pool.Type, uint32(tabletIndex)),
 			}
 
+			// If TabletPools has multiple pools within the same (cell,type) pair, we need to add a pool index to the UID generator.
+			if 0 < pool.Index {
+				tabletAlias.Uid = vttablet.UIDWithPoolIndex(pool.Cell, keyspaceName, vts.Spec.KeyRange, pool.Type, uint32(tabletIndex), uint32(pool.Index))
+			}
+
 			// Copy parent labels map and add tablet-specific labels.
 			labels := make(map[string]string, len(parentLabels)+4)
 			for k, v := range parentLabels {
@@ -292,6 +297,7 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 			labels[planetscalev2.CellLabel] = tabletAlias.Cell
 			labels[planetscalev2.TabletUidLabel] = strconv.FormatUint(uint64(tabletAlias.Uid), 10)
 			labels[planetscalev2.TabletTypeLabel] = string(pool.Type)
+			labels[planetscalev2.TabletPoolIndexLabel] = strconv.FormatUint(uint64(pool.Index), 10)
 			labels[planetscalev2.TabletIndexLabel] = strconv.FormatUint(uint64(tabletIndex), 10)
 
 			// Merge ExtraVitessFlags into the tablet spec ExtraFlags field.

--- a/pkg/operator/vttablet/uid.go
+++ b/pkg/operator/vttablet/uid.go
@@ -43,11 +43,30 @@ lead time to develop a smarter way to handle tablet identity and MySQL server
 IDs in Vitess itself.
 
 WARNING: DO NOT change the behavior of this function, as that may result in
-         the deletion and recreation of all tablets.
+
+	the deletion and recreation of all tablets.
 */
 func UID(cellName, keyspaceName string, shardKeyRange planetscalev2.VitessKeyRange, tabletPoolType planetscalev2.VitessTabletPoolType, tabletIndex uint32) uint32 {
 	h := md5.New()
 	fmt.Fprintln(h, cellName, keyspaceName, shardKeyRange.String(), string(tabletPoolType), tabletIndex)
+	sum := h.Sum(nil)
+	return binary.BigEndian.Uint32(sum[:4])
+}
+
+/*
+UIDWithPoolIndex function generates a 32-bit unsigned integer similar to the UID function above.
+
+However, it additionally takes the poolIndex as an input.
+This allows the generation of a unique UID for a tablet that belongs to a different pool
+but shares other common attributes.
+
+To preserve the existing UID, it is recommended to use the UID function instead of this function
+when the poolIndex is set to its default value of 0.
+*/
+func UIDWithPoolIndex(cellName, keyspaceName string, shardKeyRange planetscalev2.VitessKeyRange,
+	tabletPoolType planetscalev2.VitessTabletPoolType, tabletIndex uint32, poolIndex uint32) uint32 {
+	h := md5.New()
+	fmt.Fprintln(h, cellName, keyspaceName, shardKeyRange.String(), string(tabletPoolType), tabletIndex, poolIndex)
 	sum := h.Sum(nil)
 	return binary.BigEndian.Uint32(sum[:4])
 }

--- a/pkg/operator/vttablet/uid_test.go
+++ b/pkg/operator/vttablet/uid_test.go
@@ -38,3 +38,21 @@ func TestUIDHash(t *testing.T) {
 		t.Fatalf("UID() = %v, want %v", got, want)
 	}
 }
+
+// TestUIDWithPoolIndexHash checks that nobody changed the hash function for UIDWithPoolIndex().
+func TestUIDWithPoolIndexHash(t *testing.T) {
+	cell := "cell"
+	keyspace := "keyspace"
+	keyRange := planetscalev2.VitessKeyRange{Start: "10", End: "20"}
+	tabletType := planetscalev2.ReplicaPoolType
+	tabletIndex := uint32(1)
+	poolIndex := uint32(1)
+
+	// DO NOT CHANGE THIS VALUE!
+	// This is intentionally a change-detection test. If it breaks, you messed up.
+	want := uint32(3840445776)
+
+	if got := UIDWithPoolIndex(cell, keyspace, keyRange, tabletType, tabletIndex, poolIndex); got != want {
+		t.Fatalf("UIDWithPoolIndex() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR introduces a new field named "index" to the `x-kubernetes-list-map-keys` of TabletPools. It enables the presence of multiple TabletPool instances with a specific tablet type in a given cell.

By assigning a default value of 0 to the index, the existing users and most use cases remain unaffected. The index value can be explicitly set to a value greater than 0 only when building a redundant system with unmanaged tablets.

## Related Issue(s)

- Fixes #428