### PR TITLE
Disable CGO usage in builds

### DIFF
--- a/build/Dockerfile.release
+++ b/build/Dockerfile.release
@@ -16,7 +16,7 @@ FROM golang:1.20.2 AS build
 ENV GO111MODULE=on
 WORKDIR /go/src/planetscale.dev/vitess-operator
 COPY . /go/src/planetscale.dev/vitess-operator
-RUN go install /go/src/planetscale.dev/vitess-operator/cmd/manager
+RUN CGO_ENABLED=0 go install /go/src/planetscale.dev/vitess-operator/cmd/manager
 
 # The rest is meant to mimic the output from operator-sdk's Dockerfile.
 # We just copy the binary we built inside Docker instead of from outside.

--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -15,13 +15,13 @@ spec:
           path: /backup
           type: Directory
   images:
-    vtctld: vitess/lite:v17.0.2-mysql57
-    vtgate: vitess/lite:v17.0.2-mysql57
-    vttablet: vitess/lite:v17.0.2-mysql57
-    vtorc: vitess/lite:v17.0.2-mysql57
-    vtbackup: vitess/lite:v17.0.2-mysql57
+    vtctld: vitess/lite:v17.0.2
+    vtgate: vitess/lite:v17.0.2
+    vttablet: vitess/lite:v17.0.2
+    vtorc: vitess/lite:v17.0.2
+    vtbackup: vitess/lite:v17.0.2
     mysqld:
-      mysql56Compatible: vitess/lite:v17.0.2-mysql57
+      mysql56Compatible: vitess/lite:v17.0.2
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1


### PR DESCRIPTION
Vitess has not used CGO since v15 where our usage of the native sqlite C library was replaced: https://github.com/vitessio/vitess/pull/12214

We should not build the operator using CGO as it will not run on platforms that have an older glibc version than the one used on the golang container image used for the build.

This also moves the backup and restore test to using the default/`mysql80` images in `test/endtoend/operator/101_initial_cluster_backup.yaml`. This was the only test still using the `mysql57` images and this moves everything to 8.0 (MySQL 5.7 is EOL next month).