### PR TITLE
Support customisation of docker images per-keyspace

### DIFF
--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -1318,6 +1318,14 @@ spec:
                             mysql80Compatible:
                               type: string
                           type: object
+                        mysqldExporter:
+                          type: string
+                        vtbackup:
+                          type: string
+                        vtorc:
+                          type: string
+                        vttablet:
+                          type: string
                       type: object
                     name:
                       maxLength: 63

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -6552,7 +6552,13 @@ operation, after which the source keyspace is destroyed.</p>
 <p>
 <p>VitessKeyspaceTemplateImages specifies user-definable container images to
 use for this keyspace. The images defined here by the user will override
-those defined at the top-level in VitessCluster.spec.images</p>
+those defined at the top-level in VitessCluster.spec.images.</p>
+<p>While this field allows you to set a different set of Vitess version for
+some components of Vitess than the version defined at the top level, it
+is important to note that Vitess only ensure compatibility between one
+version and the next and previous one. For instance: N is only compatible
+with N+1 and N-1. Do be careful when specifying multiple versions across
+your cluster so that they respect this compatibility rule.</p>
 <p>Note: this structure is a copy of VitessKeyspaceImages, once we have gotten
 rid of MysqldImage and replaced it by MysqldImageNew (planned for v2.15), we
 should be able to remove VitessKeyspaceTemplateImages entirely and just use

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -6553,10 +6553,10 @@ operation, after which the source keyspace is destroyed.</p>
 <p>VitessKeyspaceTemplateImages specifies user-definable container images to
 use for this keyspace. The images defined here by the user will override
 those defined at the top-level in VitessCluster.spec.images.</p>
-<p>While this field allows you to set a different set of Vitess version for
-some components of Vitess than the version defined at the top level, it
-is important to note that Vitess only ensure compatibility between one
-version and the next and previous one. For instance: N is only compatible
+<p>While this field allows you to set a different Vitess version for some
+components than the version defined at the top level, it is important to
+note that Vitess only ensures compatibility between one version and the
+next and previous one. For instance: N is only guaranteed  to be compatible
 with N+1 and N-1. Do be careful when specifying multiple versions across
 your cluster so that they respect this compatibility rule.</p>
 <p>Note: this structure is a copy of VitessKeyspaceImages, once we have gotten

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -6551,7 +6551,12 @@ operation, after which the source keyspace is destroyed.</p>
 </p>
 <p>
 <p>VitessKeyspaceTemplateImages specifies user-definable container images to
-use for this keyspace.</p>
+use for this keyspace. The images defined here by the user will override
+those defined at the top-level in VitessCluster.spec.images</p>
+<p>Note: this structure is a copy of VitessKeyspaceImages, once we have gotten
+rid of MysqldImage and replaced it by MysqldImageNew (planned for v2.15), we
+should be able to remove VitessKeyspaceTemplateImages entirely and just use
+VitessKeyspaceImages instead as it contains exactly the same fields.</p>
 </p>
 <table class="table table-striped">
 <thead class="thead-dark">
@@ -6561,6 +6566,39 @@ use for this keyspace.</p>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>vttablet</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Vttablet is the container image (including version tag) to use for Vitess Tablet instances.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vtorc</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Vtorc is the container image (including version tag) to use for Vitess Orchestrator instances.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vtbackup</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Vtbackup is the container image (including version tag) to use for Vitess Backup jobs.</p>
+</td>
+</tr>
 <tr>
 <td>
 <code>mysqld</code></br>
@@ -6575,6 +6613,17 @@ MysqldImageNew
 declaring which MySQL flavor setting in Vitess the image is
 compatible with. Only one flavor image may be provided at a time.
 mysqld running alongside each tablet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mysqldExporter</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>MysqldExporter specifies the container image for mysqld-exporter.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/planetscale/v2/vitesskeyspace_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_defaults.go
@@ -73,8 +73,20 @@ func DefaultVitessKeyspaceImages(dst *VitessKeyspaceImages, clusterDefaults *Vit
 // MergeVitessKeyspaceTemplateImages takes non-empty image values from a non-nil src
 // and sets them on dst.
 func MergeVitessKeyspaceTemplateImages(dst *VitessKeyspaceImages, src *VitessKeyspaceTemplateImages) {
+	if src.Vttablet != "" {
+		dst.Vttablet = src.Vttablet
+	}
+	if src.Vtorc != "" {
+		dst.Vtorc = src.Vtorc
+	}
+	if src.Vtbackup != "" {
+		dst.Vtbackup = src.Vtbackup
+	}
 	if src.Mysqld != nil {
 		dst.Mysqld.Mysql56Compatible = src.Mysqld.Mysql56Compatible
 		dst.Mysqld.Mysql80Compatible = src.Mysqld.Mysql80Compatible
+	}
+	if src.MysqldExporter != "" {
+		dst.MysqldExporter = src.MysqldExporter
 	}
 }

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -188,13 +188,27 @@ type VitessKeyspaceTemplate struct {
 }
 
 // VitessKeyspaceTemplateImages specifies user-definable container images to
-// use for this keyspace.
+// use for this keyspace. The images defined here by the user will override
+// those defined at the top-level in VitessCluster.spec.images
+//
+// Note: this structure is a copy of VitessKeyspaceImages, once we have gotten
+// rid of MysqldImage and replaced it by MysqldImageNew (planned for v2.15), we
+// should be able to remove VitessKeyspaceTemplateImages entirely and just use
+// VitessKeyspaceImages instead as it contains exactly the same fields.
 type VitessKeyspaceTemplateImages struct {
+	// Vttablet is the container image (including version tag) to use for Vitess Tablet instances.
+	Vttablet string `json:"vttablet,omitempty"`
+	// Vtorc is the container image (including version tag) to use for Vitess Orchestrator instances.
+	Vtorc string `json:"vtorc,omitempty"`
+	// Vtbackup is the container image (including version tag) to use for Vitess Backup jobs.
+	Vtbackup string `json:"vtbackup,omitempty"`
 	// Mysqld specifies the container image to use for mysqld, as well as
 	// declaring which MySQL flavor setting in Vitess the image is
 	// compatible with. Only one flavor image may be provided at a time.
 	// mysqld running alongside each tablet.
 	Mysqld *MysqldImageNew `json:"mysqld,omitempty"`
+	// MysqldExporter specifies the container image for mysqld-exporter.
+	MysqldExporter string `json:"mysqldExporter,omitempty"`
 }
 
 // VitessOrchestratorSpec specifies deployment parameters for vtorc.

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -191,10 +191,10 @@ type VitessKeyspaceTemplate struct {
 // use for this keyspace. The images defined here by the user will override
 // those defined at the top-level in VitessCluster.spec.images.
 //
-// While this field allows you to set a different set of Vitess version for
-// some components of Vitess than the version defined at the top level, it
-// is important to note that Vitess only ensure compatibility between one
-// version and the next and previous one. For instance: N is only compatible
+// While this field allows you to set a different Vitess version for some
+// components than the version defined at the top level, it is important to
+// note that Vitess only ensures compatibility between one version and the
+// next and previous one. For instance: N is only guaranteed  to be compatible
 // with N+1 and N-1. Do be careful when specifying multiple versions across
 // your cluster so that they respect this compatibility rule.
 //

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -189,7 +189,14 @@ type VitessKeyspaceTemplate struct {
 
 // VitessKeyspaceTemplateImages specifies user-definable container images to
 // use for this keyspace. The images defined here by the user will override
-// those defined at the top-level in VitessCluster.spec.images
+// those defined at the top-level in VitessCluster.spec.images.
+//
+// While this field allows you to set a different set of Vitess version for
+// some components of Vitess than the version defined at the top level, it
+// is important to note that Vitess only ensure compatibility between one
+// version and the next and previous one. For instance: N is only compatible
+// with N+1 and N-1. Do be careful when specifying multiple versions across
+// your cluster so that they respect this compatibility rule.
 //
 // Note: this structure is a copy of VitessKeyspaceImages, once we have gotten
 // rid of MysqldImage and replaced it by MysqldImageNew (planned for v2.15), we

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -2830,6 +2830,14 @@ spec:
                               mysql80Compatible:
                                 type: string
                             type: object
+                          mysqldExporter:
+                            type: string
+                          vtbackup:
+                            type: string
+                          vtorc:
+                            type: string
+                          vttablet:
+                            type: string
                         type: object
                       name:
                         maxLength: 63


### PR DESCRIPTION
## Description
This PR builds on top of https://github.com/planetscale/vitess-operator/pull/524 and adds full support for cusomisation of all Docker Images per keyspace. We can now define what Docker Image we want to use at the keyspace level. the containers for which we can customise the image we want at the keyspace level are: `vttablet`, `vtbackup`, `mysql`, `mysqldExporter`, `vtorc`.

This per-keyspace definition takes precedence over the top-level definition in `spec.images`.

This PR is part of https://github.com/planetscale/vitess-operator/issues/608. It fixes the `Issue 1` part.

## Tests

```yaml
apiVersion: planetscale.com/v2
kind: VitessCluster
metadata:
  name: example
spec:
  ...
  images:
    vtctld: vitess/lite:latest
    vtgate: vitess/lite:latest
    vttablet: vitess/lite:latest
    vtorc: vitess/lite:latest
    vtbackup: vitess/lite:latest
    mysqld:
      mysql80Compatible: mysql:8.0.30
    mysqldExporter: prom/mysqld-exporter:v0.11.0
...
...
  keyspaces:
  - name: commerce
    images:
      vtbackup: vitess/lite:v20.0.2
      vtorc: vitess/lite:v20.0.2
      vttablet: vitess/lite:v20.0.2
      mysqld:
        mysql80Compatible: mysql:8.0.31
      mysqldExporter: prom/mysqld-exporter:v0.11.0

```
```
$ kubectl describe pod example-vttablet-zone1-2548885007-46a852d0 | grep "Image:"

    Image:         vitess/lite:v20.0.2
    Image:         vitess/lite:v20.0.2
    Image:         vitess/lite:v20.0.2
    Image:         mysql:8.0.31
    Image:         prom/mysqld-exporter:v0.11.0

$ kubectl describe pod example-commerce-x-x-zone1-vtorc-c13ef6ff-8647487fd9-kjmm9 | grep "Image:" 

   Image:         vitess/lite:v20.0.2
```

## Backports

As #524 was made on `v2.12`, let's backport this all the way to `v2.12` plus `v2.11`too as explained in https://github.com/planetscale/vitess-operator/pull/609.