### PR TITLE
Update README for 2.14 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ compatible with certain Vitess and Kubernetes versions, as shown in this table:
 | `v2.11.*`               | `v18.0.*`                   | `v1.22.*`, `v1.23.*`, `v1.24.*`, or `v1.25.*` |
 | `v2.12.*`               | `v19.0.*`                   | `v1.25.*`, `v1.26.*`, `v1.27.*`, or `v1.28.*` |
 | `v2.13.*`               | `v20.0.*`                   | `v1.25.*`, `v1.26.*`, `v1.27.*`, or `v1.28.*` |
+| `v2.14.*`               | `v21.0.*`                   | `v1.29.*`, `v1.30.*`, `v1.31.*`               |
 | `latest`                | `latest`                    | `v1.29.*`, `v1.30.*`, `v1.31.*`               |
 
 If for some reason you must attempt to use versions outside the recommend


### PR DESCRIPTION
Add a new row before the last row. This new row should include the v2.14.0 vitess-operator release and the v21.0.*, along with the matching K8S version.