### PR TITLE
Copy the affinity configuration to backup init job

### DIFF
--- a/pkg/controller/vitessshard/reconcile_backup_job.go
+++ b/pkg/controller/vitessshard/reconcile_backup_job.go
@@ -247,6 +247,7 @@ func vtbackupSpec(key client.ObjectKey, vts *planetscalev2.VitessShard, parentLa
 		SidecarContainers:        pool.SidecarContainers,
 		ExtraEnv:                 pool.ExtraEnv,
 		Annotations:              annotations,
+		Affinity:                 pool.Affinity,
 		Tolerations:              pool.Tolerations,
 		ImagePullSecrets:         vts.Spec.ImagePullSecrets,
 	}


### PR DESCRIPTION
This will allow the backup initialization job to use the same affinity configuration vttablet uses, copied from the top-level pool configuration.