### PR TITLE
Fix the operator tests to use the latest version after v17.0.0 release

### DIFF
--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -8,13 +8,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v17.0.0-rc1
-    vtgate: vitess/lite:v17.0.0-rc1
-    vttablet: vitess/lite:v17.0.0-rc1
-    vtorc: vitess/lite:v17.0.0-rc1
-    vtbackup: vitess/lite:v17.0.0-rc1
+    vtctld: vitess/lite:v17.0.0
+    vtgate: vitess/lite:v17.0.0
+    vttablet: vitess/lite:v17.0.0
+    vtorc: vitess/lite:v17.0.0
+    vtbackup: vitess/lite:v17.0.0
     mysqld:
-      mysql80Compatible: vitess/lite:v17.0.0-rc1
+      mysql80Compatible: vitess/lite:v17.0.0
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/operator.yaml
+++ b/test/endtoend/operator/operator.yaml
@@ -6357,7 +6357,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: planetscale/vitess-operator:v2.10.0-rc1
+          image: planetscale/vitess-operator:v2.10.0
           name: vitess-operator
           resources:
             limits:


### PR DESCRIPTION
### Description

This PR updates `main` to use the latest version of the images after we have release v17.0.0 version of Vitess.