### PR TITLE
Post release of v2.13.1 and v20.0.1

### DIFF
--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -8,11 +8,11 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v20.0.0-rc2
-    vtgate: vitess/lite:v20.0.0-rc2
-    vttablet: vitess/lite:v20.0.0-rc2
-    vtorc: vitess/lite:v20.0.0-rc2
-    vtbackup: vitess/lite:v20.0.0-rc2
+    vtctld: vitess/lite:v20.0.1
+    vtgate: vitess/lite:v20.0.1
+    vttablet: vitess/lite:v20.0.1
+    vtorc: vitess/lite:v20.0.1
+    vtbackup: vitess/lite:v20.0.1
     mysqld:
       mysql80Compatible: mysql:8.0.30
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/test/endtoend/operator/operator.yaml
+++ b/test/endtoend/operator/operator.yaml
@@ -6885,7 +6885,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: planetscale/vitess-operator:v2.13.0
+          image: planetscale/vitess-operator:v2.13.1
           name: vitess-operator
           resources:
             limits:

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -245,7 +245,7 @@ killall kubectl
 setupKubectlAccessForCI
 
 get_started "operator.yaml" "101_initial_cluster.yaml"
-verifyVtGateVersion "20.0.0"
+verifyVtGateVersion "20.0.1"
 checkSemiSyncSetup
 # Initially too durability policy should be specified
 verifyDurabilityPolicy "commerce" "semi_sync"

--- a/tools/get-e2e-test-deps.sh
+++ b/tools/get-e2e-test-deps.sh
@@ -40,8 +40,8 @@ fi
 if ! command -v vtctldclient &> /dev/null
 then
   echo "Downloading vtctldclient..."
-  version=20.0.0-rc2
-  file=vitess-${version}-4af99b5.tar.gz
+  version=20.0.1
+  file=vitess-${version}-003c441.tar.gz
   wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
   tar -xzf ${file}
   cd ${file/.tar.gz/}

--- a/version/version.go
+++ b/version/version.go
@@ -20,5 +20,5 @@ package version
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
 var (
-	Version = "2.13.0"
+	Version = "2.14.0"
 )


### PR DESCRIPTION
This PR updates the test infrastructure to use the proper version of vitess and vtop, following up the recent v2.13.1 and v20.0.1 releases.