### PR TITLE
Add unmanaged_tablet_test.sh to run a new e2e build on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -82,3 +82,22 @@ steps:
           propagate-environment: true
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
+
+  - name: "Unmanaged Tablet Test"
+    command:
+    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat chromium
+    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - tar -C /usr/local -xzf $GO_VERSION_FILE
+    - export PATH=$PATH:/usr/local/go/bin
+    - rm $GO_VERSION_FILE
+    - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
+    - make unmanaged-tablet-test
+    concurrency: 1
+    concurrency_group: 'vtop/unmanaged-tablet-test'
+    timeout_in_minutes: 60
+    plugins:
+      - docker#v3.12.0:
+          image: "docker:latest"
+          propagate-environment: true
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"

--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,7 @@ backup-schedule-test: build e2e-test-setup
 vtorc-vtadmin-test: build e2e-test-setup
 	echo "Running VTOrc and VtAdmin test"
 	test/endtoend/vtorc_vtadmin_test.sh
+
+unmanaged-tablet-test: build e2e-test-setup
+	echo "Running Unmanaged Tablet test"
+	test/endtoend/unmanaged_tablet_test.sh

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -107,7 +107,7 @@ from the pull request, so in order to have the tag on the release branche's hist
 
 ##### Update the test output
 
-The `upgrade_test.sh`, `backup_restore_test.sh` and `vtorc_vtadmin_test.sh` files must be updated with the proper release increment. Change the `verifyVtGateVersion` function calls to use the proper version (current version being released and latest previous version (only used in `upgrade_test.sh`)).
+The `upgrade_test.sh`, `backup_restore_test.sh`, `vtorc_vtadmin_test.sh` and `unmanaged_tablet_test.sh` files must be updated with the proper release increment. Change the `verifyVtGateVersion` function calls to use the proper version (current version being released and latest previous version (only used in `upgrade_test.sh`)).
 
 ##### CI Failures
 

--- a/test/endtoend/operator/101_initial_cluster_unmanaged_tablet.yaml
+++ b/test/endtoend/operator/101_initial_cluster_unmanaged_tablet.yaml
@@ -1,0 +1,259 @@
+# The following example is minimalist. The security policies
+# and resource specifications are not meant to be used in production.
+# Please refer to the operator documentation for recommendations on
+# production settings.
+apiVersion: planetscale.com/v2
+kind: VitessCluster
+metadata:
+  name: example
+spec:
+  images:
+    vtctld: vitess/lite:latest
+    vtadmin: vitess/vtadmin:latest
+    vtgate: vitess/lite:latest
+    vttablet: vitess/lite:latest
+    vtbackup: vitess/lite:latest
+    vtorc: vitess/lite:latest
+    mysqld:
+      mysql80Compatible: mysql:8.0.30
+    mysqldExporter: prom/mysqld-exporter:v0.11.0
+  cells:
+  - name: zone1
+    gateway:
+      authentication:
+        static:
+          secret:
+            name: example-cluster-config
+            key: users.json
+      replicas: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+  vitessDashboard:
+    cells:
+    - zone1
+    extraFlags:
+      security_policy: read-only
+    replicas: 1
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+  keyspaces:
+  - name: commerce
+    durabilityPolicy: none
+    turndownPolicy: Immediate
+    vitessOrchestrator:
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi
+      extraFlags:
+        recovery-period-block-duration: 5s
+    partitionings:
+    - equal:
+        parts: 1
+        shardTemplate:
+          databaseInitScriptSecret:
+            name: example-cluster-config
+            key: init_db.sql
+          tabletPools:
+          - cell: zone1
+            type: externalmaster
+            replicas: 1
+            vttablet:
+              extraFlags:
+                db_charset: utf8mb4
+              resources:
+                limits:
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+            externalDatastore:
+              user: root
+              host: mysql
+              port: 3306
+              database: main
+              credentialsSecret:
+                name: example-cluster-config
+                key: ext_db_credentials_secret.json
+  updateStrategy:
+    type: Immediate
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-cluster-config
+type: Opaque
+stringData:
+  users.json: |
+    {
+      "user": [{
+        "UserData": "user",
+        "Password": ""
+      }]
+    }
+  init_db.sql: |
+    # This file is executed immediately after mysql_install_db,
+    # to initialize a fresh data directory.
+
+    ###############################################################################
+    # Equivalent of mysql_secure_installation
+    ###############################################################################
+    # We need to ensure that super_read_only is disabled so that we can execute
+    # these commands. Note that disabling it does NOT disable read_only.
+    # We save the current value so that we only re-enable it at the end if it was
+    # enabled before.
+    SET @original_super_read_only=IF(@@global.super_read_only=1, 'ON', 'OFF');
+    SET GLOBAL super_read_only='OFF';
+
+    # Changes during the init db should not make it to the binlog.
+    # They could potentially create errant transactions on replicas.
+    SET sql_log_bin = 0;
+    # Remove anonymous users.
+    DELETE FROM mysql.user WHERE User = '';
+
+    # Disable remote root access (only allow UNIX socket).
+    DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
+
+    # Remove test database.
+    DROP DATABASE IF EXISTS test;
+
+    ###############################################################################
+    # Vitess defaults
+    ###############################################################################
+
+    # Vitess-internal database.
+    CREATE DATABASE IF NOT EXISTS _vt;
+    # Note that definitions of local_metadata and shard_metadata should be the same
+    # as in production which is defined in go/vt/mysqlctl/metadata_tables.go.
+    CREATE TABLE IF NOT EXISTS _vt.local_metadata (
+      name VARCHAR(255) NOT NULL,
+      value VARCHAR(255) NOT NULL,
+      db_name VARBINARY(255) NOT NULL,
+      PRIMARY KEY (db_name, name)
+      ) ENGINE=InnoDB;
+    CREATE TABLE IF NOT EXISTS _vt.shard_metadata (
+      name VARCHAR(255) NOT NULL,
+      value MEDIUMBLOB NOT NULL,
+      db_name VARBINARY(255) NOT NULL,
+      PRIMARY KEY (db_name, name)
+      ) ENGINE=InnoDB;
+
+    # Admin user with all privileges.
+    CREATE USER 'vt_dba'@'localhost';
+    GRANT ALL ON *.* TO 'vt_dba'@'localhost';
+    GRANT GRANT OPTION ON *.* TO 'vt_dba'@'localhost';
+
+    # User for app traffic, with global read-write access.
+    CREATE USER 'vt_app'@'localhost';
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
+      REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+      LOCK TABLES, EXECUTE, REPLICATION CLIENT, CREATE VIEW,
+      SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+      ON *.* TO 'vt_app'@'localhost';
+
+    # User for app debug traffic, with global read access.
+    CREATE USER 'vt_appdebug'@'localhost';
+    GRANT SELECT, SHOW DATABASES, PROCESS ON *.* TO 'vt_appdebug'@'localhost';
+
+    # User for administrative operations that need to be executed as non-SUPER.
+    # Same permissions as vt_app here.
+    CREATE USER 'vt_allprivs'@'localhost';
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
+      REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+      LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
+      SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+      ON *.* TO 'vt_allprivs'@'localhost';
+
+    # User for slave replication connections.
+    # TODO: Should we set a password on this since it allows remote connections?
+    CREATE USER 'vt_repl'@'%';
+    GRANT REPLICATION SLAVE ON *.* TO 'vt_repl'@'%';
+
+    # User for Vitess filtered replication (binlog player).
+    # Same permissions as vt_app.
+    CREATE USER 'vt_filtered'@'localhost';
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
+      REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+      LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
+      SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+      ON *.* TO 'vt_filtered'@'localhost';
+
+    FLUSH PRIVILEGES;
+
+    RESET SLAVE ALL;
+    RESET MASTER;
+
+    # custom sql is used to add custom scripts like creating users/passwords. We use it in our tests
+    # {{custom_sql}}
+
+    # We need to set super_read_only back to what it was before
+    SET GLOBAL super_read_only=IFNULL(@original_super_read_only, 'ON');
+  ext_db_credentials_secret.json: |
+    {
+      "root": ["password"]
+    }
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: mysql
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: password
+          ports:
+            - containerPort: 3306
+          volumeMounts:
+            - name: mysql-persistent-storage
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mysql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mysql-pv-claim

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -19,7 +19,7 @@ function get_started_unmanaged() {
     sleep 10
     echo "Creating vschema and commerce SQL schema"
 
-    ./pf_vtadmin.sh > /dev/null 2>&1 &
+    ./pf.sh > /dev/null 2>&1 &
     sleep 5
 
     waitForKeyspaceToBeServing commerce - 0

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+source ./tools/test.env
+source ./test/endtoend/utils.sh
+
+# get_started_unmanaged:
+function get_started_unmanaged() {
+    echo "Apply latest operator-latest.yaml"
+    kubectl apply -f "operator-latest.yaml"
+    checkPodStatusWithTimeout "vitess-operator(.*)1/1(.*)Running(.*)"
+
+    echo "Apply 101_initial_cluster_unmanaged_tablet.yaml"
+    kubectl apply -f "101_initial_cluster_unmanaged_tablet.yaml"
+    checkPodStatusWithTimeout "example-zone1-vtctld(.*)1/1(.*)Running(.*)"
+    checkPodStatusWithTimeout "example-zone1-vtgate(.*)1/1(.*)Running(.*)"
+    checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
+    checkPodStatusWithTimeout "example-vttablet-zone1(.*)1/1(.*)Running(.*)"
+
+    sleep 10
+    echo "Creating vschema and commerce SQL schema"
+
+    ./pf_vtadmin.sh > /dev/null 2>&1 &
+    sleep 5
+
+    waitForKeyspaceToBeServing commerce - 0
+    sleep 5
+
+    applySchemaWithRetry create_commerce_schema.sql commerce drop_all_commerce_tables.sql
+    vtctldclient ApplyVSchema --vschema-file="vschema_commerce_initial.json" commerce
+    if [[ $? -ne 0 ]]; then
+      echo "ApplySchema failed for initial commerce"
+      printMysqlErrorFiles
+      exit 1
+    fi
+    sleep 5
+
+    echo "show databases;" | mysql | grep "commerce" > /dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+      echo "Could not find commerce database"
+      printMysqlErrorFiles
+      exit 1
+    fi
+
+    echo "show tables;" | mysql commerce | grep -E 'corder|customer|product' | wc -l | grep 3 > /dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+      echo "Could not find commerce's tables"
+      printMysqlErrorFiles
+      exit 1
+    fi
+
+    insertWithRetry
+
+    assertSelect ../common/select_commerce_data.sql "commerce" << EOF
+Using commerce
+Customer
++-------------+--------------------+
+| customer_id | email              |
++-------------+--------------------+
+|           1 | alice@domain.com   |
+|           2 | bob@domain.com     |
+|           3 | charlie@domain.com |
+|           4 | dan@domain.com     |
+|           5 | eve@domain.com     |
++-------------+--------------------+
+Product
++----------+-------------+-------+
+| sku      | description | price |
++----------+-------------+-------+
+| SKU-1001 | Monitor     |   100 |
+| SKU-1002 | Keyboard    |    30 |
++----------+-------------+-------+
+COrder
++----------+-------------+----------+-------+
+| order_id | customer_id | sku      | price |
++----------+-------------+----------+-------+
+|        1 |           1 | SKU-1001 |   100 |
+|        2 |           2 | SKU-1002 |    30 |
+|        3 |           3 | SKU-1002 |    30 |
+|        4 |           4 | SKU-1002 |    30 |
+|        5 |           5 | SKU-1002 |    30 |
++----------+-------------+----------+-------+
+EOF
+}
+
+# Test setup
+echo "Building the docker image"
+docker build -f build/Dockerfile.release -t vitess-operator-pr:latest .
+echo "Creating Kind cluster"
+kind create cluster --wait 30s --name kind-${BUILDKITE_BUILD_ID} --image ${KIND_VERSION}
+echo "Loading docker image into Kind cluster"
+kind load docker-image vitess-operator-pr:latest --name kind-${BUILDKITE_BUILD_ID}
+
+cd "$PWD/test/endtoend/operator"
+killall kubectl
+setupKubectlAccessForCI
+
+# Check Unmanaged tablet is running properly
+get_started_unmanaged
+
+# Teardown
+echo "Deleting Kind cluster. This also deletes the volume associated with it"
+kind delete cluster --name kind-${BUILDKITE_BUILD_ID}


### PR DESCRIPTION
## Description

This PR adds a new e2e test to ensure unmanaged tablet runs on the latest operator.

You see the following output on my personal build space:

- Test failed due to https://github.com/planetscale/vitess-operator/issues/575
   - Link: https://buildkite.com/yoheimuta/vitess-operator/builds/26#0190b9d3-8f76-4f75-99c1-e68baae22494/54-575
- Test passed after cherry-picking https://github.com/planetscale/vitess-operator/pull/576
   - Link: https://buildkite.com/yoheimuta/vitess-operator/builds/27
- 📝 I needed to apply [a tweak](https://github.com/planetscale/vitess-operator/commit/e74b533421eff3d4417651da3e9ede66638eb608) to the PR to run a build on my space due to a machine resource issue.

## Related Issue(s)

fixes: https://github.com/planetscale/vitess-operator/issues/577