### PR TITLE
Pass extra env to all vttablet containers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6675,7 +6675,7 @@ created for this component.</p>
 <td>
 <p>ExtraEnv can optionally be used to override default environment variables
 set by the operator, or pass additional environment variables.
-These values are applied to both the vttablet and mysqld containers.</p>
+These values are applied to the vttablet, mysqld, and mysqld-exporter containers.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/operator/vttablet/env_vars.go
+++ b/pkg/operator/vttablet/env_vars.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vttablet
 
 import (
+	"fmt"
 	"strings"
 
 	"planetscale.dev/vitess-operator/pkg/operator/lazy"
@@ -38,6 +39,15 @@ func init() {
 			{
 				Name:  "EXTRA_MY_CNF",
 				Value: strings.Join(extraMyCnf.Get(spec), ":"),
+			},
+		}
+	})
+
+	mysqldExporterEnvVars.Add(func(s lazy.Spec) []corev1.EnvVar {
+		return []corev1.EnvVar{
+			{
+				Name:  "DATA_SOURCE_NAME",
+				Value: fmt.Sprintf("%s@unix(%s)/", mysqldExporterUser, mysqlSocketPath),
 			},
 		}
 	})

--- a/pkg/operator/vttablet/lazy_values.go
+++ b/pkg/operator/vttablet/lazy_values.go
@@ -30,6 +30,8 @@ var (
 	tabletEnvVars lazy.EnvVars
 	// vttabletEnvVars are extra env vars for only the vttablet container.
 	vttabletEnvVars lazy.EnvVars
+	// mysqldExporterEnvVars are extra env vars for only the mysqld container.
+	mysqldExporterEnvVars lazy.EnvVars
 	// extraMyCnf is a list of file paths to put into the EXTRA_MY_CNF env var.
 	extraMyCnf lazy.Strings
 


### PR DESCRIPTION
This allows for the mysqld-exporter to be configured with the same
environment variables as the vttablet and mysqld containers. This
is useful for configuring an AWS IAM-based service account, which
automatically injects additional AWS_* environment variables into
the pod. Without this, the operator continuously restarts the vttablet
pod due to trying to remove the AWS_* environment variables from
the mysqld-exporter container.

Related to #383 