### PR TITLE
Update images and tests after the release of `v20.0.2`

### DIFF
--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -8,11 +8,11 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v20.0.1
-    vtgate: vitess/lite:v20.0.1
-    vttablet: vitess/lite:v20.0.1
-    vtorc: vitess/lite:v20.0.1
-    vtbackup: vitess/lite:v20.0.1
+    vtctld: vitess/lite:v20.0.2
+    vtgate: vitess/lite:v20.0.2
+    vttablet: vitess/lite:v20.0.2
+    vtorc: vitess/lite:v20.0.2
+    vtbackup: vitess/lite:v20.0.2
     mysqld:
       mysql80Compatible: mysql:8.0.30
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -245,7 +245,7 @@ killall kubectl
 setupKubectlAccessForCI
 
 get_started "operator.yaml" "101_initial_cluster.yaml"
-verifyVtGateVersion "20.0.1"
+verifyVtGateVersion "20.0.2"
 checkSemiSyncSetup
 # Initially too durability policy should be specified
 verifyDurabilityPolicy "commerce" "semi_sync"

--- a/tools/get-e2e-test-deps.sh
+++ b/tools/get-e2e-test-deps.sh
@@ -40,8 +40,8 @@ fi
 if ! command -v vtctldclient &> /dev/null
 then
   echo "Downloading vtctldclient..."
-  version=20.0.1
-  file=vitess-${version}-003c441.tar.gz
+  version=20.0.2
+  file=vitess-${version}-2592c59.tar.gz
   wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
   tar -xzf ${file}
   cd ${file/.tar.gz/}


### PR DESCRIPTION
This PR is a follow up of the `v20.0.2` release, which updates the docker images used and the expectations in the tests.