### PR TITLE
Fix Release script to work with any image used in the yaml files

### DIFF
--- a/tools/release/do_release.sh
+++ b/tools/release/do_release.sh
@@ -27,12 +27,11 @@ function updateVitessImages() {
   old_vitess_version=$1
   new_vitess_version=$2
 
-  operator_files=$(find -E $ROOT/test/endtoend/operator/* -name "*.yaml" | grep -v "101_initial_cluster.yaml" | grep -v "101_initial_cluster_backup.yaml")
-  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:v$new_vitess_version/g" $operator_files
-  sed -i.bak -E "s/vitess\/vtadmin:(.*)/vitess\/vtadmin:v$new_vitess_version/g" $operator_files
-  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:v$new_vitess_version\"/g" $ROOT/pkg/apis/planetscale/v2/defaults.go
-  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:v$old_vitess_version/g" $ROOT/test/endtoend/operator/101_initial_cluster.yaml
-  sed -i.bak -E "s/vitess\/lite:(.*)/vitess\/lite:v$new_vitess_version-mysql57/g" $ROOT/test/endtoend/operator/101_initial_cluster_backup.yaml
+  operator_files=$(find -E $ROOT/test/endtoend/operator/* -name "*.yaml" | grep -v "101_initial_cluster.yaml")
+  sed -i.bak -E "s/vitess\/lite:([^-]*)(-rc[0-9]*)?(-mysql..)?/vitess\/lite:v$new_vitess_version\3/g" $operator_files
+  sed -i.bak -E "s/vitess\/vtadmin:([^-]*)(-rc[0-9]*)?(-mysql..)?/vitess\/vtadmin:v$new_vitess_version\3/g" $operator_files
+  sed -i.bak -E "s/vitess\/lite:([^-]*)(-rc[0-9]*)?(-mysql..)?/vitess\/lite:v$new_vitess_version\3\"/g" $ROOT/pkg/apis/planetscale/v2/defaults.go
+  sed -i.bak -E "s/vitess\/lite:([^-]*)(-rc[0-9]*)?(-mysql..)?/vitess\/lite:v$old_vitess_version\3/g" $ROOT/test/endtoend/operator/101_initial_cluster.yaml
 
   rm -f $(find -E $ROOT/test/endtoend/operator/ -name "*.yaml.bak") $ROOT/pkg/apis/planetscale/v2/defaults.go.bak
 }


### PR DESCRIPTION
### Description

Previously the release script was opinionated about what yaml files should be using MySQL 5.7 and what should be using MySQL 8.0 images. This however caused issues because we switch around this as part of development and don't always update the release script.

In this PR, I have changed the way the release script works by changing the sed commands, such that now the release script conserves the image variant to what it already is. This is the intended and correct behavior because when we do a release, we only intend to change the release number in the yaml files and not their variant.