### PR TITLE
Use proper line break in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -47,7 +47,7 @@ consistency model that Vitess expects of a lockserver.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -57,14 +57,14 @@ planetscale.com/v2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>EtcdLockserver</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -78,7 +78,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverSpec">
 EtcdLockserverSpec
@@ -91,7 +91,7 @@ EtcdLockserverSpec
 <table>
 <tr>
 <td>
-<code>EtcdLockserverTemplate</code></br>
+<code>EtcdLockserverTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverTemplate">
 EtcdLockserverTemplate
@@ -109,7 +109,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>zone</code></br>
+<code>zone</code><br>
 <em>
 string
 </em>
@@ -126,7 +126,7 @@ If the Kubernetes Nodes don&rsquo;t have such a label, leave this empty.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverStatus">
 EtcdLockserverStatus
@@ -156,7 +156,7 @@ the storage location will be represented by its own VitessBackup object.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -166,14 +166,14 @@ planetscale.com/v2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>VitessBackup</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -187,7 +187,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupSpec">
 VitessBackupSpec
@@ -203,7 +203,7 @@ VitessBackupSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupStatus">
 VitessBackupStatus
@@ -237,7 +237,7 @@ the VitessCluster object.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -247,14 +247,14 @@ planetscale.com/v2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>VitessCluster</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -268,7 +268,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterSpec">
 VitessClusterSpec
@@ -281,7 +281,7 @@ VitessClusterSpec
 <table>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImages">
 VitessImages
@@ -296,7 +296,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -310,7 +310,7 @@ images defined in the &lsquo;images&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -324,7 +324,7 @@ use the images defined in the &lsquo;images&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>backup</code></br>
+<code>backup</code><br>
 <em>
 <a href="#planetscale.com/v2.ClusterBackupSpec">
 ClusterBackupSpec
@@ -340,7 +340,7 @@ of a new tablet in a shard with existing data, as an implementation detail.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverSpec">
 LockserverSpec
@@ -355,7 +355,7 @@ Default: Deploy an etcd cluster as the global lockserver.</p>
 </tr>
 <tr>
 <td>
-<code>vitessDashboard</code></br>
+<code>vitessDashboard</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessDashboardSpec">
 VitessDashboardSpec
@@ -368,7 +368,7 @@ VitessDashboardSpec
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 <a href="#planetscale.com/v2.VtAdminSpec">
 VtAdminSpec
@@ -381,7 +381,7 @@ VtAdminSpec
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellTemplate">
 []VitessCellTemplate
@@ -400,7 +400,7 @@ that no keyspaces are set to deploy to this cell.</p>
 </tr>
 <tr>
 <td>
-<code>keyspaces</code></br>
+<code>keyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplate">
 []VitessKeyspaceTemplate
@@ -418,7 +418,7 @@ of target cells.</p>
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -434,7 +434,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -447,7 +447,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -461,7 +461,7 @@ when a revision is made to the VitessCluster spec.</p>
 </tr>
 <tr>
 <td>
-<code>gatewayService</code></br>
+<code>gatewayService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -476,7 +476,7 @@ definition.</p>
 </tr>
 <tr>
 <td>
-<code>tabletService</code></br>
+<code>tabletService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -492,7 +492,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterStatus">
 VitessClusterStatus
@@ -500,6 +500,80 @@ VitessClusterStatus
 </em>
 </td>
 <td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="planetscale.com/v2.AutoscalerSpec">AutoscalerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#planetscale.com/v2.VitessCellGatewaySpec">VitessCellGatewaySpec</a>)
+</p>
+<p>
+<p>AutoscalerSpec defines the vtgate&rsquo;s pod autoscaling specification.</p>
+</p>
+<table class="table table-striped">
+<thead class="thead-dark">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReplicas</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReplicas is the minimum number of instances of vtgate to run in
+this cell when autoscaling is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxReplicas</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MaxReplicas is the maximum number of instances of vtgate to run in
+this cell when autoscaling is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metrics</code><br>
+<em>
+<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#metricspec-v2-autoscaling">
+[]Kubernetes autoscaling/v2.MetricSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metrics is meant to provide a customizable way to configure HPA metrics.
+currently the only supported custom metrics is type=Pod.
+Use TargetCPUUtilization or TargetMemoryUtilization instead if scaling on these common resource metrics.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>behavior</code><br>
+<em>
+<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#horizontalpodautoscalerbehavior-v2-autoscaling">
+Kubernetes autoscaling/v2.HorizontalPodAutoscalerBehavior
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Behavior specifies the scaling behavior of the target in both Up and Down directions.</p>
 </td>
 </tr>
 </tbody>
@@ -523,7 +597,7 @@ VitessClusterStatus
 <tbody>
 <tr>
 <td>
-<code>account</code></br>
+<code>account</code><br>
 <em>
 string
 </em>
@@ -534,7 +608,7 @@ string
 </tr>
 <tr>
 <td>
-<code>container</code></br>
+<code>container</code><br>
 <em>
 string
 </em>
@@ -545,7 +619,7 @@ string
 </tr>
 <tr>
 <td>
-<code>keyPrefix</code></br>
+<code>keyPrefix</code><br>
 <em>
 string
 </em>
@@ -560,7 +634,7 @@ within a container, regardless of this setting.</p>
 </tr>
 <tr>
 <td>
-<code>authSecret</code></br>
+<code>authSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -602,7 +676,7 @@ When scheduling a backup, you must specify at least one strategy.</p>
 <tbody>
 <tr>
 <td>
-<code>authSecret</code></br>
+<code>authSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -638,7 +712,7 @@ provisioning of a new tablet in a shard with existing data, as an implementation
 <tbody>
 <tr>
 <td>
-<code>locations</code></br>
+<code>locations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -658,7 +732,7 @@ were originally taken.</p>
 </tr>
 <tr>
 <td>
-<code>engine</code></br>
+<code>engine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -676,7 +750,7 @@ Default: builtin</p>
 </tr>
 <tr>
 <td>
-<code>subcontroller</code></br>
+<code>subcontroller</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupSubcontrollerSpec">
 VitessBackupSubcontrollerSpec
@@ -689,7 +763,7 @@ VitessBackupSubcontrollerSpec
 </tr>
 <tr>
 <td>
-<code>schedules</code></br>
+<code>schedules</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleTemplate">
 []VitessBackupScheduleTemplate
@@ -733,7 +807,7 @@ is handled, the default is set to AllowConcurrent.</p>
 <tbody>
 <tr>
 <td>
-<code>EtcdLockserverTemplate</code></br>
+<code>EtcdLockserverTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverTemplate">
 EtcdLockserverTemplate
@@ -751,7 +825,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>zone</code></br>
+<code>zone</code><br>
 <em>
 string
 </em>
@@ -785,7 +859,7 @@ If the Kubernetes Nodes don&rsquo;t have such a label, leave this empty.</p>
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -796,7 +870,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -809,7 +883,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>clientServiceName</code></br>
+<code>clientServiceName</code><br>
 <em>
 string
 </em>
@@ -842,7 +916,7 @@ lockserver.</p>
 <tbody>
 <tr>
 <td>
-<code>image</code></br>
+<code>image</code><br>
 <em>
 string
 </em>
@@ -854,7 +928,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicy</code></br>
+<code>imagePullPolicy</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -867,7 +941,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -881,7 +955,7 @@ etcd Pods.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -895,7 +969,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>dataVolumeClaimTemplate</code></br>
+<code>dataVolumeClaimTemplate</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#persistentvolumeclaimspec-v1-core">
 Kubernetes core/v1.PersistentVolumeClaimSpec
@@ -914,7 +988,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -929,7 +1003,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -943,7 +1017,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -960,7 +1034,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -975,7 +1049,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -989,7 +1063,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -1003,7 +1077,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -1019,7 +1093,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -1031,7 +1105,7 @@ created for this component.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -1043,7 +1117,7 @@ created for this component.</p>
 </tr>
 <tr>
 <td>
-<code>createPDB</code></br>
+<code>createPDB</code><br>
 <em>
 bool
 </em>
@@ -1057,7 +1131,7 @@ member Pods.</p>
 </tr>
 <tr>
 <td>
-<code>createClientService</code></br>
+<code>createClientService</code><br>
 <em>
 bool
 </em>
@@ -1071,7 +1145,7 @@ of etcd member Pods.</p>
 </tr>
 <tr>
 <td>
-<code>createPeerService</code></br>
+<code>createPeerService</code><br>
 <em>
 bool
 </em>
@@ -1085,7 +1159,7 @@ of etcd member Pods.</p>
 </tr>
 <tr>
 <td>
-<code>advertisePeerURLs</code></br>
+<code>advertisePeerURLs</code><br>
 <em>
 []string
 </em>
@@ -1100,7 +1174,7 @@ member index (1,2,3) respectively.</p>
 </tr>
 <tr>
 <td>
-<code>localMemberIndex</code></br>
+<code>localMemberIndex</code><br>
 <em>
 int32
 </em>
@@ -1116,7 +1190,7 @@ index must be 1, 2, or 3.</p>
 </tr>
 <tr>
 <td>
-<code>clientService</code></br>
+<code>clientService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -1129,7 +1203,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>peerService</code></br>
+<code>peerService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -1142,7 +1216,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -1175,7 +1249,7 @@ externally managed MySQL.</p>
 <tbody>
 <tr>
 <td>
-<code>user</code></br>
+<code>user</code><br>
 <em>
 string
 </em>
@@ -1187,7 +1261,7 @@ carry out necessary actions.  Password for this user must be supplied in the Cre
 </tr>
 <tr>
 <td>
-<code>host</code></br>
+<code>host</code><br>
 <em>
 string
 </em>
@@ -1198,7 +1272,7 @@ string
 </tr>
 <tr>
 <td>
-<code>port</code></br>
+<code>port</code><br>
 <em>
 int32
 </em>
@@ -1209,7 +1283,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>database</code></br>
+<code>database</code><br>
 <em>
 string
 </em>
@@ -1220,7 +1294,7 @@ string
 </tr>
 <tr>
 <td>
-<code>credentialsSecret</code></br>
+<code>credentialsSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -1240,7 +1314,7 @@ Vitess always uses the first password in the password array.</p>
 </tr>
 <tr>
 <td>
-<code>serverCACertSecret</code></br>
+<code>serverCACertSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -1271,7 +1345,7 @@ SecretSource
 <tbody>
 <tr>
 <td>
-<code>allowResourceChanges</code></br>
+<code>allowResourceChanges</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcename-v1-core">
 []Kubernetes core/v1.ResourceName
@@ -1307,7 +1381,7 @@ requests and limits to propagate immediately, bypassing the external rollout too
 <tbody>
 <tr>
 <td>
-<code>bucket</code></br>
+<code>bucket</code><br>
 <em>
 string
 </em>
@@ -1318,7 +1392,7 @@ string
 </tr>
 <tr>
 <td>
-<code>keyPrefix</code></br>
+<code>keyPrefix</code><br>
 <em>
 string
 </em>
@@ -1333,7 +1407,7 @@ within a bucket, regardless of this setting.</p>
 </tr>
 <tr>
 <td>
-<code>authSecret</code></br>
+<code>authSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -1370,7 +1444,7 @@ which can be either global or local.</p>
 <tbody>
 <tr>
 <td>
-<code>external</code></br>
+<code>external</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -1385,7 +1459,7 @@ If this is set, all other Lockserver fields are ignored.</p>
 </tr>
 <tr>
 <td>
-<code>etcd</code></br>
+<code>etcd</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverTemplate">
 EtcdLockserverTemplate
@@ -1398,7 +1472,7 @@ EtcdLockserverTemplate
 </tr>
 <tr>
 <td>
-<code>cellInfoAddress</code></br>
+<code>cellInfoAddress</code><br>
 <em>
 string
 </em>
@@ -1430,7 +1504,7 @@ Default: etcd client service.</p>
 <tbody>
 <tr>
 <td>
-<code>etcd</code></br>
+<code>etcd</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverStatus">
 EtcdLockserverStatus
@@ -1462,7 +1536,7 @@ EtcdLockserverStatus
 <tbody>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -1495,7 +1569,7 @@ Kubernetes core/v1.ResourceRequirements
 <tbody>
 <tr>
 <td>
-<code>mysql56Compatible</code></br>
+<code>mysql56Compatible</code><br>
 <em>
 string
 </em>
@@ -1507,7 +1581,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MySQL56&rdquo; flavor setting.</p
 </tr>
 <tr>
 <td>
-<code>mysql80Compatible</code></br>
+<code>mysql80Compatible</code><br>
 <em>
 string
 </em>
@@ -1519,7 +1593,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MySQL80&rdquo; flavor setting.</p
 </tr>
 <tr>
 <td>
-<code>mariadbCompatible</code></br>
+<code>mariadbCompatible</code><br>
 <em>
 string
 </em>
@@ -1531,7 +1605,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MariaDB&rdquo; flavor setting.</p
 </tr>
 <tr>
 <td>
-<code>mariadb103Compatible</code></br>
+<code>mariadb103Compatible</code><br>
 <em>
 string
 </em>
@@ -1565,7 +1639,7 @@ image is compatible with.</p>
 <tbody>
 <tr>
 <td>
-<code>mysql56Compatible</code></br>
+<code>mysql56Compatible</code><br>
 <em>
 string
 </em>
@@ -1577,7 +1651,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MySQL56&rdquo; flavor setting.</p
 </tr>
 <tr>
 <td>
-<code>mysql80Compatible</code></br>
+<code>mysql80Compatible</code><br>
 <em>
 string
 </em>
@@ -1608,7 +1682,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MySQL80&rdquo; flavor setting.</p
 <tbody>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -1623,7 +1697,7 @@ This field is required.</p>
 </tr>
 <tr>
 <td>
-<code>configOverrides</code></br>
+<code>configOverrides</code><br>
 <em>
 string
 </em>
@@ -1657,7 +1731,7 @@ particular MySQL instance.</p>
 <tbody>
 <tr>
 <td>
-<code>reason</code></br>
+<code>reason</code><br>
 <em>
 string
 </em>
@@ -1668,7 +1742,7 @@ string
 </tr>
 <tr>
 <td>
-<code>message</code></br>
+<code>message</code><br>
 <em>
 string
 </em>
@@ -1698,7 +1772,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>workflow</code></br>
+<code>workflow</code><br>
 <em>
 string
 </em>
@@ -1709,7 +1783,7 @@ string
 </tr>
 <tr>
 <td>
-<code>state</code></br>
+<code>state</code><br>
 <em>
 <a href="#planetscale.com/v2.WorkflowState">
 WorkflowState
@@ -1722,7 +1796,7 @@ WorkflowState
 </tr>
 <tr>
 <td>
-<code>sourceShards</code></br>
+<code>sourceShards</code><br>
 <em>
 []string
 </em>
@@ -1733,7 +1807,7 @@ WorkflowState
 </tr>
 <tr>
 <td>
-<code>targetShards</code></br>
+<code>targetShards</code><br>
 <em>
 []string
 </em>
@@ -1744,7 +1818,7 @@ WorkflowState
 </tr>
 <tr>
 <td>
-<code>copyProgress</code></br>
+<code>copyProgress</code><br>
 <em>
 int
 </em>
@@ -1777,7 +1851,7 @@ If we can not compute the copy progress in a timely fashion, we will report -1 t
 <tbody>
 <tr>
 <td>
-<code>region</code></br>
+<code>region</code><br>
 <em>
 string
 </em>
@@ -1788,7 +1862,7 @@ string
 </tr>
 <tr>
 <td>
-<code>bucket</code></br>
+<code>bucket</code><br>
 <em>
 string
 </em>
@@ -1799,7 +1873,7 @@ string
 </tr>
 <tr>
 <td>
-<code>endpoint</code></br>
+<code>endpoint</code><br>
 <em>
 string
 </em>
@@ -1811,7 +1885,7 @@ Default: Use the endpoint associated with <code>region</code> by the driver.</p>
 </tr>
 <tr>
 <td>
-<code>forcePathStyle</code></br>
+<code>forcePathStyle</code><br>
 <em>
 bool
 </em>
@@ -1823,7 +1897,7 @@ Default: false By default the s3 client will try to connect to <bucket>.<endpoin
 </tr>
 <tr>
 <td>
-<code>keyPrefix</code></br>
+<code>keyPrefix</code><br>
 <em>
 string
 </em>
@@ -1838,7 +1912,7 @@ within a bucket, regardless of this setting.</p>
 </tr>
 <tr>
 <td>
-<code>authSecret</code></br>
+<code>authSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -1881,7 +1955,7 @@ Default: Use the default credentials of the Node.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -1897,7 +1971,7 @@ with the &lsquo;volumeName&rsquo; field instead.</p>
 </tr>
 <tr>
 <td>
-<code>volumeName</code></br>
+<code>volumeName</code><br>
 <em>
 string
 </em>
@@ -1912,7 +1986,7 @@ If specified, this takes precedence over the &lsquo;name&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>key</code></br>
+<code>key</code><br>
 <em>
 string
 </em>
@@ -1951,7 +2025,7 @@ within that Volume.</p>
 <tbody>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -1964,7 +2038,7 @@ Service object if they are removed here.</p>
 </tr>
 <tr>
 <td>
-<code>clusterIP</code></br>
+<code>clusterIP</code><br>
 <em>
 string
 </em>
@@ -1994,7 +2068,7 @@ a given backup location.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -2005,7 +2079,7 @@ string
 </tr>
 <tr>
 <td>
-<code>completeBackups</code></br>
+<code>completeBackups</code><br>
 <em>
 int32
 </em>
@@ -2016,7 +2090,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>incompleteBackups</code></br>
+<code>incompleteBackups</code><br>
 <em>
 int32
 </em>
@@ -2027,7 +2101,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>latestCompleteBackupTime</code></br>
+<code>latestCompleteBackupTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -2063,7 +2137,7 @@ This should only be necessary if you need to override defaults, and shouldn&rsqu
 <tbody>
 <tr>
 <td>
-<code>registerCellsAliases</code></br>
+<code>registerCellsAliases</code><br>
 <em>
 bool
 </em>
@@ -2075,7 +2149,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>registerCells</code></br>
+<code>registerCells</code><br>
 <em>
 bool
 </em>
@@ -2087,7 +2161,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneCells</code></br>
+<code>pruneCells</code><br>
 <em>
 bool
 </em>
@@ -2099,7 +2173,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneKeyspaces</code></br>
+<code>pruneKeyspaces</code><br>
 <em>
 bool
 </em>
@@ -2111,7 +2185,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneSrvKeyspaces</code></br>
+<code>pruneSrvKeyspaces</code><br>
 <em>
 bool
 </em>
@@ -2123,7 +2197,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneShards</code></br>
+<code>pruneShards</code><br>
 <em>
 bool
 </em>
@@ -2135,7 +2209,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneShardCells</code></br>
+<code>pruneShardCells</code><br>
 <em>
 bool
 </em>
@@ -2147,7 +2221,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneTablets</code></br>
+<code>pruneTablets</code><br>
 <em>
 bool
 </em>
@@ -2192,7 +2266,7 @@ Default: true</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -2209,7 +2283,7 @@ location used when a tablet pool does not specify a backupLocationName.</p>
 </tr>
 <tr>
 <td>
-<code>gcs</code></br>
+<code>gcs</code><br>
 <em>
 <a href="#planetscale.com/v2.GCSBackupLocation">
 GCSBackupLocation
@@ -2222,7 +2296,7 @@ GCSBackupLocation
 </tr>
 <tr>
 <td>
-<code>s3</code></br>
+<code>s3</code><br>
 <em>
 <a href="#planetscale.com/v2.S3BackupLocation">
 S3BackupLocation
@@ -2235,7 +2309,7 @@ S3BackupLocation
 </tr>
 <tr>
 <td>
-<code>azblob</code></br>
+<code>azblob</code><br>
 <em>
 <a href="#planetscale.com/v2.AzblobBackupLocation">
 AzblobBackupLocation
@@ -2248,7 +2322,7 @@ AzblobBackupLocation
 </tr>
 <tr>
 <td>
-<code>ceph</code></br>
+<code>ceph</code><br>
 <em>
 <a href="#planetscale.com/v2.CephBackupLocation">
 CephBackupLocation
@@ -2261,7 +2335,7 @@ CephBackupLocation
 </tr>
 <tr>
 <td>
-<code>volume</code></br>
+<code>volume</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumesource-v1-core">
 Kubernetes core/v1.VolumeSource
@@ -2276,7 +2350,7 @@ a shared host path for local testing.</p>
 </tr>
 <tr>
 <td>
-<code>volumeSubPath</code></br>
+<code>volumeSubPath</code><br>
 <em>
 string
 </em>
@@ -2288,7 +2362,7 @@ Only used for Volume-backed backup storage, ignored otherwise.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -2315,7 +2389,7 @@ that need access to this backup storage location.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -2329,7 +2403,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleSpec">
 VitessBackupScheduleSpec
@@ -2342,7 +2416,7 @@ VitessBackupScheduleSpec
 <table>
 <tr>
 <td>
-<code>VitessBackupScheduleTemplate</code></br>
+<code>VitessBackupScheduleTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleTemplate">
 VitessBackupScheduleTemplate
@@ -2359,7 +2433,7 @@ These are the parts that are configurable through the VitessCluster CRD.</p>
 </tr>
 <tr>
 <td>
-<code>cluster</code></br>
+<code>cluster</code><br>
 <em>
 string
 </em>
@@ -2370,7 +2444,7 @@ string
 </tr>
 <tr>
 <td>
-<code>image</code></br>
+<code>image</code><br>
 <em>
 string
 </em>
@@ -2382,7 +2456,7 @@ The controller will re-use the vtctld image by default.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicy</code></br>
+<code>imagePullPolicy</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -2399,7 +2473,7 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleStatus">
 VitessBackupScheduleStatus
@@ -2430,7 +2504,7 @@ VitessBackupScheduleStatus
 <tbody>
 <tr>
 <td>
-<code>VitessBackupScheduleTemplate</code></br>
+<code>VitessBackupScheduleTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleTemplate">
 VitessBackupScheduleTemplate
@@ -2447,7 +2521,7 @@ These are the parts that are configurable through the VitessCluster CRD.</p>
 </tr>
 <tr>
 <td>
-<code>cluster</code></br>
+<code>cluster</code><br>
 <em>
 string
 </em>
@@ -2458,7 +2532,7 @@ string
 </tr>
 <tr>
 <td>
-<code>image</code></br>
+<code>image</code><br>
 <em>
 string
 </em>
@@ -2470,7 +2544,7 @@ The controller will re-use the vtctld image by default.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicy</code></br>
+<code>imagePullPolicy</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -2503,7 +2577,7 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 <tbody>
 <tr>
 <td>
-<code>active</code></br>
+<code>active</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 []Kubernetes core/v1.ObjectReference
@@ -2517,7 +2591,7 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 </tr>
 <tr>
 <td>
-<code>lastScheduledTime</code></br>
+<code>lastScheduledTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -2552,7 +2626,7 @@ command line that will be executed in the Job&rsquo;s pod.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 <a href="#planetscale.com/v2.BackupStrategyName">
 BackupStrategyName
@@ -2565,7 +2639,7 @@ BackupStrategyName
 </tr>
 <tr>
 <td>
-<code>keyspace</code></br>
+<code>keyspace</code><br>
 <em>
 string
 </em>
@@ -2576,7 +2650,7 @@ string
 </tr>
 <tr>
 <td>
-<code>shard</code></br>
+<code>shard</code><br>
 <em>
 string
 </em>
@@ -2587,7 +2661,7 @@ string
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -2620,7 +2694,7 @@ able to define when writing their YAML file.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -2632,7 +2706,7 @@ objects in the cluster.</p>
 </tr>
 <tr>
 <td>
-<code>schedule</code></br>
+<code>schedule</code><br>
 <em>
 string
 </em>
@@ -2643,7 +2717,7 @@ string
 </tr>
 <tr>
 <td>
-<code>strategies</code></br>
+<code>strategies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleStrategy">
 []VitessBackupScheduleStrategy
@@ -2662,7 +2736,7 @@ is executed when the Job&rsquo;s container starts.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -2675,7 +2749,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>successfulJobsHistoryLimit</code></br>
+<code>successfulJobsHistoryLimit</code><br>
 <em>
 int32
 </em>
@@ -2687,7 +2761,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>failedJobsHistoryLimit</code></br>
+<code>failedJobsHistoryLimit</code><br>
 <em>
 int32
 </em>
@@ -2699,7 +2773,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>suspend</code></br>
+<code>suspend</code><br>
 <em>
 bool
 </em>
@@ -2713,7 +2787,7 @@ having to remove the entire VitessBackupSchedule object from the cluster.</p>
 </tr>
 <tr>
 <td>
-<code>startingDeadlineSeconds</code></br>
+<code>startingDeadlineSeconds</code><br>
 <em>
 int64
 </em>
@@ -2729,7 +2803,7 @@ the job will be processed as usual.</p>
 </tr>
 <tr>
 <td>
-<code>concurrencyPolicy</code></br>
+<code>concurrencyPolicy</code><br>
 <em>
 <a href="#planetscale.com/v2.ConcurrencyPolicy">
 ConcurrencyPolicy
@@ -2747,7 +2821,7 @@ Valid values are:
 </tr>
 <tr>
 <td>
-<code>allowedMissedRun</code></br>
+<code>allowedMissedRun</code><br>
 <em>
 int
 </em>
@@ -2766,7 +2840,7 @@ this field to its default value.</p>
 </tr>
 <tr>
 <td>
-<code>jobTimeoutMinute</code></br>
+<code>jobTimeoutMinute</code><br>
 <em>
 int32
 </em>
@@ -2779,7 +2853,7 @@ Default value is 10 minutes.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -2791,7 +2865,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -2835,7 +2909,7 @@ guarantee optimal scheduling of your pods if you choose to set this field.</p>
 <tbody>
 <tr>
 <td>
-<code>startTime</code></br>
+<code>startTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -2848,7 +2922,7 @@ Kubernetes meta/v1.Time
 </tr>
 <tr>
 <td>
-<code>finishedTime</code></br>
+<code>finishedTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -2861,7 +2935,7 @@ Kubernetes meta/v1.Time
 </tr>
 <tr>
 <td>
-<code>complete</code></br>
+<code>complete</code><br>
 <em>
 bool
 </em>
@@ -2872,7 +2946,7 @@ bool
 </tr>
 <tr>
 <td>
-<code>position</code></br>
+<code>position</code><br>
 <em>
 string
 </em>
@@ -2886,7 +2960,7 @@ This is only available after the backup is complete.</p>
 </tr>
 <tr>
 <td>
-<code>engine</code></br>
+<code>engine</code><br>
 <em>
 string
 </em>
@@ -2897,7 +2971,7 @@ string
 </tr>
 <tr>
 <td>
-<code>storageDirectory</code></br>
+<code>storageDirectory</code><br>
 <em>
 string
 </em>
@@ -2909,7 +2983,7 @@ contains this backup.</p>
 </tr>
 <tr>
 <td>
-<code>storageName</code></br>
+<code>storageName</code><br>
 <em>
 string
 </em>
@@ -2943,7 +3017,7 @@ cluster.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -2957,7 +3031,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupStorageSpec">
 VitessBackupStorageSpec
@@ -2970,7 +3044,7 @@ VitessBackupStorageSpec
 <table>
 <tr>
 <td>
-<code>location</code></br>
+<code>location</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 VitessBackupLocation
@@ -2984,7 +3058,7 @@ storage location.</p>
 </tr>
 <tr>
 <td>
-<code>subcontroller</code></br>
+<code>subcontroller</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupSubcontrollerSpec">
 VitessBackupSubcontrollerSpec
@@ -3000,7 +3074,7 @@ VitessBackupSubcontrollerSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupStorageStatus">
 VitessBackupStorageStatus
@@ -3031,7 +3105,7 @@ VitessBackupStorageStatus
 <tbody>
 <tr>
 <td>
-<code>location</code></br>
+<code>location</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 VitessBackupLocation
@@ -3045,7 +3119,7 @@ storage location.</p>
 </tr>
 <tr>
 <td>
-<code>subcontroller</code></br>
+<code>subcontroller</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupSubcontrollerSpec">
 VitessBackupSubcontrollerSpec
@@ -3077,7 +3151,7 @@ VitessBackupSubcontrollerSpec
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -3088,7 +3162,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>totalBackupCount</code></br>
+<code>totalBackupCount</code><br>
 <em>
 int32
 </em>
@@ -3119,7 +3193,7 @@ location, across all keyspaces and shards.</p>
 <tbody>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br>
 <em>
 string
 </em>
@@ -3155,7 +3229,7 @@ just like a Deployment can manage Pods that run on multiple Nodes.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -3169,7 +3243,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellSpec">
 VitessCellSpec
@@ -3182,7 +3256,7 @@ VitessCellSpec
 <table>
 <tr>
 <td>
-<code>VitessCellTemplate</code></br>
+<code>VitessCellTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellTemplate">
 VitessCellTemplate
@@ -3200,7 +3274,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -3213,7 +3287,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>allCells</code></br>
+<code>allCells</code><br>
 <em>
 []string
 </em>
@@ -3224,7 +3298,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellImages">
 VitessCellImages
@@ -3240,7 +3314,7 @@ controller that owns this VitessCell.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -3253,7 +3327,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -3266,7 +3340,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -3277,7 +3351,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -3293,7 +3367,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellStatus">
 VitessCellStatus
@@ -3324,7 +3398,7 @@ VitessCellStatus
 <tbody>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br>
 <em>
 int32
 </em>
@@ -3335,7 +3409,22 @@ int32
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>autoscaler</code><br>
+<em>
+<a href="#planetscale.com/v2.AutoscalerSpec">
+AutoscalerSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Autoscaler specifies the pod autoscaling configuration to use
+for the vtgate workload.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -3348,7 +3437,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>authentication</code></br>
+<code>authentication</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessGatewayAuthentication">
 VitessGatewayAuthentication
@@ -3361,7 +3450,7 @@ VitessGatewayAuthentication
 </tr>
 <tr>
 <td>
-<code>secureTransport</code></br>
+<code>secureTransport</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessGatewaySecureTransport">
 VitessGatewaySecureTransport
@@ -3374,7 +3463,7 @@ VitessGatewaySecureTransport
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -3389,7 +3478,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -3403,7 +3492,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -3420,7 +3509,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -3435,7 +3524,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -3449,7 +3538,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -3463,7 +3552,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -3479,7 +3568,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -3492,7 +3581,7 @@ Pods that the vtgate Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -3505,7 +3594,7 @@ Pods that the vtgate Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>service</code></br>
+<code>service</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -3518,7 +3607,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -3531,7 +3620,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>topologySpreadConstraints</code></br>
+<code>topologySpreadConstraints</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core">
 []Kubernetes core/v1.TopologySpreadConstraint
@@ -3545,7 +3634,7 @@ specify how to spread vtgate pods among the given topology</p>
 </tr>
 <tr>
 <td>
-<code>lifecycle</code></br>
+<code>lifecycle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lifecycle-v1-core">
 Kubernetes core/v1.Lifecycle
@@ -3559,7 +3648,7 @@ to the vtgate container.</p>
 </tr>
 <tr>
 <td>
-<code>terminationGracePeriodSeconds</code></br>
+<code>terminationGracePeriodSeconds</code><br>
 <em>
 int64
 </em>
@@ -3590,7 +3679,7 @@ terminationGracePeriodSeconds of the vtgate pod.</p>
 <tbody>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -3603,13 +3692,37 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br>
 <em>
 string
 </em>
 </td>
 <td>
 <p>ServiceName is the name of the Service for this cell&rsquo;s vtgate.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>labelSelector</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>LabelSelector is required by the Scale subresource, which is used by
+HorizontalPodAutoscaler when reading pod metrics.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicas</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas is required by the Scale subresource, which is used by
+HorizontalPodAutoscaler to determine the current number of replicas.</p>
 </td>
 </tr>
 </tbody>
@@ -3633,7 +3746,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>vtgate</code></br>
+<code>vtgate</code><br>
 <em>
 string
 </em>
@@ -3672,7 +3785,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>VitessCellTemplate</code></br>
+<code>VitessCellTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellTemplate">
 VitessCellTemplate
@@ -3690,7 +3803,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -3703,7 +3816,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>allCells</code></br>
+<code>allCells</code><br>
 <em>
 []string
 </em>
@@ -3714,7 +3827,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellImages">
 VitessCellImages
@@ -3730,7 +3843,7 @@ controller that owns this VitessCell.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -3743,7 +3856,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -3756,7 +3869,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -3767,7 +3880,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -3799,7 +3912,7 @@ TopoReconcileConfig
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -3810,7 +3923,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>lockserver</code></br>
+<code>lockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverStatus">
 LockserverStatus
@@ -3823,7 +3936,7 @@ LockserverStatus
 </tr>
 <tr>
 <td>
-<code>gateway</code></br>
+<code>gateway</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellGatewayStatus">
 VitessCellGatewayStatus
@@ -3836,7 +3949,7 @@ VitessCellGatewayStatus
 </tr>
 <tr>
 <td>
-<code>keyspaces</code></br>
+<code>keyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellKeyspaceStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessCellKeyspaceStatus
@@ -3853,7 +3966,7 @@ when the difference matters.</p>
 </tr>
 <tr>
 <td>
-<code>idle</code></br>
+<code>idle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -3888,7 +4001,7 @@ should be safe to turn down the cell.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -3901,7 +4014,7 @@ metadata.name, which is generated by the operator.</p>
 </tr>
 <tr>
 <td>
-<code>zone</code></br>
+<code>zone</code><br>
 <em>
 string
 </em>
@@ -3915,7 +4028,7 @@ If the Kubernetes Nodes don&rsquo;t have such a label, leave this empty.</p>
 </tr>
 <tr>
 <td>
-<code>lockserver</code></br>
+<code>lockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverSpec">
 LockserverSpec
@@ -3930,7 +4043,7 @@ Default: Put this cell&rsquo;s topology data in the global lockserver instead of
 </tr>
 <tr>
 <td>
-<code>gateway</code></br>
+<code>gateway</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellGatewaySpec">
 VitessCellGatewaySpec
@@ -3962,7 +4075,7 @@ VitessCellGatewaySpec
 <tbody>
 <tr>
 <td>
-<code>pendingChanges</code></br>
+<code>pendingChanges</code><br>
 <em>
 string
 </em>
@@ -3974,7 +4087,7 @@ applied the next time a rolling update allows.</p>
 </tr>
 <tr>
 <td>
-<code>gatewayAvailable</code></br>
+<code>gatewayAvailable</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -4006,7 +4119,7 @@ Kubernetes core/v1.ConditionStatus
 <tbody>
 <tr>
 <td>
-<code>pendingChanges</code></br>
+<code>pendingChanges</code><br>
 <em>
 string
 </em>
@@ -4018,7 +4131,7 @@ applied the next time a rolling update allows.</p>
 </tr>
 <tr>
 <td>
-<code>desiredShards</code></br>
+<code>desiredShards</code><br>
 <em>
 int32
 </em>
@@ -4032,7 +4145,7 @@ own.</p>
 </tr>
 <tr>
 <td>
-<code>shards</code></br>
+<code>shards</code><br>
 <em>
 int32
 </em>
@@ -4044,7 +4157,7 @@ than desiredShards if the state has not yet converged.</p>
 </tr>
 <tr>
 <td>
-<code>readyShards</code></br>
+<code>readyShards</code><br>
 <em>
 int32
 </em>
@@ -4055,7 +4168,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>updatedShards</code></br>
+<code>updatedShards</code><br>
 <em>
 int32
 </em>
@@ -4067,7 +4180,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>desiredTablets</code></br>
+<code>desiredTablets</code><br>
 <em>
 int32
 </em>
@@ -4081,7 +4194,7 @@ partitionings on their own.</p>
 </tr>
 <tr>
 <td>
-<code>tablets</code></br>
+<code>tablets</code><br>
 <em>
 int32
 </em>
@@ -4094,7 +4207,7 @@ yet converged.</p>
 </tr>
 <tr>
 <td>
-<code>readyTablets</code></br>
+<code>readyTablets</code><br>
 <em>
 int32
 </em>
@@ -4105,7 +4218,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>updatedTablets</code></br>
+<code>updatedTablets</code><br>
 <em>
 int32
 </em>
@@ -4117,7 +4230,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -4148,7 +4261,7 @@ are deployed.</p>
 <tbody>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImages">
 VitessImages
@@ -4163,7 +4276,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -4177,7 +4290,7 @@ images defined in the &lsquo;images&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -4191,7 +4304,7 @@ use the images defined in the &lsquo;images&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>backup</code></br>
+<code>backup</code><br>
 <em>
 <a href="#planetscale.com/v2.ClusterBackupSpec">
 ClusterBackupSpec
@@ -4207,7 +4320,7 @@ of a new tablet in a shard with existing data, as an implementation detail.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverSpec">
 LockserverSpec
@@ -4222,7 +4335,7 @@ Default: Deploy an etcd cluster as the global lockserver.</p>
 </tr>
 <tr>
 <td>
-<code>vitessDashboard</code></br>
+<code>vitessDashboard</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessDashboardSpec">
 VitessDashboardSpec
@@ -4235,7 +4348,7 @@ VitessDashboardSpec
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 <a href="#planetscale.com/v2.VtAdminSpec">
 VtAdminSpec
@@ -4248,7 +4361,7 @@ VtAdminSpec
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellTemplate">
 []VitessCellTemplate
@@ -4267,7 +4380,7 @@ that no keyspaces are set to deploy to this cell.</p>
 </tr>
 <tr>
 <td>
-<code>keyspaces</code></br>
+<code>keyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplate">
 []VitessKeyspaceTemplate
@@ -4285,7 +4398,7 @@ of target cells.</p>
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -4301,7 +4414,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -4314,7 +4427,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -4328,7 +4441,7 @@ when a revision is made to the VitessCluster spec.</p>
 </tr>
 <tr>
 <td>
-<code>gatewayService</code></br>
+<code>gatewayService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -4343,7 +4456,7 @@ definition.</p>
 </tr>
 <tr>
 <td>
-<code>tabletService</code></br>
+<code>tabletService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -4375,7 +4488,7 @@ ServiceOverrides
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -4386,7 +4499,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverStatus">
 LockserverStatus
@@ -4399,7 +4512,7 @@ LockserverStatus
 </tr>
 <tr>
 <td>
-<code>gatewayServiceName</code></br>
+<code>gatewayServiceName</code><br>
 <em>
 string
 </em>
@@ -4410,7 +4523,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vitessDashboard</code></br>
+<code>vitessDashboard</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessDashboardStatus">
 VitessDashboardStatus
@@ -4423,7 +4536,7 @@ VitessDashboardStatus
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 <a href="#planetscale.com/v2.VtadminStatus">
 VtadminStatus
@@ -4436,7 +4549,7 @@ VtadminStatus
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterCellStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessClusterCellStatus
@@ -4449,7 +4562,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessCluster
 </tr>
 <tr>
 <td>
-<code>keyspaces</code></br>
+<code>keyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterKeyspaceStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessClusterKeyspaceStatus
@@ -4462,7 +4575,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessCluster
 </tr>
 <tr>
 <td>
-<code>orphanedCells</code></br>
+<code>orphanedCells</code><br>
 <em>
 <a href="#planetscale.com/v2.OrphanStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
@@ -4475,7 +4588,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 </tr>
 <tr>
 <td>
-<code>orphanedKeyspaces</code></br>
+<code>orphanedKeyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.OrphanStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
@@ -4511,7 +4624,7 @@ necessary to perform the update for the indicated strategy.</p>
 <tbody>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategyType">
 VitessClusterUpdateStrategyType
@@ -4535,7 +4648,7 @@ planned reparents whenever possible to avoid master downtime.</li>
 </tr>
 <tr>
 <td>
-<code>external</code></br>
+<code>external</code><br>
 <em>
 <a href="#planetscale.com/v2.ExternalVitessClusterUpdateStrategyOptions">
 ExternalVitessClusterUpdateStrategyOptions
@@ -4578,7 +4691,7 @@ all possible update strategies for the VitessCluster.</p>
 <tbody>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -4591,7 +4704,7 @@ Default: Deploy to all defined cells.</p>
 </tr>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br>
 <em>
 int32
 </em>
@@ -4602,7 +4715,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -4615,7 +4728,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -4630,7 +4743,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -4644,7 +4757,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -4661,7 +4774,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -4676,7 +4789,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -4690,7 +4803,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -4704,7 +4817,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -4720,7 +4833,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -4733,7 +4846,7 @@ Pods that the vtctld Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -4746,7 +4859,7 @@ Pods that the vtctld Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>service</code></br>
+<code>service</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -4759,7 +4872,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -4791,7 +4904,7 @@ ServiceOverrides
 <tbody>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -4804,7 +4917,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br>
 <em>
 string
 </em>
@@ -4834,7 +4947,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>static</code></br>
+<code>static</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessGatewayStaticAuthentication">
 VitessGatewayStaticAuthentication
@@ -4866,7 +4979,7 @@ VitessGatewayStaticAuthentication
 <tbody>
 <tr>
 <td>
-<code>required</code></br>
+<code>required</code><br>
 <em>
 bool
 </em>
@@ -4879,7 +4992,7 @@ All GRPC transport is required to be encrypted when certs are set.</p>
 </tr>
 <tr>
 <td>
-<code>tls</code></br>
+<code>tls</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessGatewayTLSSecureTransport">
 VitessGatewayTLSSecureTransport
@@ -4911,7 +5024,7 @@ VitessGatewayTLSSecureTransport
 <tbody>
 <tr>
 <td>
-<code>secret</code></br>
+<code>secret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -4943,7 +5056,7 @@ SecretSource
 <tbody>
 <tr>
 <td>
-<code>clientCACertSecret</code></br>
+<code>clientCACertSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -4958,7 +5071,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>certSecret</code></br>
+<code>certSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -4971,7 +5084,7 @@ SecretSource
 </tr>
 <tr>
 <td>
-<code>keySecret</code></br>
+<code>keySecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -5006,7 +5119,7 @@ SecretSource
 <tbody>
 <tr>
 <td>
-<code>vtctld</code></br>
+<code>vtctld</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5019,7 +5132,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5032,7 +5145,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vtorc</code></br>
+<code>vtorc</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5045,7 +5158,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vtgate</code></br>
+<code>vtgate</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5058,7 +5171,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vttablet</code></br>
+<code>vttablet</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5071,7 +5184,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vtbackup</code></br>
+<code>vtbackup</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5084,7 +5197,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>mysqld</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5097,7 +5210,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>mysqldExporter</code></br>
+<code>mysqldExporter</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5129,7 +5242,7 @@ Kubernetes core/v1.PullPolicy
 <tbody>
 <tr>
 <td>
-<code>vtctld</code></br>
+<code>vtctld</code><br>
 <em>
 string
 </em>
@@ -5140,7 +5253,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 string
 </em>
@@ -5151,7 +5264,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtorc</code></br>
+<code>vtorc</code><br>
 <em>
 string
 </em>
@@ -5162,7 +5275,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtgate</code></br>
+<code>vtgate</code><br>
 <em>
 string
 </em>
@@ -5173,7 +5286,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vttablet</code></br>
+<code>vttablet</code><br>
 <em>
 string
 </em>
@@ -5184,7 +5297,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtbackup</code></br>
+<code>vtbackup</code><br>
 <em>
 string
 </em>
@@ -5195,7 +5308,7 @@ string
 </tr>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>mysqld</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldImage">
 MysqldImage
@@ -5211,7 +5324,7 @@ mysqld running alongside each tablet.</p>
 </tr>
 <tr>
 <td>
-<code>mysqldExporter</code></br>
+<code>mysqldExporter</code><br>
 <em>
 string
 </em>
@@ -5242,7 +5355,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>start</code></br>
+<code>start</code><br>
 <em>
 string
 </em>
@@ -5256,7 +5369,7 @@ than or equal to Start in lexicographical order to be in the range.</p>
 </tr>
 <tr>
 <td>
-<code>end</code></br>
+<code>end</code><br>
 <em>
 string
 </em>
@@ -5288,7 +5401,7 @@ various VitessCells.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -5302,7 +5415,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceSpec">
 VitessKeyspaceSpec
@@ -5315,7 +5428,7 @@ VitessKeyspaceSpec
 <table>
 <tr>
 <td>
-<code>VitessKeyspaceTemplate</code></br>
+<code>VitessKeyspaceTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplate">
 VitessKeyspaceTemplate
@@ -5333,7 +5446,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -5346,7 +5459,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceImages">
 VitessKeyspaceImages
@@ -5364,7 +5477,7 @@ images on VitessKeyspaceTemplate.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -5377,7 +5490,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -5390,7 +5503,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>zoneMap</code></br>
+<code>zoneMap</code><br>
 <em>
 map[string]string
 </em>
@@ -5402,7 +5515,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -5415,7 +5528,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>backupEngine</code></br>
+<code>backupEngine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -5428,7 +5541,7 @@ VitessBackupEngine
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -5439,7 +5552,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -5452,7 +5565,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -5468,7 +5581,7 @@ VitessClusterUpdateStrategy
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceStatus">
 VitessKeyspaceStatus
@@ -5499,7 +5612,7 @@ VitessKeyspaceStatus
 <tbody>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceConditionType">
 VitessKeyspaceConditionType
@@ -5512,7 +5625,7 @@ VitessKeyspaceConditionType
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -5526,7 +5639,7 @@ Can be True, False, Unknown.</p>
 </tr>
 <tr>
 <td>
-<code>lastTransitionTime</code></br>
+<code>lastTransitionTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -5540,7 +5653,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>reason</code></br>
+<code>reason</code><br>
 <em>
 string
 </em>
@@ -5552,7 +5665,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>message</code></br>
+<code>message</code><br>
 <em>
 string
 </em>
@@ -5593,7 +5706,7 @@ VitessKeyspaceConditionType and the value is a VitessKeyspaceCondition.</p>
 <tbody>
 <tr>
 <td>
-<code>shards</code></br>
+<code>shards</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceKeyRangeShard">
 []VitessKeyspaceKeyRangeShard
@@ -5625,7 +5738,7 @@ VitessKeyspaceConditionType and the value is a VitessKeyspaceCondition.</p>
 <tbody>
 <tr>
 <td>
-<code>parts</code></br>
+<code>parts</code><br>
 <em>
 int32
 </em>
@@ -5644,7 +5757,7 @@ migration, and then remove the old partitioning.</p>
 </tr>
 <tr>
 <td>
-<code>shardTemplate</code></br>
+<code>shardTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTemplate">
 VitessShardTemplate
@@ -5679,7 +5792,7 @@ use custom partitioning instead.</p>
 <tbody>
 <tr>
 <td>
-<code>vttablet</code></br>
+<code>vttablet</code><br>
 <em>
 string
 </em>
@@ -5690,7 +5803,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtorc</code></br>
+<code>vtorc</code><br>
 <em>
 string
 </em>
@@ -5701,7 +5814,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtbackup</code></br>
+<code>vtbackup</code><br>
 <em>
 string
 </em>
@@ -5712,7 +5825,7 @@ string
 </tr>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>mysqld</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldImage">
 MysqldImage
@@ -5728,7 +5841,7 @@ mysqld running alongside each tablet.</p>
 </tr>
 <tr>
 <td>
-<code>mysqldExporter</code></br>
+<code>mysqldExporter</code><br>
 <em>
 string
 </em>
@@ -5758,7 +5871,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>keyRange</code></br>
+<code>keyRange</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyRange">
 VitessKeyRange
@@ -5776,7 +5889,7 @@ migration, and then remove the old partitioning.</p>
 </tr>
 <tr>
 <td>
-<code>VitessShardTemplate</code></br>
+<code>VitessShardTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTemplate">
 VitessShardTemplate
@@ -5813,7 +5926,7 @@ a given partitioning.</p>
 <tbody>
 <tr>
 <td>
-<code>equal</code></br>
+<code>equal</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceEqualPartitioning">
 VitessKeyspaceEqualPartitioning
@@ -5828,7 +5941,7 @@ because they&rsquo;re generated by a hash vindex.</p>
 </tr>
 <tr>
 <td>
-<code>custom</code></br>
+<code>custom</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceCustomPartitioning">
 VitessKeyspaceCustomPartitioning
@@ -5861,7 +5974,7 @@ in case you don&rsquo;t want them to be divided equally.</p>
 <tbody>
 <tr>
 <td>
-<code>shardNames</code></br>
+<code>shardNames</code><br>
 <em>
 []string
 </em>
@@ -5873,7 +5986,7 @@ in the format Vitess uses for shard names.</p>
 </tr>
 <tr>
 <td>
-<code>servingWrites</code></br>
+<code>servingWrites</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -5890,7 +6003,7 @@ Check the per-shard status for full details.</p>
 </tr>
 <tr>
 <td>
-<code>desiredTablets</code></br>
+<code>desiredTablets</code><br>
 <em>
 int32
 </em>
@@ -5904,7 +6017,7 @@ own.</p>
 </tr>
 <tr>
 <td>
-<code>tablets</code></br>
+<code>tablets</code><br>
 <em>
 int32
 </em>
@@ -5916,7 +6029,7 @@ lower than desiredTablets if the state has not yet converged.</p>
 </tr>
 <tr>
 <td>
-<code>readyTablets</code></br>
+<code>readyTablets</code><br>
 <em>
 int32
 </em>
@@ -5927,7 +6040,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>updatedTablets</code></br>
+<code>updatedTablets</code><br>
 <em>
 int32
 </em>
@@ -5939,7 +6052,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>desiredShards</code></br>
+<code>desiredShards</code><br>
 <em>
 int32
 </em>
@@ -5953,7 +6066,7 @@ own.</p>
 </tr>
 <tr>
 <td>
-<code>readyShards</code></br>
+<code>readyShards</code><br>
 <em>
 int32
 </em>
@@ -5983,7 +6096,7 @@ int32
 <tbody>
 <tr>
 <td>
-<code>hasMaster</code></br>
+<code>hasMaster</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -5997,7 +6110,7 @@ reflects a master for this shard.</p>
 </tr>
 <tr>
 <td>
-<code>servingWrites</code></br>
+<code>servingWrites</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -6013,7 +6126,7 @@ the target of a resharding operation that is still in progress.</p>
 </tr>
 <tr>
 <td>
-<code>desiredTablets</code></br>
+<code>desiredTablets</code><br>
 <em>
 int32
 </em>
@@ -6027,7 +6140,7 @@ own.</p>
 </tr>
 <tr>
 <td>
-<code>tablets</code></br>
+<code>tablets</code><br>
 <em>
 int32
 </em>
@@ -6039,7 +6152,7 @@ lower than desiredTablets if the state has not yet converged.</p>
 </tr>
 <tr>
 <td>
-<code>readyTablets</code></br>
+<code>readyTablets</code><br>
 <em>
 int32
 </em>
@@ -6050,7 +6163,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>updatedTablets</code></br>
+<code>updatedTablets</code><br>
 <em>
 int32
 </em>
@@ -6062,7 +6175,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>pendingChanges</code></br>
+<code>pendingChanges</code><br>
 <em>
 string
 </em>
@@ -6074,7 +6187,7 @@ the next time a rolling update allows.</p>
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -6104,7 +6217,7 @@ the next time a rolling update allows.</p>
 <tbody>
 <tr>
 <td>
-<code>VitessKeyspaceTemplate</code></br>
+<code>VitessKeyspaceTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplate">
 VitessKeyspaceTemplate
@@ -6122,7 +6235,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -6135,7 +6248,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceImages">
 VitessKeyspaceImages
@@ -6153,7 +6266,7 @@ images on VitessKeyspaceTemplate.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -6166,7 +6279,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -6179,7 +6292,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>zoneMap</code></br>
+<code>zoneMap</code><br>
 <em>
 map[string]string
 </em>
@@ -6191,7 +6304,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -6204,7 +6317,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>backupEngine</code></br>
+<code>backupEngine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -6217,7 +6330,7 @@ VitessBackupEngine
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -6228,7 +6341,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -6241,7 +6354,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -6273,7 +6386,7 @@ VitessClusterUpdateStrategy
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -6284,7 +6397,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>shards</code></br>
+<code>shards</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceShardStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspaceShardStatus
@@ -6297,7 +6410,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspac
 </tr>
 <tr>
 <td>
-<code>partitionings</code></br>
+<code>partitionings</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspacePartitioningStatus">
 []VitessKeyspacePartitioningStatus
@@ -6310,7 +6423,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspac
 </tr>
 <tr>
 <td>
-<code>orphanedShards</code></br>
+<code>orphanedShards</code><br>
 <em>
 <a href="#planetscale.com/v2.OrphanStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
@@ -6323,7 +6436,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 </tr>
 <tr>
 <td>
-<code>idle</code></br>
+<code>idle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -6338,7 +6451,7 @@ be safe to turn down the keyspace.</p>
 </tr>
 <tr>
 <td>
-<code>resharding</code></br>
+<code>resharding</code><br>
 <em>
 <a href="#planetscale.com/v2.ReshardingStatus">
 ReshardingStatus
@@ -6353,7 +6466,7 @@ it means the operator was unable to query resharding status from Vitess.</p>
 </tr>
 <tr>
 <td>
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceCondition">
 []VitessKeyspaceCondition
@@ -6387,7 +6500,7 @@ It&rsquo;s ok for multiple controllers to add conditions here, and those conditi
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -6403,7 +6516,7 @@ instruction to delete the old keyspace and create a new one.</p>
 </tr>
 <tr>
 <td>
-<code>databaseName</code></br>
+<code>databaseName</code><br>
 <em>
 string
 </em>
@@ -6424,7 +6537,7 @@ this to be the same as the keyspace name to reduce confusion.</p>
 </tr>
 <tr>
 <td>
-<code>durabilityPolicy</code></br>
+<code>durabilityPolicy</code><br>
 <em>
 string
 </em>
@@ -6436,7 +6549,7 @@ If unspecified, vtop will not set the durability policy.</p>
 </tr>
 <tr>
 <td>
-<code>vitessOrchestrator</code></br>
+<code>vitessOrchestrator</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessOrchestratorSpec">
 VitessOrchestratorSpec
@@ -6451,7 +6564,7 @@ for the vttablets if enabling vtorc.</p>
 </tr>
 <tr>
 <td>
-<code>partitionings</code></br>
+<code>partitionings</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspacePartitioning">
 []VitessKeyspacePartitioning
@@ -6487,7 +6600,7 @@ partitioning into 1 part.</p>
 </tr>
 <tr>
 <td>
-<code>turndownPolicy</code></br>
+<code>turndownPolicy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTurndownPolicy">
 VitessKeyspaceTurndownPolicy
@@ -6515,7 +6628,7 @@ you can set the policy to Immediate to skip these checks.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -6526,7 +6639,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplateImages">
 VitessKeyspaceTemplateImages
@@ -6549,7 +6662,18 @@ operation, after which the source keyspace is destroyed.</p>
 </p>
 <p>
 <p>VitessKeyspaceTemplateImages specifies user-definable container images to
-use for this keyspace.</p>
+use for this keyspace. The images defined here by the user will override
+those defined at the top-level in VitessCluster.spec.images.</p>
+<p>While this field allows you to set a different Vitess version for some
+components than the version defined at the top level, it is important to
+note that Vitess only ensures compatibility between one version and the
+next and previous one. For instance: N is only guaranteed  to be compatible
+with N+1 and N-1. Do be careful when specifying multiple versions across
+your cluster so that they respect this compatibility rule.</p>
+<p>Note: this structure is a copy of VitessKeyspaceImages, once we have gotten
+rid of MysqldImage and replaced it by MysqldImageNew (planned for v2.15), we
+should be able to remove VitessKeyspaceTemplateImages entirely and just use
+VitessKeyspaceImages instead as it contains exactly the same fields.</p>
 </p>
 <table class="table table-striped">
 <thead class="thead-dark">
@@ -6561,7 +6685,40 @@ use for this keyspace.</p>
 <tbody>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>vttablet</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Vttablet is the container image (including version tag) to use for Vitess Tablet instances.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vtorc</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Vtorc is the container image (including version tag) to use for Vitess Orchestrator instances.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vtbackup</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Vtbackup is the container image (including version tag) to use for Vitess Backup jobs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mysqld</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldImageNew">
 MysqldImageNew
@@ -6573,6 +6730,17 @@ MysqldImageNew
 declaring which MySQL flavor setting in Vitess the image is
 compatible with. Only one flavor image may be provided at a time.
 mysqld running alongside each tablet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mysqldExporter</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>MysqldExporter specifies the container image for mysqld-exporter.</p>
 </td>
 </tr>
 </tbody>
@@ -6609,7 +6777,7 @@ to connect to a given lockserver.</p>
 <tbody>
 <tr>
 <td>
-<code>implementation</code></br>
+<code>implementation</code><br>
 <em>
 string
 </em>
@@ -6620,7 +6788,7 @@ string
 </tr>
 <tr>
 <td>
-<code>address</code></br>
+<code>address</code><br>
 <em>
 string
 </em>
@@ -6631,7 +6799,7 @@ string
 </tr>
 <tr>
 <td>
-<code>rootPath</code></br>
+<code>rootPath</code><br>
 <em>
 string
 </em>
@@ -6663,7 +6831,7 @@ Multiple Vitess clusters can share a lockserver as long as they have unique root
 <tbody>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -6676,7 +6844,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -6691,7 +6859,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -6705,7 +6873,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -6722,7 +6890,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -6737,7 +6905,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -6751,7 +6919,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -6765,7 +6933,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -6781,7 +6949,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -6794,7 +6962,7 @@ Pods that the vtorc Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -6807,7 +6975,7 @@ Pods that the vtorc Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>service</code></br>
+<code>service</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -6820,7 +6988,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -6852,7 +7020,7 @@ ServiceOverrides
 <tbody>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -6865,7 +7033,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br>
 <em>
 string
 </em>
@@ -6895,7 +7063,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>initializeMaster</code></br>
+<code>initializeMaster</code><br>
 <em>
 bool
 </em>
@@ -6908,7 +7076,7 @@ new or restored shard that has no master yet.</p>
 </tr>
 <tr>
 <td>
-<code>initializeBackup</code></br>
+<code>initializeBackup</code><br>
 <em>
 bool
 </em>
@@ -6922,7 +7090,7 @@ if a backup location is defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>recoverRestartedMaster</code></br>
+<code>recoverRestartedMaster</code><br>
 <em>
 bool
 </em>
@@ -6956,7 +7124,7 @@ for that shard.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -6970,7 +7138,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardSpec">
 VitessShardSpec
@@ -6983,7 +7151,7 @@ VitessShardSpec
 <table>
 <tr>
 <td>
-<code>VitessShardTemplate</code></br>
+<code>VitessShardTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTemplate">
 VitessShardTemplate
@@ -7001,7 +7169,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -7012,7 +7180,7 @@ string
 </tr>
 <tr>
 <td>
-<code>databaseName</code></br>
+<code>databaseName</code><br>
 <em>
 string
 </em>
@@ -7025,7 +7193,7 @@ the keyspace level.</p>
 </tr>
 <tr>
 <td>
-<code>zoneMap</code></br>
+<code>zoneMap</code><br>
 <em>
 map[string]string
 </em>
@@ -7037,7 +7205,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceImages">
 VitessKeyspaceImages
@@ -7053,7 +7221,7 @@ controller that owns this VitessShard.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -7066,7 +7234,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -7079,7 +7247,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>keyRange</code></br>
+<code>keyRange</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyRange">
 VitessKeyRange
@@ -7092,7 +7260,7 @@ VitessKeyRange
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -7105,7 +7273,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>vitessOrchestrator</code></br>
+<code>vitessOrchestrator</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessOrchestratorSpec">
 VitessOrchestratorSpec
@@ -7118,7 +7286,7 @@ VitessOrchestratorSpec
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -7131,7 +7299,7 @@ VitessOrchestratorSpec
 </tr>
 <tr>
 <td>
-<code>backupEngine</code></br>
+<code>backupEngine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -7144,7 +7312,7 @@ VitessBackupEngine
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -7155,7 +7323,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -7168,7 +7336,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -7184,7 +7352,7 @@ VitessClusterUpdateStrategy
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardStatus">
 VitessShardStatus
@@ -7215,7 +7383,7 @@ VitessShardStatus
 <tbody>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7229,7 +7397,7 @@ Can be True, False, Unknown.</p>
 </tr>
 <tr>
 <td>
-<code>lastTransitionTime</code></br>
+<code>lastTransitionTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -7243,7 +7411,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>reason</code></br>
+<code>reason</code><br>
 <em>
 string
 </em>
@@ -7255,7 +7423,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>message</code></br>
+<code>message</code><br>
 <em>
 string
 </em>
@@ -7292,7 +7460,7 @@ VitessShardConditionType and the value is a VitessShardCondition.</p>
 <tbody>
 <tr>
 <td>
-<code>VitessShardTemplate</code></br>
+<code>VitessShardTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTemplate">
 VitessShardTemplate
@@ -7310,7 +7478,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -7321,7 +7489,7 @@ string
 </tr>
 <tr>
 <td>
-<code>databaseName</code></br>
+<code>databaseName</code><br>
 <em>
 string
 </em>
@@ -7334,7 +7502,7 @@ the keyspace level.</p>
 </tr>
 <tr>
 <td>
-<code>zoneMap</code></br>
+<code>zoneMap</code><br>
 <em>
 map[string]string
 </em>
@@ -7346,7 +7514,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceImages">
 VitessKeyspaceImages
@@ -7362,7 +7530,7 @@ controller that owns this VitessShard.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -7375,7 +7543,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -7388,7 +7556,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>keyRange</code></br>
+<code>keyRange</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyRange">
 VitessKeyRange
@@ -7401,7 +7569,7 @@ VitessKeyRange
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -7414,7 +7582,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>vitessOrchestrator</code></br>
+<code>vitessOrchestrator</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessOrchestratorSpec">
 VitessOrchestratorSpec
@@ -7427,7 +7595,7 @@ VitessOrchestratorSpec
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -7440,7 +7608,7 @@ VitessOrchestratorSpec
 </tr>
 <tr>
 <td>
-<code>backupEngine</code></br>
+<code>backupEngine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -7453,7 +7621,7 @@ VitessBackupEngine
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -7464,7 +7632,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -7477,7 +7645,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -7509,7 +7677,7 @@ VitessClusterUpdateStrategy
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -7520,7 +7688,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>tablets</code></br>
+<code>tablets</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessTabletStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessTabletStatus
@@ -7533,7 +7701,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessTabletS
 </tr>
 <tr>
 <td>
-<code>orphanedTablets</code></br>
+<code>orphanedTablets</code><br>
 <em>
 <a href="#planetscale.com/v2.OrphanStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
@@ -7546,7 +7714,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -7557,7 +7725,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 </tr>
 <tr>
 <td>
-<code>vitessOrchestrator</code></br>
+<code>vitessOrchestrator</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessOrchestratorStatus">
 VitessOrchestratorStatus
@@ -7570,7 +7738,7 @@ VitessOrchestratorStatus
 </tr>
 <tr>
 <td>
-<code>hasMaster</code></br>
+<code>hasMaster</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7584,7 +7752,7 @@ reflects a master for this shard.</p>
 </tr>
 <tr>
 <td>
-<code>hasInitialBackup</code></br>
+<code>hasInitialBackup</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7598,7 +7766,7 @@ has been seeded for the shard.</p>
 </tr>
 <tr>
 <td>
-<code>servingWrites</code></br>
+<code>servingWrites</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7614,7 +7782,7 @@ the target of a resharding operation that is still in progress.</p>
 </tr>
 <tr>
 <td>
-<code>idle</code></br>
+<code>idle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7630,7 +7798,7 @@ to turn down the shard.</p>
 </tr>
 <tr>
 <td>
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardCondition">
 map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardCondition
@@ -7644,7 +7812,7 @@ It&rsquo;s ok for multiple controllers to add conditions here, and those conditi
 </tr>
 <tr>
 <td>
-<code>masterAlias</code></br>
+<code>masterAlias</code><br>
 <em>
 string
 </em>
@@ -7658,7 +7826,7 @@ condition whenever the distinction is important.</p>
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.*planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.ShardBackupLocationStatus">
 []ShardBackupLocationStatus
@@ -7672,7 +7840,7 @@ each backup location.</p>
 </tr>
 <tr>
 <td>
-<code>lowestPodGeneration</code></br>
+<code>lowestPodGeneration</code><br>
 <em>
 int64
 </em>
@@ -7705,7 +7873,7 @@ subsequent generations that affect tablets may not be reflected in status yet.</
 <tbody>
 <tr>
 <td>
-<code>cell</code></br>
+<code>cell</code><br>
 <em>
 string
 </em>
@@ -7716,7 +7884,7 @@ string
 </tr>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessTabletPoolType">
 VitessTabletPoolType
@@ -7737,7 +7905,7 @@ VitessTabletPoolType
 </tr>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -7752,7 +7920,7 @@ Hence, you must specify ExternalDatastore when assigning a name to this field.</
 </tr>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br>
 <em>
 int32
 </em>
@@ -7765,7 +7933,7 @@ which will scale the pool down to 0 tablets.</p>
 </tr>
 <tr>
 <td>
-<code>dataVolumeClaimTemplate</code></br>
+<code>dataVolumeClaimTemplate</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#persistentvolumeclaimspec-v1-core">
 Kubernetes core/v1.PersistentVolumeClaimSpec
@@ -7784,7 +7952,7 @@ is set on the StorageClass specified in the storageClassName field here.</p>
 </tr>
 <tr>
 <td>
-<code>backupLocationName</code></br>
+<code>backupLocationName</code><br>
 <em>
 string
 </em>
@@ -7798,7 +7966,7 @@ Default: Use the backup location whose name is empty.</p>
 </tr>
 <tr>
 <td>
-<code>vttablet</code></br>
+<code>vttablet</code><br>
 <em>
 <a href="#planetscale.com/v2.VttabletSpec">
 VttabletSpec
@@ -7811,7 +7979,7 @@ VttabletSpec
 </tr>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>mysqld</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldSpec">
 MysqldSpec
@@ -7825,7 +7993,7 @@ You must specify either Mysqld or ExternalDatastore, but not both.</p>
 </tr>
 <tr>
 <td>
-<code>mysqldExporter</code></br>
+<code>mysqldExporter</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldExporterSpec">
 MysqldExporterSpec
@@ -7838,7 +8006,7 @@ MysqldExporterSpec
 </tr>
 <tr>
 <td>
-<code>externalDatastore</code></br>
+<code>externalDatastore</code><br>
 <em>
 <a href="#planetscale.com/v2.ExternalDatastore">
 ExternalDatastore
@@ -7852,7 +8020,7 @@ You must specify either Mysqld or ExternalDatastore, but not both.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -7869,7 +8037,7 @@ optimal scheduling of your pods if you choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -7881,7 +8049,7 @@ created for this component.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -7893,7 +8061,7 @@ created for this component.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -7908,7 +8076,7 @@ These values are applied to both the vttablet and mysqld containers.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -7926,7 +8094,7 @@ These volumes are available to be mounted by both vttablet and mysqld.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -7942,7 +8110,7 @@ These values are applied to both the vttablet and mysqld containers.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -7956,7 +8124,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -7970,7 +8138,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -7983,7 +8151,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>topologySpreadConstraints</code></br>
+<code>topologySpreadConstraints</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core">
 []Kubernetes core/v1.TopologySpreadConstraint
@@ -8018,7 +8186,7 @@ specify how to spread vttablet pods among the given topology</p>
 <tbody>
 <tr>
 <td>
-<code>tabletPools</code></br>
+<code>tabletPools</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTabletPool">
 []VitessShardTabletPool
@@ -8035,7 +8203,7 @@ in order to be able to serve.</p>
 </tr>
 <tr>
 <td>
-<code>databaseInitScriptSecret</code></br>
+<code>databaseInitScriptSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -8050,7 +8218,7 @@ to set up initial tables and other MySQL-level entities needed by Vitess.</p>
 </tr>
 <tr>
 <td>
-<code>replication</code></br>
+<code>replication</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessReplicationSpec">
 VitessReplicationSpec
@@ -8063,7 +8231,7 @@ VitessReplicationSpec
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -8104,7 +8272,7 @@ transient states are not valid pool types.</p>
 <tbody>
 <tr>
 <td>
-<code>poolType</code></br>
+<code>poolType</code><br>
 <em>
 string
 </em>
@@ -8115,7 +8283,7 @@ string
 </tr>
 <tr>
 <td>
-<code>index</code></br>
+<code>index</code><br>
 <em>
 int32
 </em>
@@ -8126,7 +8294,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>running</code></br>
+<code>running</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8139,7 +8307,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8153,7 +8321,7 @@ meaning it&rsquo;s ready to serve queries.</p>
 </tr>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8167,7 +8335,7 @@ for long enough to be considered stable.</p>
 </tr>
 <tr>
 <td>
-<code>dataVolumeBound</code></br>
+<code>dataVolumeBound</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8181,7 +8349,7 @@ matched up with a PersistentVolume and bound to it.</p>
 </tr>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br>
 <em>
 string
 </em>
@@ -8192,7 +8360,7 @@ string
 </tr>
 <tr>
 <td>
-<code>pendingChanges</code></br>
+<code>pendingChanges</code><br>
 <em>
 string
 </em>
@@ -8223,7 +8391,7 @@ the next time a rolling update allows.</p>
 <tbody>
 <tr>
 <td>
-<code>rbac</code></br>
+<code>rbac</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -8237,7 +8405,7 @@ If it is omitted, then it is considered to disable rbac.</p>
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -8250,7 +8418,7 @@ Default: Deploy to all defined cells.</p>
 </tr>
 <tr>
 <td>
-<code>apiAddresses</code></br>
+<code>apiAddresses</code><br>
 <em>
 []string
 </em>
@@ -8265,7 +8433,7 @@ or it should match the length of the Cells list</p>
 </tr>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br>
 <em>
 int32
 </em>
@@ -8276,7 +8444,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>webResources</code></br>
+<code>webResources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -8289,7 +8457,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>apiResources</code></br>
+<code>apiResources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -8302,7 +8470,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>readOnly</code></br>
+<code>readOnly</code><br>
 <em>
 bool
 </em>
@@ -8315,7 +8483,7 @@ or should it allow users to take actions</p>
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -8330,7 +8498,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -8344,7 +8512,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -8361,7 +8529,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -8376,7 +8544,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -8390,7 +8558,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -8404,7 +8572,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -8420,7 +8588,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -8433,7 +8601,7 @@ Pods that the vtadmin Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -8446,7 +8614,7 @@ Pods that the vtadmin Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>service</code></br>
+<code>service</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -8459,7 +8627,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -8491,7 +8659,7 @@ ServiceOverrides
 <tbody>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8504,7 +8672,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br>
 <em>
 string
 </em>
@@ -8534,7 +8702,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -8549,7 +8717,7 @@ This field is required.</p>
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -8564,7 +8732,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>lifecycle</code></br>
+<code>lifecycle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lifecycle-v1-core">
 Kubernetes core/v1.Lifecycle
@@ -8578,7 +8746,7 @@ to vttablet container</p>
 </tr>
 <tr>
 <td>
-<code>terminationGracePeriodSeconds</code></br>
+<code>terminationGracePeriodSeconds</code><br>
 <em>
 int64
 </em>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -49,7 +49,7 @@ consistency model that Vitess expects of a lockserver.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -59,14 +59,14 @@ planetscale.com/v2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>EtcdLockserver</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -80,7 +80,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverSpec">
 EtcdLockserverSpec
@@ -93,7 +93,7 @@ EtcdLockserverSpec
 <table>
 <tr>
 <td>
-<code>EtcdLockserverTemplate</code></br>
+<code>EtcdLockserverTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverTemplate">
 EtcdLockserverTemplate
@@ -111,7 +111,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>zone</code></br>
+<code>zone</code><br>
 <em>
 string
 </em>
@@ -128,7 +128,7 @@ If the Kubernetes Nodes don&rsquo;t have such a label, leave this empty.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverStatus">
 EtcdLockserverStatus
@@ -158,7 +158,7 @@ the storage location will be represented by its own VitessBackup object.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -168,14 +168,14 @@ planetscale.com/v2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>VitessBackup</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -189,7 +189,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupSpec">
 VitessBackupSpec
@@ -205,7 +205,7 @@ VitessBackupSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupStatus">
 VitessBackupStatus
@@ -239,7 +239,7 @@ the VitessCluster object.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -249,14 +249,14 @@ planetscale.com/v2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>VitessCluster</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -270,7 +270,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterSpec">
 VitessClusterSpec
@@ -283,7 +283,7 @@ VitessClusterSpec
 <table>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImages">
 VitessImages
@@ -298,7 +298,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -312,7 +312,7 @@ images defined in the &lsquo;images&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -326,7 +326,7 @@ use the images defined in the &lsquo;images&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>backup</code></br>
+<code>backup</code><br>
 <em>
 <a href="#planetscale.com/v2.ClusterBackupSpec">
 ClusterBackupSpec
@@ -342,7 +342,7 @@ of a new tablet in a shard with existing data, as an implementation detail.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverSpec">
 LockserverSpec
@@ -357,7 +357,7 @@ Default: Deploy an etcd cluster as the global lockserver.</p>
 </tr>
 <tr>
 <td>
-<code>vitessDashboard</code></br>
+<code>vitessDashboard</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessDashboardSpec">
 VitessDashboardSpec
@@ -370,7 +370,7 @@ VitessDashboardSpec
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 <a href="#planetscale.com/v2.VtAdminSpec">
 VtAdminSpec
@@ -383,7 +383,7 @@ VtAdminSpec
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellTemplate">
 []VitessCellTemplate
@@ -402,7 +402,7 @@ that no keyspaces are set to deploy to this cell.</p>
 </tr>
 <tr>
 <td>
-<code>keyspaces</code></br>
+<code>keyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplate">
 []VitessKeyspaceTemplate
@@ -420,7 +420,7 @@ of target cells.</p>
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -436,7 +436,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -449,7 +449,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -463,7 +463,7 @@ when a revision is made to the VitessCluster spec.</p>
 </tr>
 <tr>
 <td>
-<code>gatewayService</code></br>
+<code>gatewayService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -478,7 +478,7 @@ definition.</p>
 </tr>
 <tr>
 <td>
-<code>tabletService</code></br>
+<code>tabletService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -494,7 +494,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterStatus">
 VitessClusterStatus
@@ -525,7 +525,7 @@ VitessClusterStatus
 <tbody>
 <tr>
 <td>
-<code>minReplicas</code></br>
+<code>minReplicas</code><br>
 <em>
 int32
 </em>
@@ -538,7 +538,7 @@ this cell when autoscaling is enabled.</p>
 </tr>
 <tr>
 <td>
-<code>maxReplicas</code></br>
+<code>maxReplicas</code><br>
 <em>
 int32
 </em>
@@ -550,7 +550,7 @@ this cell when autoscaling is enabled.</p>
 </tr>
 <tr>
 <td>
-<code>metrics</code></br>
+<code>metrics</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#metricspec-v2-autoscaling">
 []Kubernetes autoscaling/v2.MetricSpec
@@ -566,7 +566,7 @@ Use TargetCPUUtilization or TargetMemoryUtilization instead if scaling on these 
 </tr>
 <tr>
 <td>
-<code>behavior</code></br>
+<code>behavior</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#horizontalpodautoscalerbehavior-v2-autoscaling">
 Kubernetes autoscaling/v2.HorizontalPodAutoscalerBehavior
@@ -599,7 +599,7 @@ Kubernetes autoscaling/v2.HorizontalPodAutoscalerBehavior
 <tbody>
 <tr>
 <td>
-<code>account</code></br>
+<code>account</code><br>
 <em>
 string
 </em>
@@ -610,7 +610,7 @@ string
 </tr>
 <tr>
 <td>
-<code>container</code></br>
+<code>container</code><br>
 <em>
 string
 </em>
@@ -621,7 +621,7 @@ string
 </tr>
 <tr>
 <td>
-<code>keyPrefix</code></br>
+<code>keyPrefix</code><br>
 <em>
 string
 </em>
@@ -636,7 +636,7 @@ within a container, regardless of this setting.</p>
 </tr>
 <tr>
 <td>
-<code>authSecret</code></br>
+<code>authSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -678,7 +678,7 @@ When scheduling a backup, you must specify at least one strategy.</p>
 <tbody>
 <tr>
 <td>
-<code>authSecret</code></br>
+<code>authSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -714,7 +714,7 @@ provisioning of a new tablet in a shard with existing data, as an implementation
 <tbody>
 <tr>
 <td>
-<code>locations</code></br>
+<code>locations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -734,7 +734,7 @@ were originally taken.</p>
 </tr>
 <tr>
 <td>
-<code>engine</code></br>
+<code>engine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -752,7 +752,7 @@ Default: builtin</p>
 </tr>
 <tr>
 <td>
-<code>subcontroller</code></br>
+<code>subcontroller</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupSubcontrollerSpec">
 VitessBackupSubcontrollerSpec
@@ -765,7 +765,7 @@ VitessBackupSubcontrollerSpec
 </tr>
 <tr>
 <td>
-<code>schedules</code></br>
+<code>schedules</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleTemplate">
 []VitessBackupScheduleTemplate
@@ -809,7 +809,7 @@ is handled, the default is set to AllowConcurrent.</p>
 <tbody>
 <tr>
 <td>
-<code>EtcdLockserverTemplate</code></br>
+<code>EtcdLockserverTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverTemplate">
 EtcdLockserverTemplate
@@ -827,7 +827,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>zone</code></br>
+<code>zone</code><br>
 <em>
 string
 </em>
@@ -861,7 +861,7 @@ If the Kubernetes Nodes don&rsquo;t have such a label, leave this empty.</p>
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -872,7 +872,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -885,7 +885,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>clientServiceName</code></br>
+<code>clientServiceName</code><br>
 <em>
 string
 </em>
@@ -918,7 +918,7 @@ lockserver.</p>
 <tbody>
 <tr>
 <td>
-<code>image</code></br>
+<code>image</code><br>
 <em>
 string
 </em>
@@ -930,7 +930,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicy</code></br>
+<code>imagePullPolicy</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -943,7 +943,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -957,7 +957,7 @@ etcd Pods.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -971,7 +971,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>dataVolumeClaimTemplate</code></br>
+<code>dataVolumeClaimTemplate</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#persistentvolumeclaimspec-v1-core">
 Kubernetes core/v1.PersistentVolumeClaimSpec
@@ -990,7 +990,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -1005,7 +1005,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -1019,7 +1019,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -1036,7 +1036,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -1051,7 +1051,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -1065,7 +1065,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -1079,7 +1079,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -1095,7 +1095,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -1107,7 +1107,7 @@ created for this component.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -1119,7 +1119,7 @@ created for this component.</p>
 </tr>
 <tr>
 <td>
-<code>createPDB</code></br>
+<code>createPDB</code><br>
 <em>
 bool
 </em>
@@ -1133,7 +1133,7 @@ member Pods.</p>
 </tr>
 <tr>
 <td>
-<code>createClientService</code></br>
+<code>createClientService</code><br>
 <em>
 bool
 </em>
@@ -1147,7 +1147,7 @@ of etcd member Pods.</p>
 </tr>
 <tr>
 <td>
-<code>createPeerService</code></br>
+<code>createPeerService</code><br>
 <em>
 bool
 </em>
@@ -1161,7 +1161,7 @@ of etcd member Pods.</p>
 </tr>
 <tr>
 <td>
-<code>advertisePeerURLs</code></br>
+<code>advertisePeerURLs</code><br>
 <em>
 []string
 </em>
@@ -1176,7 +1176,7 @@ member index (1,2,3) respectively.</p>
 </tr>
 <tr>
 <td>
-<code>localMemberIndex</code></br>
+<code>localMemberIndex</code><br>
 <em>
 int32
 </em>
@@ -1192,7 +1192,7 @@ index must be 1, 2, or 3.</p>
 </tr>
 <tr>
 <td>
-<code>clientService</code></br>
+<code>clientService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -1205,7 +1205,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>peerService</code></br>
+<code>peerService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -1218,7 +1218,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -1251,7 +1251,7 @@ externally managed MySQL.</p>
 <tbody>
 <tr>
 <td>
-<code>user</code></br>
+<code>user</code><br>
 <em>
 string
 </em>
@@ -1263,7 +1263,7 @@ carry out necessary actions.  Password for this user must be supplied in the Cre
 </tr>
 <tr>
 <td>
-<code>host</code></br>
+<code>host</code><br>
 <em>
 string
 </em>
@@ -1274,7 +1274,7 @@ string
 </tr>
 <tr>
 <td>
-<code>port</code></br>
+<code>port</code><br>
 <em>
 int32
 </em>
@@ -1285,7 +1285,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>database</code></br>
+<code>database</code><br>
 <em>
 string
 </em>
@@ -1296,7 +1296,7 @@ string
 </tr>
 <tr>
 <td>
-<code>credentialsSecret</code></br>
+<code>credentialsSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -1316,7 +1316,7 @@ Vitess always uses the first password in the password array.</p>
 </tr>
 <tr>
 <td>
-<code>serverCACertSecret</code></br>
+<code>serverCACertSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -1347,7 +1347,7 @@ SecretSource
 <tbody>
 <tr>
 <td>
-<code>allowResourceChanges</code></br>
+<code>allowResourceChanges</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcename-v1-core">
 []Kubernetes core/v1.ResourceName
@@ -1383,7 +1383,7 @@ requests and limits to propagate immediately, bypassing the external rollout too
 <tbody>
 <tr>
 <td>
-<code>bucket</code></br>
+<code>bucket</code><br>
 <em>
 string
 </em>
@@ -1394,7 +1394,7 @@ string
 </tr>
 <tr>
 <td>
-<code>keyPrefix</code></br>
+<code>keyPrefix</code><br>
 <em>
 string
 </em>
@@ -1409,7 +1409,7 @@ within a bucket, regardless of this setting.</p>
 </tr>
 <tr>
 <td>
-<code>authSecret</code></br>
+<code>authSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -1446,7 +1446,7 @@ which can be either global or local.</p>
 <tbody>
 <tr>
 <td>
-<code>external</code></br>
+<code>external</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -1461,7 +1461,7 @@ If this is set, all other Lockserver fields are ignored.</p>
 </tr>
 <tr>
 <td>
-<code>etcd</code></br>
+<code>etcd</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverTemplate">
 EtcdLockserverTemplate
@@ -1474,7 +1474,7 @@ EtcdLockserverTemplate
 </tr>
 <tr>
 <td>
-<code>cellInfoAddress</code></br>
+<code>cellInfoAddress</code><br>
 <em>
 string
 </em>
@@ -1506,7 +1506,7 @@ Default: etcd client service.</p>
 <tbody>
 <tr>
 <td>
-<code>etcd</code></br>
+<code>etcd</code><br>
 <em>
 <a href="#planetscale.com/v2.EtcdLockserverStatus">
 EtcdLockserverStatus
@@ -1538,7 +1538,7 @@ EtcdLockserverStatus
 <tbody>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -1571,7 +1571,7 @@ Kubernetes core/v1.ResourceRequirements
 <tbody>
 <tr>
 <td>
-<code>mysql56Compatible</code></br>
+<code>mysql56Compatible</code><br>
 <em>
 string
 </em>
@@ -1583,7 +1583,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MySQL56&rdquo; flavor setting.</p
 </tr>
 <tr>
 <td>
-<code>mysql80Compatible</code></br>
+<code>mysql80Compatible</code><br>
 <em>
 string
 </em>
@@ -1595,7 +1595,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MySQL80&rdquo; flavor setting.</p
 </tr>
 <tr>
 <td>
-<code>mariadbCompatible</code></br>
+<code>mariadbCompatible</code><br>
 <em>
 string
 </em>
@@ -1607,7 +1607,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MariaDB&rdquo; flavor setting.</p
 </tr>
 <tr>
 <td>
-<code>mariadb103Compatible</code></br>
+<code>mariadb103Compatible</code><br>
 <em>
 string
 </em>
@@ -1641,7 +1641,7 @@ image is compatible with.</p>
 <tbody>
 <tr>
 <td>
-<code>mysql56Compatible</code></br>
+<code>mysql56Compatible</code><br>
 <em>
 string
 </em>
@@ -1653,7 +1653,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MySQL56&rdquo; flavor setting.</p
 </tr>
 <tr>
 <td>
-<code>mysql80Compatible</code></br>
+<code>mysql80Compatible</code><br>
 <em>
 string
 </em>
@@ -1684,7 +1684,7 @@ that&rsquo;s compatible with the Vitess &ldquo;MySQL80&rdquo; flavor setting.</p
 <tbody>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -1699,7 +1699,7 @@ This field is required.</p>
 </tr>
 <tr>
 <td>
-<code>configOverrides</code></br>
+<code>configOverrides</code><br>
 <em>
 string
 </em>
@@ -1733,7 +1733,7 @@ particular MySQL instance.</p>
 <tbody>
 <tr>
 <td>
-<code>reason</code></br>
+<code>reason</code><br>
 <em>
 string
 </em>
@@ -1744,7 +1744,7 @@ string
 </tr>
 <tr>
 <td>
-<code>message</code></br>
+<code>message</code><br>
 <em>
 string
 </em>
@@ -1774,7 +1774,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>workflow</code></br>
+<code>workflow</code><br>
 <em>
 string
 </em>
@@ -1785,7 +1785,7 @@ string
 </tr>
 <tr>
 <td>
-<code>state</code></br>
+<code>state</code><br>
 <em>
 <a href="#planetscale.com/v2.WorkflowState">
 WorkflowState
@@ -1798,7 +1798,7 @@ WorkflowState
 </tr>
 <tr>
 <td>
-<code>sourceShards</code></br>
+<code>sourceShards</code><br>
 <em>
 []string
 </em>
@@ -1809,7 +1809,7 @@ WorkflowState
 </tr>
 <tr>
 <td>
-<code>targetShards</code></br>
+<code>targetShards</code><br>
 <em>
 []string
 </em>
@@ -1820,7 +1820,7 @@ WorkflowState
 </tr>
 <tr>
 <td>
-<code>copyProgress</code></br>
+<code>copyProgress</code><br>
 <em>
 int
 </em>
@@ -1853,7 +1853,7 @@ If we can not compute the copy progress in a timely fashion, we will report -1 t
 <tbody>
 <tr>
 <td>
-<code>region</code></br>
+<code>region</code><br>
 <em>
 string
 </em>
@@ -1864,7 +1864,7 @@ string
 </tr>
 <tr>
 <td>
-<code>bucket</code></br>
+<code>bucket</code><br>
 <em>
 string
 </em>
@@ -1875,7 +1875,7 @@ string
 </tr>
 <tr>
 <td>
-<code>endpoint</code></br>
+<code>endpoint</code><br>
 <em>
 string
 </em>
@@ -1887,7 +1887,7 @@ Default: Use the endpoint associated with <code>region</code> by the driver.</p>
 </tr>
 <tr>
 <td>
-<code>forcePathStyle</code></br>
+<code>forcePathStyle</code><br>
 <em>
 bool
 </em>
@@ -1899,7 +1899,7 @@ Default: false By default the s3 client will try to connect to <bucket>.<endpoin
 </tr>
 <tr>
 <td>
-<code>keyPrefix</code></br>
+<code>keyPrefix</code><br>
 <em>
 string
 </em>
@@ -1914,7 +1914,7 @@ within a bucket, regardless of this setting.</p>
 </tr>
 <tr>
 <td>
-<code>authSecret</code></br>
+<code>authSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -1957,7 +1957,7 @@ Default: Use the default credentials of the Node.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -1973,7 +1973,7 @@ with the &lsquo;volumeName&rsquo; field instead.</p>
 </tr>
 <tr>
 <td>
-<code>volumeName</code></br>
+<code>volumeName</code><br>
 <em>
 string
 </em>
@@ -1988,7 +1988,7 @@ If specified, this takes precedence over the &lsquo;name&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>key</code></br>
+<code>key</code><br>
 <em>
 string
 </em>
@@ -2027,7 +2027,7 @@ within that Volume.</p>
 <tbody>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -2040,7 +2040,7 @@ Service object if they are removed here.</p>
 </tr>
 <tr>
 <td>
-<code>clusterIP</code></br>
+<code>clusterIP</code><br>
 <em>
 string
 </em>
@@ -2070,7 +2070,7 @@ a given backup location.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -2081,7 +2081,7 @@ string
 </tr>
 <tr>
 <td>
-<code>completeBackups</code></br>
+<code>completeBackups</code><br>
 <em>
 int32
 </em>
@@ -2092,7 +2092,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>incompleteBackups</code></br>
+<code>incompleteBackups</code><br>
 <em>
 int32
 </em>
@@ -2103,7 +2103,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>latestCompleteBackupTime</code></br>
+<code>latestCompleteBackupTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -2139,7 +2139,7 @@ This should only be necessary if you need to override defaults, and shouldn&rsqu
 <tbody>
 <tr>
 <td>
-<code>registerCellsAliases</code></br>
+<code>registerCellsAliases</code><br>
 <em>
 bool
 </em>
@@ -2151,7 +2151,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>registerCells</code></br>
+<code>registerCells</code><br>
 <em>
 bool
 </em>
@@ -2163,7 +2163,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneCells</code></br>
+<code>pruneCells</code><br>
 <em>
 bool
 </em>
@@ -2175,7 +2175,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneKeyspaces</code></br>
+<code>pruneKeyspaces</code><br>
 <em>
 bool
 </em>
@@ -2187,7 +2187,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneSrvKeyspaces</code></br>
+<code>pruneSrvKeyspaces</code><br>
 <em>
 bool
 </em>
@@ -2199,7 +2199,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneShards</code></br>
+<code>pruneShards</code><br>
 <em>
 bool
 </em>
@@ -2211,7 +2211,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneShardCells</code></br>
+<code>pruneShardCells</code><br>
 <em>
 bool
 </em>
@@ -2223,7 +2223,7 @@ Default: true</p>
 </tr>
 <tr>
 <td>
-<code>pruneTablets</code></br>
+<code>pruneTablets</code><br>
 <em>
 bool
 </em>
@@ -2268,7 +2268,7 @@ Default: true</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -2285,7 +2285,7 @@ location used when a tablet pool does not specify a backupLocationName.</p>
 </tr>
 <tr>
 <td>
-<code>gcs</code></br>
+<code>gcs</code><br>
 <em>
 <a href="#planetscale.com/v2.GCSBackupLocation">
 GCSBackupLocation
@@ -2298,7 +2298,7 @@ GCSBackupLocation
 </tr>
 <tr>
 <td>
-<code>s3</code></br>
+<code>s3</code><br>
 <em>
 <a href="#planetscale.com/v2.S3BackupLocation">
 S3BackupLocation
@@ -2311,7 +2311,7 @@ S3BackupLocation
 </tr>
 <tr>
 <td>
-<code>azblob</code></br>
+<code>azblob</code><br>
 <em>
 <a href="#planetscale.com/v2.AzblobBackupLocation">
 AzblobBackupLocation
@@ -2324,7 +2324,7 @@ AzblobBackupLocation
 </tr>
 <tr>
 <td>
-<code>ceph</code></br>
+<code>ceph</code><br>
 <em>
 <a href="#planetscale.com/v2.CephBackupLocation">
 CephBackupLocation
@@ -2337,7 +2337,7 @@ CephBackupLocation
 </tr>
 <tr>
 <td>
-<code>volume</code></br>
+<code>volume</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumesource-v1-core">
 Kubernetes core/v1.VolumeSource
@@ -2352,7 +2352,7 @@ a shared host path for local testing.</p>
 </tr>
 <tr>
 <td>
-<code>volumeSubPath</code></br>
+<code>volumeSubPath</code><br>
 <em>
 string
 </em>
@@ -2364,7 +2364,7 @@ Only used for Volume-backed backup storage, ignored otherwise.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -2391,7 +2391,7 @@ that need access to this backup storage location.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -2405,7 +2405,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleSpec">
 VitessBackupScheduleSpec
@@ -2418,7 +2418,7 @@ VitessBackupScheduleSpec
 <table>
 <tr>
 <td>
-<code>VitessBackupScheduleTemplate</code></br>
+<code>VitessBackupScheduleTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleTemplate">
 VitessBackupScheduleTemplate
@@ -2435,7 +2435,7 @@ These are the parts that are configurable through the VitessCluster CRD.</p>
 </tr>
 <tr>
 <td>
-<code>cluster</code></br>
+<code>cluster</code><br>
 <em>
 string
 </em>
@@ -2446,7 +2446,7 @@ string
 </tr>
 <tr>
 <td>
-<code>image</code></br>
+<code>image</code><br>
 <em>
 string
 </em>
@@ -2458,7 +2458,7 @@ The controller will re-use the vtctld image by default.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicy</code></br>
+<code>imagePullPolicy</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -2475,7 +2475,7 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleStatus">
 VitessBackupScheduleStatus
@@ -2506,7 +2506,7 @@ VitessBackupScheduleStatus
 <tbody>
 <tr>
 <td>
-<code>VitessBackupScheduleTemplate</code></br>
+<code>VitessBackupScheduleTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleTemplate">
 VitessBackupScheduleTemplate
@@ -2523,7 +2523,7 @@ These are the parts that are configurable through the VitessCluster CRD.</p>
 </tr>
 <tr>
 <td>
-<code>cluster</code></br>
+<code>cluster</code><br>
 <em>
 string
 </em>
@@ -2534,7 +2534,7 @@ string
 </tr>
 <tr>
 <td>
-<code>image</code></br>
+<code>image</code><br>
 <em>
 string
 </em>
@@ -2546,7 +2546,7 @@ The controller will re-use the vtctld image by default.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicy</code></br>
+<code>imagePullPolicy</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -2579,7 +2579,7 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 <tbody>
 <tr>
 <td>
-<code>active</code></br>
+<code>active</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 []Kubernetes core/v1.ObjectReference
@@ -2593,7 +2593,7 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 </tr>
 <tr>
 <td>
-<code>lastScheduledTime</code></br>
+<code>lastScheduledTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -2628,7 +2628,7 @@ command line that will be executed in the Job&rsquo;s pod.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 <a href="#planetscale.com/v2.BackupStrategyName">
 BackupStrategyName
@@ -2641,7 +2641,7 @@ BackupStrategyName
 </tr>
 <tr>
 <td>
-<code>keyspace</code></br>
+<code>keyspace</code><br>
 <em>
 string
 </em>
@@ -2652,7 +2652,7 @@ string
 </tr>
 <tr>
 <td>
-<code>shard</code></br>
+<code>shard</code><br>
 <em>
 string
 </em>
@@ -2663,7 +2663,7 @@ string
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -2696,7 +2696,7 @@ able to define when writing their YAML file.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -2708,7 +2708,7 @@ objects in the cluster.</p>
 </tr>
 <tr>
 <td>
-<code>schedule</code></br>
+<code>schedule</code><br>
 <em>
 string
 </em>
@@ -2719,7 +2719,7 @@ string
 </tr>
 <tr>
 <td>
-<code>strategies</code></br>
+<code>strategies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupScheduleStrategy">
 []VitessBackupScheduleStrategy
@@ -2738,7 +2738,7 @@ is executed when the Job&rsquo;s container starts.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -2751,7 +2751,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>successfulJobsHistoryLimit</code></br>
+<code>successfulJobsHistoryLimit</code><br>
 <em>
 int32
 </em>
@@ -2763,7 +2763,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>failedJobsHistoryLimit</code></br>
+<code>failedJobsHistoryLimit</code><br>
 <em>
 int32
 </em>
@@ -2775,7 +2775,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>suspend</code></br>
+<code>suspend</code><br>
 <em>
 bool
 </em>
@@ -2789,7 +2789,7 @@ having to remove the entire VitessBackupSchedule object from the cluster.</p>
 </tr>
 <tr>
 <td>
-<code>startingDeadlineSeconds</code></br>
+<code>startingDeadlineSeconds</code><br>
 <em>
 int64
 </em>
@@ -2805,7 +2805,7 @@ the job will be processed as usual.</p>
 </tr>
 <tr>
 <td>
-<code>concurrencyPolicy</code></br>
+<code>concurrencyPolicy</code><br>
 <em>
 <a href="#planetscale.com/v2.ConcurrencyPolicy">
 ConcurrencyPolicy
@@ -2823,7 +2823,7 @@ Valid values are:
 </tr>
 <tr>
 <td>
-<code>allowedMissedRun</code></br>
+<code>allowedMissedRun</code><br>
 <em>
 int
 </em>
@@ -2842,7 +2842,7 @@ this field to its default value.</p>
 </tr>
 <tr>
 <td>
-<code>jobTimeoutMinute</code></br>
+<code>jobTimeoutMinute</code><br>
 <em>
 int32
 </em>
@@ -2855,7 +2855,7 @@ Default value is 10 minutes.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -2867,7 +2867,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -2911,7 +2911,7 @@ guarantee optimal scheduling of your pods if you choose to set this field.</p>
 <tbody>
 <tr>
 <td>
-<code>startTime</code></br>
+<code>startTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -2924,7 +2924,7 @@ Kubernetes meta/v1.Time
 </tr>
 <tr>
 <td>
-<code>finishedTime</code></br>
+<code>finishedTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -2937,7 +2937,7 @@ Kubernetes meta/v1.Time
 </tr>
 <tr>
 <td>
-<code>complete</code></br>
+<code>complete</code><br>
 <em>
 bool
 </em>
@@ -2948,7 +2948,7 @@ bool
 </tr>
 <tr>
 <td>
-<code>position</code></br>
+<code>position</code><br>
 <em>
 string
 </em>
@@ -2962,7 +2962,7 @@ This is only available after the backup is complete.</p>
 </tr>
 <tr>
 <td>
-<code>engine</code></br>
+<code>engine</code><br>
 <em>
 string
 </em>
@@ -2973,7 +2973,7 @@ string
 </tr>
 <tr>
 <td>
-<code>storageDirectory</code></br>
+<code>storageDirectory</code><br>
 <em>
 string
 </em>
@@ -2985,7 +2985,7 @@ contains this backup.</p>
 </tr>
 <tr>
 <td>
-<code>storageName</code></br>
+<code>storageName</code><br>
 <em>
 string
 </em>
@@ -3019,7 +3019,7 @@ cluster.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -3033,7 +3033,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupStorageSpec">
 VitessBackupStorageSpec
@@ -3046,7 +3046,7 @@ VitessBackupStorageSpec
 <table>
 <tr>
 <td>
-<code>location</code></br>
+<code>location</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 VitessBackupLocation
@@ -3060,7 +3060,7 @@ storage location.</p>
 </tr>
 <tr>
 <td>
-<code>subcontroller</code></br>
+<code>subcontroller</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupSubcontrollerSpec">
 VitessBackupSubcontrollerSpec
@@ -3076,7 +3076,7 @@ VitessBackupSubcontrollerSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupStorageStatus">
 VitessBackupStorageStatus
@@ -3107,7 +3107,7 @@ VitessBackupStorageStatus
 <tbody>
 <tr>
 <td>
-<code>location</code></br>
+<code>location</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 VitessBackupLocation
@@ -3121,7 +3121,7 @@ storage location.</p>
 </tr>
 <tr>
 <td>
-<code>subcontroller</code></br>
+<code>subcontroller</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupSubcontrollerSpec">
 VitessBackupSubcontrollerSpec
@@ -3153,7 +3153,7 @@ VitessBackupSubcontrollerSpec
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -3164,7 +3164,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>totalBackupCount</code></br>
+<code>totalBackupCount</code><br>
 <em>
 int32
 </em>
@@ -3195,7 +3195,7 @@ location, across all keyspaces and shards.</p>
 <tbody>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br>
 <em>
 string
 </em>
@@ -3231,7 +3231,7 @@ just like a Deployment can manage Pods that run on multiple Nodes.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -3245,7 +3245,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellSpec">
 VitessCellSpec
@@ -3258,7 +3258,7 @@ VitessCellSpec
 <table>
 <tr>
 <td>
-<code>VitessCellTemplate</code></br>
+<code>VitessCellTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellTemplate">
 VitessCellTemplate
@@ -3276,7 +3276,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -3289,7 +3289,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>allCells</code></br>
+<code>allCells</code><br>
 <em>
 []string
 </em>
@@ -3300,7 +3300,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellImages">
 VitessCellImages
@@ -3316,7 +3316,7 @@ controller that owns this VitessCell.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -3329,7 +3329,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -3342,7 +3342,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -3353,7 +3353,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -3369,7 +3369,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellStatus">
 VitessCellStatus
@@ -3400,7 +3400,7 @@ VitessCellStatus
 <tbody>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br>
 <em>
 int32
 </em>
@@ -3411,7 +3411,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>autoscaler</code></br>
+<code>autoscaler</code><br>
 <em>
 <a href="#planetscale.com/v2.AutoscalerSpec">
 AutoscalerSpec
@@ -3426,7 +3426,7 @@ for the vtgate workload.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -3439,7 +3439,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>authentication</code></br>
+<code>authentication</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessGatewayAuthentication">
 VitessGatewayAuthentication
@@ -3452,7 +3452,7 @@ VitessGatewayAuthentication
 </tr>
 <tr>
 <td>
-<code>secureTransport</code></br>
+<code>secureTransport</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessGatewaySecureTransport">
 VitessGatewaySecureTransport
@@ -3465,7 +3465,7 @@ VitessGatewaySecureTransport
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -3480,7 +3480,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -3494,7 +3494,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -3511,7 +3511,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -3526,7 +3526,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -3540,7 +3540,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -3554,7 +3554,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -3570,7 +3570,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -3583,7 +3583,7 @@ Pods that the vtgate Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -3596,7 +3596,7 @@ Pods that the vtgate Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>service</code></br>
+<code>service</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -3609,7 +3609,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -3622,7 +3622,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>topologySpreadConstraints</code></br>
+<code>topologySpreadConstraints</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core">
 []Kubernetes core/v1.TopologySpreadConstraint
@@ -3636,7 +3636,7 @@ specify how to spread vtgate pods among the given topology</p>
 </tr>
 <tr>
 <td>
-<code>lifecycle</code></br>
+<code>lifecycle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lifecycle-v1-core">
 Kubernetes core/v1.Lifecycle
@@ -3650,7 +3650,7 @@ to the vtgate container.</p>
 </tr>
 <tr>
 <td>
-<code>terminationGracePeriodSeconds</code></br>
+<code>terminationGracePeriodSeconds</code><br>
 <em>
 int64
 </em>
@@ -3681,7 +3681,7 @@ terminationGracePeriodSeconds of the vtgate pod.</p>
 <tbody>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -3694,7 +3694,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br>
 <em>
 string
 </em>
@@ -3705,7 +3705,7 @@ string
 </tr>
 <tr>
 <td>
-<code>labelSelector</code></br>
+<code>labelSelector</code><br>
 <em>
 string
 </em>
@@ -3717,7 +3717,7 @@ HorizontalPodAutoscaler when reading pod metrics.</p>
 </tr>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br>
 <em>
 int32
 </em>
@@ -3748,7 +3748,7 @@ HorizontalPodAutoscaler to determine the current number of replicas.</p>
 <tbody>
 <tr>
 <td>
-<code>vtgate</code></br>
+<code>vtgate</code><br>
 <em>
 string
 </em>
@@ -3787,7 +3787,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>VitessCellTemplate</code></br>
+<code>VitessCellTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellTemplate">
 VitessCellTemplate
@@ -3805,7 +3805,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -3818,7 +3818,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>allCells</code></br>
+<code>allCells</code><br>
 <em>
 []string
 </em>
@@ -3829,7 +3829,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellImages">
 VitessCellImages
@@ -3845,7 +3845,7 @@ controller that owns this VitessCell.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -3858,7 +3858,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -3871,7 +3871,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -3882,7 +3882,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -3914,7 +3914,7 @@ TopoReconcileConfig
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -3925,7 +3925,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>lockserver</code></br>
+<code>lockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverStatus">
 LockserverStatus
@@ -3938,7 +3938,7 @@ LockserverStatus
 </tr>
 <tr>
 <td>
-<code>gateway</code></br>
+<code>gateway</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellGatewayStatus">
 VitessCellGatewayStatus
@@ -3951,7 +3951,7 @@ VitessCellGatewayStatus
 </tr>
 <tr>
 <td>
-<code>keyspaces</code></br>
+<code>keyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellKeyspaceStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessCellKeyspaceStatus
@@ -3968,7 +3968,7 @@ when the difference matters.</p>
 </tr>
 <tr>
 <td>
-<code>idle</code></br>
+<code>idle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -4003,7 +4003,7 @@ should be safe to turn down the cell.</p>
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -4016,7 +4016,7 @@ metadata.name, which is generated by the operator.</p>
 </tr>
 <tr>
 <td>
-<code>zone</code></br>
+<code>zone</code><br>
 <em>
 string
 </em>
@@ -4030,7 +4030,7 @@ If the Kubernetes Nodes don&rsquo;t have such a label, leave this empty.</p>
 </tr>
 <tr>
 <td>
-<code>lockserver</code></br>
+<code>lockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverSpec">
 LockserverSpec
@@ -4045,7 +4045,7 @@ Default: Put this cell&rsquo;s topology data in the global lockserver instead of
 </tr>
 <tr>
 <td>
-<code>gateway</code></br>
+<code>gateway</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellGatewaySpec">
 VitessCellGatewaySpec
@@ -4077,7 +4077,7 @@ VitessCellGatewaySpec
 <tbody>
 <tr>
 <td>
-<code>pendingChanges</code></br>
+<code>pendingChanges</code><br>
 <em>
 string
 </em>
@@ -4089,7 +4089,7 @@ applied the next time a rolling update allows.</p>
 </tr>
 <tr>
 <td>
-<code>gatewayAvailable</code></br>
+<code>gatewayAvailable</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -4121,7 +4121,7 @@ Kubernetes core/v1.ConditionStatus
 <tbody>
 <tr>
 <td>
-<code>pendingChanges</code></br>
+<code>pendingChanges</code><br>
 <em>
 string
 </em>
@@ -4133,7 +4133,7 @@ applied the next time a rolling update allows.</p>
 </tr>
 <tr>
 <td>
-<code>desiredShards</code></br>
+<code>desiredShards</code><br>
 <em>
 int32
 </em>
@@ -4147,7 +4147,7 @@ own.</p>
 </tr>
 <tr>
 <td>
-<code>shards</code></br>
+<code>shards</code><br>
 <em>
 int32
 </em>
@@ -4159,7 +4159,7 @@ than desiredShards if the state has not yet converged.</p>
 </tr>
 <tr>
 <td>
-<code>readyShards</code></br>
+<code>readyShards</code><br>
 <em>
 int32
 </em>
@@ -4170,7 +4170,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>updatedShards</code></br>
+<code>updatedShards</code><br>
 <em>
 int32
 </em>
@@ -4182,7 +4182,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>desiredTablets</code></br>
+<code>desiredTablets</code><br>
 <em>
 int32
 </em>
@@ -4196,7 +4196,7 @@ partitionings on their own.</p>
 </tr>
 <tr>
 <td>
-<code>tablets</code></br>
+<code>tablets</code><br>
 <em>
 int32
 </em>
@@ -4209,7 +4209,7 @@ yet converged.</p>
 </tr>
 <tr>
 <td>
-<code>readyTablets</code></br>
+<code>readyTablets</code><br>
 <em>
 int32
 </em>
@@ -4220,7 +4220,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>updatedTablets</code></br>
+<code>updatedTablets</code><br>
 <em>
 int32
 </em>
@@ -4232,7 +4232,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -4263,7 +4263,7 @@ are deployed.</p>
 <tbody>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImages">
 VitessImages
@@ -4278,7 +4278,7 @@ Default: Let the operator choose.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -4292,7 +4292,7 @@ images defined in the &lsquo;images&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -4306,7 +4306,7 @@ use the images defined in the &lsquo;images&rsquo; field.</p>
 </tr>
 <tr>
 <td>
-<code>backup</code></br>
+<code>backup</code><br>
 <em>
 <a href="#planetscale.com/v2.ClusterBackupSpec">
 ClusterBackupSpec
@@ -4322,7 +4322,7 @@ of a new tablet in a shard with existing data, as an implementation detail.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverSpec">
 LockserverSpec
@@ -4337,7 +4337,7 @@ Default: Deploy an etcd cluster as the global lockserver.</p>
 </tr>
 <tr>
 <td>
-<code>vitessDashboard</code></br>
+<code>vitessDashboard</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessDashboardSpec">
 VitessDashboardSpec
@@ -4350,7 +4350,7 @@ VitessDashboardSpec
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 <a href="#planetscale.com/v2.VtAdminSpec">
 VtAdminSpec
@@ -4363,7 +4363,7 @@ VtAdminSpec
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessCellTemplate">
 []VitessCellTemplate
@@ -4382,7 +4382,7 @@ that no keyspaces are set to deploy to this cell.</p>
 </tr>
 <tr>
 <td>
-<code>keyspaces</code></br>
+<code>keyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplate">
 []VitessKeyspaceTemplate
@@ -4400,7 +4400,7 @@ of target cells.</p>
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -4416,7 +4416,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -4429,7 +4429,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -4443,7 +4443,7 @@ when a revision is made to the VitessCluster spec.</p>
 </tr>
 <tr>
 <td>
-<code>gatewayService</code></br>
+<code>gatewayService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -4458,7 +4458,7 @@ definition.</p>
 </tr>
 <tr>
 <td>
-<code>tabletService</code></br>
+<code>tabletService</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -4490,7 +4490,7 @@ ServiceOverrides
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -4501,7 +4501,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.LockserverStatus">
 LockserverStatus
@@ -4514,7 +4514,7 @@ LockserverStatus
 </tr>
 <tr>
 <td>
-<code>gatewayServiceName</code></br>
+<code>gatewayServiceName</code><br>
 <em>
 string
 </em>
@@ -4525,7 +4525,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vitessDashboard</code></br>
+<code>vitessDashboard</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessDashboardStatus">
 VitessDashboardStatus
@@ -4538,7 +4538,7 @@ VitessDashboardStatus
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 <a href="#planetscale.com/v2.VtadminStatus">
 VtadminStatus
@@ -4551,7 +4551,7 @@ VtadminStatus
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterCellStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessClusterCellStatus
@@ -4564,7 +4564,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessCluster
 </tr>
 <tr>
 <td>
-<code>keyspaces</code></br>
+<code>keyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterKeyspaceStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessClusterKeyspaceStatus
@@ -4577,7 +4577,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessCluster
 </tr>
 <tr>
 <td>
-<code>orphanedCells</code></br>
+<code>orphanedCells</code><br>
 <em>
 <a href="#planetscale.com/v2.OrphanStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
@@ -4590,7 +4590,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 </tr>
 <tr>
 <td>
-<code>orphanedKeyspaces</code></br>
+<code>orphanedKeyspaces</code><br>
 <em>
 <a href="#planetscale.com/v2.OrphanStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
@@ -4626,7 +4626,7 @@ necessary to perform the update for the indicated strategy.</p>
 <tbody>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategyType">
 VitessClusterUpdateStrategyType
@@ -4650,7 +4650,7 @@ planned reparents whenever possible to avoid master downtime.</li>
 </tr>
 <tr>
 <td>
-<code>external</code></br>
+<code>external</code><br>
 <em>
 <a href="#planetscale.com/v2.ExternalVitessClusterUpdateStrategyOptions">
 ExternalVitessClusterUpdateStrategyOptions
@@ -4693,7 +4693,7 @@ all possible update strategies for the VitessCluster.</p>
 <tbody>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -4706,7 +4706,7 @@ Default: Deploy to all defined cells.</p>
 </tr>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br>
 <em>
 int32
 </em>
@@ -4717,7 +4717,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -4730,7 +4730,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -4745,7 +4745,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -4759,7 +4759,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -4776,7 +4776,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -4791,7 +4791,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -4805,7 +4805,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -4819,7 +4819,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -4835,7 +4835,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -4848,7 +4848,7 @@ Pods that the vtctld Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -4861,7 +4861,7 @@ Pods that the vtctld Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>service</code></br>
+<code>service</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -4874,7 +4874,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -4906,7 +4906,7 @@ ServiceOverrides
 <tbody>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -4919,7 +4919,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br>
 <em>
 string
 </em>
@@ -4949,7 +4949,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>static</code></br>
+<code>static</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessGatewayStaticAuthentication">
 VitessGatewayStaticAuthentication
@@ -4981,7 +4981,7 @@ VitessGatewayStaticAuthentication
 <tbody>
 <tr>
 <td>
-<code>required</code></br>
+<code>required</code><br>
 <em>
 bool
 </em>
@@ -4994,7 +4994,7 @@ All GRPC transport is required to be encrypted when certs are set.</p>
 </tr>
 <tr>
 <td>
-<code>tls</code></br>
+<code>tls</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessGatewayTLSSecureTransport">
 VitessGatewayTLSSecureTransport
@@ -5026,7 +5026,7 @@ VitessGatewayTLSSecureTransport
 <tbody>
 <tr>
 <td>
-<code>secret</code></br>
+<code>secret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -5058,7 +5058,7 @@ SecretSource
 <tbody>
 <tr>
 <td>
-<code>clientCACertSecret</code></br>
+<code>clientCACertSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -5073,7 +5073,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>certSecret</code></br>
+<code>certSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -5086,7 +5086,7 @@ SecretSource
 </tr>
 <tr>
 <td>
-<code>keySecret</code></br>
+<code>keySecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -5121,7 +5121,7 @@ SecretSource
 <tbody>
 <tr>
 <td>
-<code>vtctld</code></br>
+<code>vtctld</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5134,7 +5134,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5147,7 +5147,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vtorc</code></br>
+<code>vtorc</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5160,7 +5160,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vtgate</code></br>
+<code>vtgate</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5173,7 +5173,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vttablet</code></br>
+<code>vttablet</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5186,7 +5186,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>vtbackup</code></br>
+<code>vtbackup</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5199,7 +5199,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>mysqld</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5212,7 +5212,7 @@ Kubernetes core/v1.PullPolicy
 </tr>
 <tr>
 <td>
-<code>mysqldExporter</code></br>
+<code>mysqldExporter</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pullpolicy-v1-core">
 Kubernetes core/v1.PullPolicy
@@ -5244,7 +5244,7 @@ Kubernetes core/v1.PullPolicy
 <tbody>
 <tr>
 <td>
-<code>vtctld</code></br>
+<code>vtctld</code><br>
 <em>
 string
 </em>
@@ -5255,7 +5255,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtadmin</code></br>
+<code>vtadmin</code><br>
 <em>
 string
 </em>
@@ -5266,7 +5266,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtorc</code></br>
+<code>vtorc</code><br>
 <em>
 string
 </em>
@@ -5277,7 +5277,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtgate</code></br>
+<code>vtgate</code><br>
 <em>
 string
 </em>
@@ -5288,7 +5288,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vttablet</code></br>
+<code>vttablet</code><br>
 <em>
 string
 </em>
@@ -5299,7 +5299,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtbackup</code></br>
+<code>vtbackup</code><br>
 <em>
 string
 </em>
@@ -5310,7 +5310,7 @@ string
 </tr>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>mysqld</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldImage">
 MysqldImage
@@ -5326,7 +5326,7 @@ mysqld running alongside each tablet.</p>
 </tr>
 <tr>
 <td>
-<code>mysqldExporter</code></br>
+<code>mysqldExporter</code><br>
 <em>
 string
 </em>
@@ -5357,7 +5357,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>start</code></br>
+<code>start</code><br>
 <em>
 string
 </em>
@@ -5371,7 +5371,7 @@ than or equal to Start in lexicographical order to be in the range.</p>
 </tr>
 <tr>
 <td>
-<code>end</code></br>
+<code>end</code><br>
 <em>
 string
 </em>
@@ -5403,7 +5403,7 @@ various VitessCells.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -5417,7 +5417,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceSpec">
 VitessKeyspaceSpec
@@ -5430,7 +5430,7 @@ VitessKeyspaceSpec
 <table>
 <tr>
 <td>
-<code>VitessKeyspaceTemplate</code></br>
+<code>VitessKeyspaceTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplate">
 VitessKeyspaceTemplate
@@ -5448,7 +5448,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -5461,7 +5461,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceImages">
 VitessKeyspaceImages
@@ -5479,7 +5479,7 @@ images on VitessKeyspaceTemplate.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -5492,7 +5492,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -5505,7 +5505,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>zoneMap</code></br>
+<code>zoneMap</code><br>
 <em>
 map[string]string
 </em>
@@ -5517,7 +5517,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -5530,7 +5530,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>backupEngine</code></br>
+<code>backupEngine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -5543,7 +5543,7 @@ VitessBackupEngine
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -5554,7 +5554,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -5567,7 +5567,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -5583,7 +5583,7 @@ VitessClusterUpdateStrategy
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceStatus">
 VitessKeyspaceStatus
@@ -5614,7 +5614,7 @@ VitessKeyspaceStatus
 <tbody>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceConditionType">
 VitessKeyspaceConditionType
@@ -5627,7 +5627,7 @@ VitessKeyspaceConditionType
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -5641,7 +5641,7 @@ Can be True, False, Unknown.</p>
 </tr>
 <tr>
 <td>
-<code>lastTransitionTime</code></br>
+<code>lastTransitionTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -5655,7 +5655,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>reason</code></br>
+<code>reason</code><br>
 <em>
 string
 </em>
@@ -5667,7 +5667,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>message</code></br>
+<code>message</code><br>
 <em>
 string
 </em>
@@ -5708,7 +5708,7 @@ VitessKeyspaceConditionType and the value is a VitessKeyspaceCondition.</p>
 <tbody>
 <tr>
 <td>
-<code>shards</code></br>
+<code>shards</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceKeyRangeShard">
 []VitessKeyspaceKeyRangeShard
@@ -5740,7 +5740,7 @@ VitessKeyspaceConditionType and the value is a VitessKeyspaceCondition.</p>
 <tbody>
 <tr>
 <td>
-<code>parts</code></br>
+<code>parts</code><br>
 <em>
 int32
 </em>
@@ -5759,7 +5759,7 @@ migration, and then remove the old partitioning.</p>
 </tr>
 <tr>
 <td>
-<code>shardTemplate</code></br>
+<code>shardTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTemplate">
 VitessShardTemplate
@@ -5794,7 +5794,7 @@ use custom partitioning instead.</p>
 <tbody>
 <tr>
 <td>
-<code>vttablet</code></br>
+<code>vttablet</code><br>
 <em>
 string
 </em>
@@ -5805,7 +5805,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtorc</code></br>
+<code>vtorc</code><br>
 <em>
 string
 </em>
@@ -5816,7 +5816,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtbackup</code></br>
+<code>vtbackup</code><br>
 <em>
 string
 </em>
@@ -5827,7 +5827,7 @@ string
 </tr>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>mysqld</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldImage">
 MysqldImage
@@ -5843,7 +5843,7 @@ mysqld running alongside each tablet.</p>
 </tr>
 <tr>
 <td>
-<code>mysqldExporter</code></br>
+<code>mysqldExporter</code><br>
 <em>
 string
 </em>
@@ -5873,7 +5873,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>keyRange</code></br>
+<code>keyRange</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyRange">
 VitessKeyRange
@@ -5891,7 +5891,7 @@ migration, and then remove the old partitioning.</p>
 </tr>
 <tr>
 <td>
-<code>VitessShardTemplate</code></br>
+<code>VitessShardTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTemplate">
 VitessShardTemplate
@@ -5928,7 +5928,7 @@ a given partitioning.</p>
 <tbody>
 <tr>
 <td>
-<code>equal</code></br>
+<code>equal</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceEqualPartitioning">
 VitessKeyspaceEqualPartitioning
@@ -5943,7 +5943,7 @@ because they&rsquo;re generated by a hash vindex.</p>
 </tr>
 <tr>
 <td>
-<code>custom</code></br>
+<code>custom</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceCustomPartitioning">
 VitessKeyspaceCustomPartitioning
@@ -5976,7 +5976,7 @@ in case you don&rsquo;t want them to be divided equally.</p>
 <tbody>
 <tr>
 <td>
-<code>shardNames</code></br>
+<code>shardNames</code><br>
 <em>
 []string
 </em>
@@ -5988,7 +5988,7 @@ in the format Vitess uses for shard names.</p>
 </tr>
 <tr>
 <td>
-<code>servingWrites</code></br>
+<code>servingWrites</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -6005,7 +6005,7 @@ Check the per-shard status for full details.</p>
 </tr>
 <tr>
 <td>
-<code>desiredTablets</code></br>
+<code>desiredTablets</code><br>
 <em>
 int32
 </em>
@@ -6019,7 +6019,7 @@ own.</p>
 </tr>
 <tr>
 <td>
-<code>tablets</code></br>
+<code>tablets</code><br>
 <em>
 int32
 </em>
@@ -6031,7 +6031,7 @@ lower than desiredTablets if the state has not yet converged.</p>
 </tr>
 <tr>
 <td>
-<code>readyTablets</code></br>
+<code>readyTablets</code><br>
 <em>
 int32
 </em>
@@ -6042,7 +6042,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>updatedTablets</code></br>
+<code>updatedTablets</code><br>
 <em>
 int32
 </em>
@@ -6054,7 +6054,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>desiredShards</code></br>
+<code>desiredShards</code><br>
 <em>
 int32
 </em>
@@ -6068,7 +6068,7 @@ own.</p>
 </tr>
 <tr>
 <td>
-<code>readyShards</code></br>
+<code>readyShards</code><br>
 <em>
 int32
 </em>
@@ -6098,7 +6098,7 @@ int32
 <tbody>
 <tr>
 <td>
-<code>hasMaster</code></br>
+<code>hasMaster</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -6112,7 +6112,7 @@ reflects a master for this shard.</p>
 </tr>
 <tr>
 <td>
-<code>servingWrites</code></br>
+<code>servingWrites</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -6128,7 +6128,7 @@ the target of a resharding operation that is still in progress.</p>
 </tr>
 <tr>
 <td>
-<code>desiredTablets</code></br>
+<code>desiredTablets</code><br>
 <em>
 int32
 </em>
@@ -6142,7 +6142,7 @@ own.</p>
 </tr>
 <tr>
 <td>
-<code>tablets</code></br>
+<code>tablets</code><br>
 <em>
 int32
 </em>
@@ -6154,7 +6154,7 @@ lower than desiredTablets if the state has not yet converged.</p>
 </tr>
 <tr>
 <td>
-<code>readyTablets</code></br>
+<code>readyTablets</code><br>
 <em>
 int32
 </em>
@@ -6165,7 +6165,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>updatedTablets</code></br>
+<code>updatedTablets</code><br>
 <em>
 int32
 </em>
@@ -6177,7 +6177,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>pendingChanges</code></br>
+<code>pendingChanges</code><br>
 <em>
 string
 </em>
@@ -6189,7 +6189,7 @@ the next time a rolling update allows.</p>
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -6219,7 +6219,7 @@ the next time a rolling update allows.</p>
 <tbody>
 <tr>
 <td>
-<code>VitessKeyspaceTemplate</code></br>
+<code>VitessKeyspaceTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplate">
 VitessKeyspaceTemplate
@@ -6237,7 +6237,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -6250,7 +6250,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceImages">
 VitessKeyspaceImages
@@ -6268,7 +6268,7 @@ images on VitessKeyspaceTemplate.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -6281,7 +6281,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -6294,7 +6294,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>zoneMap</code></br>
+<code>zoneMap</code><br>
 <em>
 map[string]string
 </em>
@@ -6306,7 +6306,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -6319,7 +6319,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>backupEngine</code></br>
+<code>backupEngine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -6332,7 +6332,7 @@ VitessBackupEngine
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -6343,7 +6343,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -6356,7 +6356,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -6388,7 +6388,7 @@ VitessClusterUpdateStrategy
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -6399,7 +6399,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>shards</code></br>
+<code>shards</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceShardStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspaceShardStatus
@@ -6412,7 +6412,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspac
 </tr>
 <tr>
 <td>
-<code>partitionings</code></br>
+<code>partitionings</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspacePartitioningStatus">
 []VitessKeyspacePartitioningStatus
@@ -6425,7 +6425,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessKeyspac
 </tr>
 <tr>
 <td>
-<code>orphanedShards</code></br>
+<code>orphanedShards</code><br>
 <em>
 <a href="#planetscale.com/v2.OrphanStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
@@ -6438,7 +6438,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 </tr>
 <tr>
 <td>
-<code>idle</code></br>
+<code>idle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -6453,7 +6453,7 @@ be safe to turn down the keyspace.</p>
 </tr>
 <tr>
 <td>
-<code>resharding</code></br>
+<code>resharding</code><br>
 <em>
 <a href="#planetscale.com/v2.ReshardingStatus">
 ReshardingStatus
@@ -6468,7 +6468,7 @@ it means the operator was unable to query resharding status from Vitess.</p>
 </tr>
 <tr>
 <td>
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceCondition">
 []VitessKeyspaceCondition
@@ -6502,7 +6502,7 @@ It&rsquo;s ok for multiple controllers to add conditions here, and those conditi
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -6518,7 +6518,7 @@ instruction to delete the old keyspace and create a new one.</p>
 </tr>
 <tr>
 <td>
-<code>databaseName</code></br>
+<code>databaseName</code><br>
 <em>
 string
 </em>
@@ -6539,7 +6539,7 @@ this to be the same as the keyspace name to reduce confusion.</p>
 </tr>
 <tr>
 <td>
-<code>durabilityPolicy</code></br>
+<code>durabilityPolicy</code><br>
 <em>
 string
 </em>
@@ -6551,7 +6551,7 @@ If unspecified, vtop will not set the durability policy.</p>
 </tr>
 <tr>
 <td>
-<code>vitessOrchestrator</code></br>
+<code>vitessOrchestrator</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessOrchestratorSpec">
 VitessOrchestratorSpec
@@ -6566,7 +6566,7 @@ for the vttablets if enabling vtorc.</p>
 </tr>
 <tr>
 <td>
-<code>partitionings</code></br>
+<code>partitionings</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspacePartitioning">
 []VitessKeyspacePartitioning
@@ -6602,7 +6602,7 @@ partitioning into 1 part.</p>
 </tr>
 <tr>
 <td>
-<code>turndownPolicy</code></br>
+<code>turndownPolicy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTurndownPolicy">
 VitessKeyspaceTurndownPolicy
@@ -6630,7 +6630,7 @@ you can set the policy to Immediate to skip these checks.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -6641,7 +6641,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceTemplateImages">
 VitessKeyspaceTemplateImages
@@ -6687,7 +6687,7 @@ VitessKeyspaceImages instead as it contains exactly the same fields.</p>
 <tbody>
 <tr>
 <td>
-<code>vttablet</code></br>
+<code>vttablet</code><br>
 <em>
 string
 </em>
@@ -6698,7 +6698,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtorc</code></br>
+<code>vtorc</code><br>
 <em>
 string
 </em>
@@ -6709,7 +6709,7 @@ string
 </tr>
 <tr>
 <td>
-<code>vtbackup</code></br>
+<code>vtbackup</code><br>
 <em>
 string
 </em>
@@ -6720,7 +6720,7 @@ string
 </tr>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>mysqld</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldImageNew">
 MysqldImageNew
@@ -6736,7 +6736,7 @@ mysqld running alongside each tablet.</p>
 </tr>
 <tr>
 <td>
-<code>mysqldExporter</code></br>
+<code>mysqldExporter</code><br>
 <em>
 string
 </em>
@@ -6779,7 +6779,7 @@ to connect to a given lockserver.</p>
 <tbody>
 <tr>
 <td>
-<code>implementation</code></br>
+<code>implementation</code><br>
 <em>
 string
 </em>
@@ -6790,7 +6790,7 @@ string
 </tr>
 <tr>
 <td>
-<code>address</code></br>
+<code>address</code><br>
 <em>
 string
 </em>
@@ -6801,7 +6801,7 @@ string
 </tr>
 <tr>
 <td>
-<code>rootPath</code></br>
+<code>rootPath</code><br>
 <em>
 string
 </em>
@@ -6833,7 +6833,7 @@ Multiple Vitess clusters can share a lockserver as long as they have unique root
 <tbody>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -6846,7 +6846,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -6861,7 +6861,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -6875,7 +6875,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -6892,7 +6892,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -6907,7 +6907,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -6921,7 +6921,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -6935,7 +6935,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -6951,7 +6951,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -6964,7 +6964,7 @@ Pods that the vtorc Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -6977,7 +6977,7 @@ Pods that the vtorc Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>service</code></br>
+<code>service</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -6990,7 +6990,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -7022,7 +7022,7 @@ ServiceOverrides
 <tbody>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7035,7 +7035,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br>
 <em>
 string
 </em>
@@ -7065,7 +7065,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>initializeMaster</code></br>
+<code>initializeMaster</code><br>
 <em>
 bool
 </em>
@@ -7078,7 +7078,7 @@ new or restored shard that has no master yet.</p>
 </tr>
 <tr>
 <td>
-<code>initializeBackup</code></br>
+<code>initializeBackup</code><br>
 <em>
 bool
 </em>
@@ -7092,7 +7092,7 @@ if a backup location is defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>recoverRestartedMaster</code></br>
+<code>recoverRestartedMaster</code><br>
 <em>
 bool
 </em>
@@ -7126,7 +7126,7 @@ for that shard.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -7140,7 +7140,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardSpec">
 VitessShardSpec
@@ -7153,7 +7153,7 @@ VitessShardSpec
 <table>
 <tr>
 <td>
-<code>VitessShardTemplate</code></br>
+<code>VitessShardTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTemplate">
 VitessShardTemplate
@@ -7171,7 +7171,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -7182,7 +7182,7 @@ string
 </tr>
 <tr>
 <td>
-<code>databaseName</code></br>
+<code>databaseName</code><br>
 <em>
 string
 </em>
@@ -7195,7 +7195,7 @@ the keyspace level.</p>
 </tr>
 <tr>
 <td>
-<code>zoneMap</code></br>
+<code>zoneMap</code><br>
 <em>
 map[string]string
 </em>
@@ -7207,7 +7207,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceImages">
 VitessKeyspaceImages
@@ -7223,7 +7223,7 @@ controller that owns this VitessShard.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -7236,7 +7236,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -7249,7 +7249,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>keyRange</code></br>
+<code>keyRange</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyRange">
 VitessKeyRange
@@ -7262,7 +7262,7 @@ VitessKeyRange
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -7275,7 +7275,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>vitessOrchestrator</code></br>
+<code>vitessOrchestrator</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessOrchestratorSpec">
 VitessOrchestratorSpec
@@ -7288,7 +7288,7 @@ VitessOrchestratorSpec
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -7301,7 +7301,7 @@ VitessOrchestratorSpec
 </tr>
 <tr>
 <td>
-<code>backupEngine</code></br>
+<code>backupEngine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -7314,7 +7314,7 @@ VitessBackupEngine
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -7325,7 +7325,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -7338,7 +7338,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -7354,7 +7354,7 @@ VitessClusterUpdateStrategy
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardStatus">
 VitessShardStatus
@@ -7385,7 +7385,7 @@ VitessShardStatus
 <tbody>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7399,7 +7399,7 @@ Can be True, False, Unknown.</p>
 </tr>
 <tr>
 <td>
-<code>lastTransitionTime</code></br>
+<code>lastTransitionTime</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -7413,7 +7413,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>reason</code></br>
+<code>reason</code><br>
 <em>
 string
 </em>
@@ -7425,7 +7425,7 @@ Optional.</p>
 </tr>
 <tr>
 <td>
-<code>message</code></br>
+<code>message</code><br>
 <em>
 string
 </em>
@@ -7462,7 +7462,7 @@ VitessShardConditionType and the value is a VitessShardCondition.</p>
 <tbody>
 <tr>
 <td>
-<code>VitessShardTemplate</code></br>
+<code>VitessShardTemplate</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTemplate">
 VitessShardTemplate
@@ -7480,7 +7480,7 @@ The rest of the fields below are filled in by the parent controller.</p>
 </tr>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -7491,7 +7491,7 @@ string
 </tr>
 <tr>
 <td>
-<code>databaseName</code></br>
+<code>databaseName</code><br>
 <em>
 string
 </em>
@@ -7504,7 +7504,7 @@ the keyspace level.</p>
 </tr>
 <tr>
 <td>
-<code>zoneMap</code></br>
+<code>zoneMap</code><br>
 <em>
 map[string]string
 </em>
@@ -7516,7 +7516,7 @@ for all cells defined in the VitessCluster.</p>
 </tr>
 <tr>
 <td>
-<code>images</code></br>
+<code>images</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyspaceImages">
 VitessKeyspaceImages
@@ -7532,7 +7532,7 @@ controller that owns this VitessShard.</p>
 </tr>
 <tr>
 <td>
-<code>imagePullPolicies</code></br>
+<code>imagePullPolicies</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessImagePullPolicies">
 VitessImagePullPolicies
@@ -7545,7 +7545,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>imagePullSecrets</code></br>
+<code>imagePullSecrets</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">
 []Kubernetes core/v1.LocalObjectReference
@@ -7558,7 +7558,7 @@ VitessImagePullPolicies
 </tr>
 <tr>
 <td>
-<code>keyRange</code></br>
+<code>keyRange</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessKeyRange">
 VitessKeyRange
@@ -7571,7 +7571,7 @@ VitessKeyRange
 </tr>
 <tr>
 <td>
-<code>globalLockserver</code></br>
+<code>globalLockserver</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessLockserverParams">
 VitessLockserverParams
@@ -7584,7 +7584,7 @@ VitessLockserverParams
 </tr>
 <tr>
 <td>
-<code>vitessOrchestrator</code></br>
+<code>vitessOrchestrator</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessOrchestratorSpec">
 VitessOrchestratorSpec
@@ -7597,7 +7597,7 @@ VitessOrchestratorSpec
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupLocation">
 []VitessBackupLocation
@@ -7610,7 +7610,7 @@ VitessOrchestratorSpec
 </tr>
 <tr>
 <td>
-<code>backupEngine</code></br>
+<code>backupEngine</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessBackupEngine">
 VitessBackupEngine
@@ -7623,7 +7623,7 @@ VitessBackupEngine
 </tr>
 <tr>
 <td>
-<code>extraVitessFlags</code></br>
+<code>extraVitessFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -7634,7 +7634,7 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>topologyReconciliation</code></br>
+<code>topologyReconciliation</code><br>
 <em>
 <a href="#planetscale.com/v2.TopoReconcileConfig">
 TopoReconcileConfig
@@ -7647,7 +7647,7 @@ TopoReconcileConfig
 </tr>
 <tr>
 <td>
-<code>updateStrategy</code></br>
+<code>updateStrategy</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessClusterUpdateStrategy">
 VitessClusterUpdateStrategy
@@ -7679,7 +7679,7 @@ VitessClusterUpdateStrategy
 <tbody>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br>
 <em>
 int64
 </em>
@@ -7690,7 +7690,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>tablets</code></br>
+<code>tablets</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessTabletStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessTabletStatus
@@ -7703,7 +7703,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessTabletS
 </tr>
 <tr>
 <td>
-<code>orphanedTablets</code></br>
+<code>orphanedTablets</code><br>
 <em>
 <a href="#planetscale.com/v2.OrphanStatus">
 map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
@@ -7716,7 +7716,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -7727,7 +7727,7 @@ map[string]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.OrphanStatus
 </tr>
 <tr>
 <td>
-<code>vitessOrchestrator</code></br>
+<code>vitessOrchestrator</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessOrchestratorStatus">
 VitessOrchestratorStatus
@@ -7740,7 +7740,7 @@ VitessOrchestratorStatus
 </tr>
 <tr>
 <td>
-<code>hasMaster</code></br>
+<code>hasMaster</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7754,7 +7754,7 @@ reflects a master for this shard.</p>
 </tr>
 <tr>
 <td>
-<code>hasInitialBackup</code></br>
+<code>hasInitialBackup</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7768,7 +7768,7 @@ has been seeded for the shard.</p>
 </tr>
 <tr>
 <td>
-<code>servingWrites</code></br>
+<code>servingWrites</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7784,7 +7784,7 @@ the target of a resharding operation that is still in progress.</p>
 </tr>
 <tr>
 <td>
-<code>idle</code></br>
+<code>idle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -7800,7 +7800,7 @@ to turn down the shard.</p>
 </tr>
 <tr>
 <td>
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardCondition">
 map[planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardConditionType]planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.VitessShardCondition
@@ -7814,7 +7814,7 @@ It&rsquo;s ok for multiple controllers to add conditions here, and those conditi
 </tr>
 <tr>
 <td>
-<code>masterAlias</code></br>
+<code>masterAlias</code><br>
 <em>
 string
 </em>
@@ -7828,7 +7828,7 @@ condition whenever the distinction is important.</p>
 </tr>
 <tr>
 <td>
-<code>backupLocations</code></br>
+<code>backupLocations</code><br>
 <em>
 <a href="#planetscale.com/v2.*planetscale.dev/vitess-operator/pkg/apis/planetscale/v2.ShardBackupLocationStatus">
 []ShardBackupLocationStatus
@@ -7842,7 +7842,7 @@ each backup location.</p>
 </tr>
 <tr>
 <td>
-<code>lowestPodGeneration</code></br>
+<code>lowestPodGeneration</code><br>
 <em>
 int64
 </em>
@@ -7875,7 +7875,7 @@ subsequent generations that affect tablets may not be reflected in status yet.</
 <tbody>
 <tr>
 <td>
-<code>cell</code></br>
+<code>cell</code><br>
 <em>
 string
 </em>
@@ -7886,7 +7886,7 @@ string
 </tr>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessTabletPoolType">
 VitessTabletPoolType
@@ -7907,7 +7907,7 @@ VitessTabletPoolType
 </tr>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -7922,7 +7922,7 @@ Hence, you must specify ExternalDatastore when assigning a name to this field.</
 </tr>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br>
 <em>
 int32
 </em>
@@ -7935,7 +7935,7 @@ which will scale the pool down to 0 tablets.</p>
 </tr>
 <tr>
 <td>
-<code>dataVolumeClaimTemplate</code></br>
+<code>dataVolumeClaimTemplate</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#persistentvolumeclaimspec-v1-core">
 Kubernetes core/v1.PersistentVolumeClaimSpec
@@ -7954,7 +7954,7 @@ is set on the StorageClass specified in the storageClassName field here.</p>
 </tr>
 <tr>
 <td>
-<code>backupLocationName</code></br>
+<code>backupLocationName</code><br>
 <em>
 string
 </em>
@@ -7968,7 +7968,7 @@ Default: Use the backup location whose name is empty.</p>
 </tr>
 <tr>
 <td>
-<code>vttablet</code></br>
+<code>vttablet</code><br>
 <em>
 <a href="#planetscale.com/v2.VttabletSpec">
 VttabletSpec
@@ -7981,7 +7981,7 @@ VttabletSpec
 </tr>
 <tr>
 <td>
-<code>mysqld</code></br>
+<code>mysqld</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldSpec">
 MysqldSpec
@@ -7995,7 +7995,7 @@ You must specify either Mysqld or ExternalDatastore, but not both.</p>
 </tr>
 <tr>
 <td>
-<code>mysqldExporter</code></br>
+<code>mysqldExporter</code><br>
 <em>
 <a href="#planetscale.com/v2.MysqldExporterSpec">
 MysqldExporterSpec
@@ -8008,7 +8008,7 @@ MysqldExporterSpec
 </tr>
 <tr>
 <td>
-<code>externalDatastore</code></br>
+<code>externalDatastore</code><br>
 <em>
 <a href="#planetscale.com/v2.ExternalDatastore">
 ExternalDatastore
@@ -8022,7 +8022,7 @@ You must specify either Mysqld or ExternalDatastore, but not both.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -8039,7 +8039,7 @@ optimal scheduling of your pods if you choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -8051,7 +8051,7 @@ created for this component.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -8063,7 +8063,7 @@ created for this component.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -8078,7 +8078,7 @@ These values are applied to both the vttablet and mysqld containers.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -8096,7 +8096,7 @@ These volumes are available to be mounted by both vttablet and mysqld.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -8112,7 +8112,7 @@ These values are applied to both the vttablet and mysqld containers.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -8126,7 +8126,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -8140,7 +8140,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -8153,7 +8153,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>topologySpreadConstraints</code></br>
+<code>topologySpreadConstraints</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#topologyspreadconstraint-v1-core">
 []Kubernetes core/v1.TopologySpreadConstraint
@@ -8188,7 +8188,7 @@ specify how to spread vttablet pods among the given topology</p>
 <tbody>
 <tr>
 <td>
-<code>tabletPools</code></br>
+<code>tabletPools</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessShardTabletPool">
 []VitessShardTabletPool
@@ -8205,7 +8205,7 @@ in order to be able to serve.</p>
 </tr>
 <tr>
 <td>
-<code>databaseInitScriptSecret</code></br>
+<code>databaseInitScriptSecret</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -8220,7 +8220,7 @@ to set up initial tables and other MySQL-level entities needed by Vitess.</p>
 </tr>
 <tr>
 <td>
-<code>replication</code></br>
+<code>replication</code><br>
 <em>
 <a href="#planetscale.com/v2.VitessReplicationSpec">
 VitessReplicationSpec
@@ -8233,7 +8233,7 @@ VitessReplicationSpec
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -8274,7 +8274,7 @@ transient states are not valid pool types.</p>
 <tbody>
 <tr>
 <td>
-<code>poolType</code></br>
+<code>poolType</code><br>
 <em>
 string
 </em>
@@ -8285,7 +8285,7 @@ string
 </tr>
 <tr>
 <td>
-<code>index</code></br>
+<code>index</code><br>
 <em>
 int32
 </em>
@@ -8296,7 +8296,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>running</code></br>
+<code>running</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8309,7 +8309,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8323,7 +8323,7 @@ meaning it&rsquo;s ready to serve queries.</p>
 </tr>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8337,7 +8337,7 @@ for long enough to be considered stable.</p>
 </tr>
 <tr>
 <td>
-<code>dataVolumeBound</code></br>
+<code>dataVolumeBound</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8351,7 +8351,7 @@ matched up with a PersistentVolume and bound to it.</p>
 </tr>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br>
 <em>
 string
 </em>
@@ -8362,7 +8362,7 @@ string
 </tr>
 <tr>
 <td>
-<code>pendingChanges</code></br>
+<code>pendingChanges</code><br>
 <em>
 string
 </em>
@@ -8393,7 +8393,7 @@ the next time a rolling update allows.</p>
 <tbody>
 <tr>
 <td>
-<code>rbac</code></br>
+<code>rbac</code><br>
 <em>
 <a href="#planetscale.com/v2.SecretSource">
 SecretSource
@@ -8407,7 +8407,7 @@ If it is omitted, then it is considered to disable rbac.</p>
 </tr>
 <tr>
 <td>
-<code>cells</code></br>
+<code>cells</code><br>
 <em>
 []string
 </em>
@@ -8420,7 +8420,7 @@ Default: Deploy to all defined cells.</p>
 </tr>
 <tr>
 <td>
-<code>apiAddresses</code></br>
+<code>apiAddresses</code><br>
 <em>
 []string
 </em>
@@ -8435,7 +8435,7 @@ or it should match the length of the Cells list</p>
 </tr>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br>
 <em>
 int32
 </em>
@@ -8446,7 +8446,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>webResources</code></br>
+<code>webResources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -8459,7 +8459,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>apiResources</code></br>
+<code>apiResources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -8472,7 +8472,7 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 <tr>
 <td>
-<code>readOnly</code></br>
+<code>readOnly</code><br>
 <em>
 bool
 </em>
@@ -8485,7 +8485,7 @@ or should it allow users to take actions</p>
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -8500,7 +8500,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>extraEnv</code></br>
+<code>extraEnv</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
@@ -8514,7 +8514,7 @@ set by the operator, or pass additional environment variables.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumes</code></br>
+<code>extraVolumes</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">
 []Kubernetes core/v1.Volume
@@ -8531,7 +8531,7 @@ should be mounted.</p>
 </tr>
 <tr>
 <td>
-<code>extraVolumeMounts</code></br>
+<code>extraVolumeMounts</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core">
 []Kubernetes core/v1.VolumeMount
@@ -8546,7 +8546,7 @@ Typically, these are used to mount volumes defined through extraVolumes.</p>
 </tr>
 <tr>
 <td>
-<code>initContainers</code></br>
+<code>initContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -8560,7 +8560,7 @@ that will be run to completion one after another before any app containers are s
 </tr>
 <tr>
 <td>
-<code>sidecarContainers</code></br>
+<code>sidecarContainers</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">
 []Kubernetes core/v1.Container
@@ -8574,7 +8574,7 @@ that run alongside the main containers.</p>
 </tr>
 <tr>
 <td>
-<code>affinity</code></br>
+<code>affinity</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#affinity-v1-core">
 Kubernetes core/v1.Affinity
@@ -8590,7 +8590,7 @@ choose to set this field.</p>
 </tr>
 <tr>
 <td>
-<code>annotations</code></br>
+<code>annotations</code><br>
 <em>
 map[string]string
 </em>
@@ -8603,7 +8603,7 @@ Pods that the vtadmin Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>extraLabels</code></br>
+<code>extraLabels</code><br>
 <em>
 map[string]string
 </em>
@@ -8616,7 +8616,7 @@ Pods that the vtadmin Deployment creates.</p>
 </tr>
 <tr>
 <td>
-<code>service</code></br>
+<code>service</code><br>
 <em>
 <a href="#planetscale.com/v2.ServiceOverrides">
 ServiceOverrides
@@ -8629,7 +8629,7 @@ ServiceOverrides
 </tr>
 <tr>
 <td>
-<code>tolerations</code></br>
+<code>tolerations</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core">
 []Kubernetes core/v1.Toleration
@@ -8661,7 +8661,7 @@ ServiceOverrides
 <tbody>
 <tr>
 <td>
-<code>available</code></br>
+<code>available</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -8674,7 +8674,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br>
 <em>
 string
 </em>
@@ -8704,7 +8704,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core">
 Kubernetes core/v1.ResourceRequirements
@@ -8719,7 +8719,7 @@ This field is required.</p>
 </tr>
 <tr>
 <td>
-<code>extraFlags</code></br>
+<code>extraFlags</code><br>
 <em>
 map[string]string
 </em>
@@ -8734,7 +8734,7 @@ set the string value to either &ldquo;true&rdquo; or &ldquo;false&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>lifecycle</code></br>
+<code>lifecycle</code><br>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lifecycle-v1-core">
 Kubernetes core/v1.Lifecycle
@@ -8748,7 +8748,7 @@ to vttablet container</p>
 </tr>
 <tr>
 <td>
-<code>terminationGracePeriodSeconds</code></br>
+<code>terminationGracePeriodSeconds</code><br>
 <em>
 int64
 </em>

--- a/docs/api/template/members.tpl
+++ b/docs/api/template/members.tpl
@@ -4,7 +4,7 @@
 {{ if not (hiddenMember .)}}
 <tr>
     <td>
-        <code>{{ fieldName . }}</code></br>
+        <code>{{ fieldName . }}</code><br>
         <em>
             {{ if linkForType .Type }}
                 <a href="{{linkForType .Type}}">

--- a/docs/api/template/type.tpl
+++ b/docs/api/template/type.tpl
@@ -34,7 +34,7 @@
         {{ if isExportedType . }}
         <tr>
             <td>
-                <code>apiVersion</code></br>
+                <code>apiVersion</code><br>
                 string</td>
             <td>
                 <code>
@@ -44,7 +44,7 @@
         </tr>
         <tr>
             <td>
-                <code>kind</code></br>
+                <code>kind</code><br>
                 string
             </td>
             <td><code>{{.Name.Name}}</code></td>


### PR DESCRIPTION
This PR updates the documentation to use proper line break so they render correctly in markdown.