### PR TITLE
Remove 'vreplication_tablet_type' flag to run unmanaged vttablet v20

### DIFF
--- a/pkg/operator/vttablet/constants.go
+++ b/pkg/operator/vttablet/constants.go
@@ -81,8 +81,6 @@ const (
 	dbConfigReplUname     = "vt_repl"
 	dbConfigFilteredUname = "vt_filtered"
 
-	vreplicationTabletType = "master"
-
 	dbInitScriptDirName = "db-init-script"
 
 	externalDatastoreCredentialsDirName = "external-datastore-credentials"

--- a/pkg/operator/vttablet/datastore.go
+++ b/pkg/operator/vttablet/datastore.go
@@ -126,7 +126,6 @@ func externalDatastoreFlags(spec *Spec) vitess.Flags {
 		"enable_replication_reporter": false,
 
 		"enforce_strict_trans_tables": false,
-		"vreplication_tablet_type":    vreplicationTabletType,
 	}
 
 	return flags


### PR DESCRIPTION
## Description

This PR removes a flag called `vreplication_tablet_type` that is deleted on Vitess v20.
See https://github.com/vitessio/vitess/blob/main/changelog/20.0/20.0.0/release_notes.md#vreplication-tablet-type-deletion.

## Related Issue(s)

fixes: https://github.com/planetscale/vitess-operator/issues/575