### PR TITLE
Use only one K8S version in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,131 +4,100 @@ agents:
 env:
   GO_VERSION_FILE: "go1.23.1.linux-amd64.tar.gz"
 
-
 # Mount the docker.sock as to the docker container, so that we are able to
 # run docker build command and kind is spawned as a sibling container.
 steps:
-  - group: "Upgrade Test"
-    steps:
-      - label: "Upgrade Test {{matrix}}"
-        matrix:
-          - "1.31.0"
-          - "1.30.4"
-          - "1.29.8"
-        command:
-        - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
-        - wget https://golang.org/dl/$GO_VERSION_FILE
-        - tar -C /usr/local -xzf $GO_VERSION_FILE
-        - export PATH=$PATH:/usr/local/go/bin
-        - rm $GO_VERSION_FILE
-        - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
-        - K8S_VERSION={{matrix}} make upgrade-test
-        concurrency: 1
-        concurrency_group: 'vtop/upgrade-downgrade-test'
-        timeout_in_minutes: 60
-        plugins:
-          - docker#v3.12.0:
-              image: "docker:latest"
-              propagate-environment: true
-              volumes:
-                - "/var/run/docker.sock:/var/run/docker.sock"
+  - name: "Upgrade Test"
+    command:
+    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
+    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - tar -C /usr/local -xzf $GO_VERSION_FILE
+    - export PATH=$PATH:/usr/local/go/bin
+    - rm $GO_VERSION_FILE
+    - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
+    - make upgrade-test
+    concurrency: 1
+    concurrency_group: 'vtop/upgrade-downgrade-test'
+    timeout_in_minutes: 60
+    plugins:
+      - docker#v3.12.0:
+          image: "docker:latest"
+          propagate-environment: true
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
 
-  - group: "Backup Restore Test"
-    steps:
-      - label: "Backup Restore Test {{matrix}}"
-        matrix:
-          - "1.31.0"
-          - "1.30.4"
-          - "1.29.8"
-        command:
-        - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
-        - wget https://golang.org/dl/$GO_VERSION_FILE
-        - tar -C /usr/local -xzf $GO_VERSION_FILE
-        - export PATH=$PATH:/usr/local/go/bin
-        - rm $GO_VERSION_FILE
-        - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
-        - K8S_VERSION={{matrix}} make backup-restore-test
-        concurrency: 1
-        concurrency_group: 'vtop/backup-restore-test'
-        timeout_in_minutes: 60
-        plugins:
-          - docker#v3.12.0:
-              image: "docker:latest"
-              propagate-environment: true
-              volumes:
-                - "/var/run/docker.sock:/var/run/docker.sock"
+  - name: "Backup Restore Test"
+    command:
+    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
+    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - tar -C /usr/local -xzf $GO_VERSION_FILE
+    - export PATH=$PATH:/usr/local/go/bin
+    - rm $GO_VERSION_FILE
+    - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
+    - make backup-restore-test
+    concurrency: 1
+    concurrency_group: 'vtop/backup-restore-test'
+    timeout_in_minutes: 60
+    plugins:
+      - docker#v3.12.0:
+          image: "docker:latest"
+          propagate-environment: true
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
 
-  - group: "Backup Schedule Test"
-    steps:
-      - name: "Backup Schedule Test {{matrix}}"
-        matrix:
-          - "1.31.0"
-          - "1.30.4"
-          - "1.29.8"
-        command:
-          - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
-          - wget https://golang.org/dl/$GO_VERSION_FILE
-          - tar -C /usr/local -xzf $GO_VERSION_FILE
-          - export PATH=$PATH:/usr/local/go/bin
-          - rm $GO_VERSION_FILE
-          - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
-          - K8S_VERSION={{matrix}} make backup-schedule-test
-        concurrency: 1
-        concurrency_group: 'vtop/backup-schedule-test'
-        timeout_in_minutes: 60
-        plugins:
-          - docker#v3.12.0:
-              image: "docker:latest"
-              propagate-environment: true
-              volumes:
-                - "/var/run/docker.sock:/var/run/docker.sock"
+  - name: "Backup Schedule Test"
+    command:
+      - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
+      - wget https://golang.org/dl/$GO_VERSION_FILE
+      - tar -C /usr/local -xzf $GO_VERSION_FILE
+      - export PATH=$PATH:/usr/local/go/bin
+      - rm $GO_VERSION_FILE
+      - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
+      - make backup-schedule-test
+    concurrency: 1
+    concurrency_group: 'vtop/backup-schedule-test'
+    timeout_in_minutes: 60
+    plugins:
+      - docker#v3.12.0:
+          image: "docker:latest"
+          propagate-environment: true
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
 
-  - group: "VTOrc and VTAdmin Test"
-    steps:
-      - label: "VTOrc and VTAdmin Test {{matrix}}"
-        matrix:
-          - "1.31.0"
-          - "1.30.4"
-          - "1.29.8"
-        command:
-        - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat chromium
-        - wget https://golang.org/dl/$GO_VERSION_FILE
-        - tar -C /usr/local -xzf $GO_VERSION_FILE
-        - export PATH=$PATH:/usr/local/go/bin
-        - rm $GO_VERSION_FILE
-        - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
-        - K8S_VERSION={{matrix}} make vtorc-vtadmin-test
-        concurrency: 1
-        concurrency_group: 'vtop/vtorc-vtadmin-test'
-        timeout_in_minutes: 60
-        plugins:
-          - docker#v3.12.0:
-              image: "docker:latest"
-              propagate-environment: true
-              volumes:
-                - "/var/run/docker.sock:/var/run/docker.sock"
+  - name: "VTOrc and VTAdmin Test"
+    command:
+    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat chromium
+    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - tar -C /usr/local -xzf $GO_VERSION_FILE
+    - export PATH=$PATH:/usr/local/go/bin
+    - rm $GO_VERSION_FILE
+    - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
+    - make vtorc-vtadmin-test
+    concurrency: 1
+    concurrency_group: 'vtop/vtorc-vtadmin-test'
+    timeout_in_minutes: 60
+    plugins:
+      - docker#v3.12.0:
+          image: "docker:latest"
+          propagate-environment: true
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
 
-  - group: "Unmanaged Tablet Test"
-    steps:
-      - label: "Unmanaged Tablet Test {{matrix}}"
-        matrix:
-          - "1.31.0"
-          - "1.30.4"
-          - "1.29.8"
-        command:
-        - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat chromium
-        - wget https://golang.org/dl/$GO_VERSION_FILE
-        - tar -C /usr/local -xzf $GO_VERSION_FILE
-        - export PATH=$PATH:/usr/local/go/bin
-        - rm $GO_VERSION_FILE
-        - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
-        - K8S_VERSION={{matrix}} make unmanaged-tablet-test
-        concurrency: 1
-        concurrency_group: 'vtop/unmanaged-tablet-test'
-        timeout_in_minutes: 60
-        plugins:
-          - docker#v3.12.0:
-              image: "docker:latest"
-              propagate-environment: true
-              volumes:
-                - "/var/run/docker.sock:/var/run/docker.sock"
+  - name: "Unmanaged Tablet Test"
+    command:
+    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat chromium
+    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - tar -C /usr/local -xzf $GO_VERSION_FILE
+    - export PATH=$PATH:/usr/local/go/bin
+    - rm $GO_VERSION_FILE
+    - ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
+    - make unmanaged-tablet-test
+    concurrency: 1
+    concurrency_group: 'vtop/unmanaged-tablet-test'
+    timeout_in_minutes: 60
+    plugins:
+      - docker#v3.12.0:
+          image: "docker:latest"
+          propagate-environment: true
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ the new pairing.
 
 ## Build
 
-This secton describes how to build your own Vitess Operator binaries and images.
+This section describes how to build your own Vitess Operator binaries and images.
 See the Getting Started guides above if you just want to deploy Vitess Operator
 from pre-built images.
 


### PR DESCRIPTION
This PR is a quick fix to how we run our CI test on buildkite, it has become harder to run CI since https://github.com/planetscale/vitess-operator/pull/597 was merged: we had 3 times more workflows running, significantly increasing the total runtime of our CI and also increasing the likelihood of having workflows fail due to flakiness.

This PR removes the matrix introduced by https://github.com/planetscale/vitess-operator/pull/597 and rely on the default K8S version defined in `tools/test.env`.