### PR TITLE
Correctly set the resources of `mysqldExporter`

### DIFF
--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -229,7 +229,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 		}
 
 		if spec.MysqldExporter != nil && (len(spec.MysqldExporter.Resources.Limits) > 0 || len(spec.MysqldExporter.Resources.Requests) > 0) {
-			mysqldExporterContainer.Resources = spec.MysqldExporter.Resources
+			update.ResourceRequirements(&mysqldExporterContainer.Resources, &spec.MysqldExporter.Resources)
 		} else {
 			mysqldExporterContainer.Resources = corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{

--- a/pkg/operator/vttablet/pod.go
+++ b/pkg/operator/vttablet/pod.go
@@ -223,7 +223,15 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 			},
 			SecurityContext: securityContext,
 			VolumeMounts:    mysqldMounts,
-			Resources: corev1.ResourceRequirements{
+			// TODO(enisoc): Add readiness and liveness probes that make sense for mysqld-exporter.
+			//   This depends on the exact semantics of each of mysqld-exporter's HTTP handlers,
+			//   so we need to do more investigation. For now it's better to leave them empty.
+		}
+
+		if spec.MysqldExporter != nil && (len(spec.MysqldExporter.Resources.Limits) > 0 || len(spec.MysqldExporter.Resources.Requests) > 0) {
+			mysqldExporterContainer.Resources = spec.MysqldExporter.Resources
+		} else {
+			mysqldExporterContainer.Resources = corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    *resource.NewMilliQuantity(mysqldExporterCPURequestMillis, resource.DecimalSI),
 					corev1.ResourceMemory: *resource.NewQuantity(mysqldExporterMemoryRequestBytes, resource.BinarySI),
@@ -234,14 +242,7 @@ func UpdatePod(obj *corev1.Pod, spec *Spec) {
 					corev1.ResourceCPU:    *resource.NewMilliQuantity(mysqldExporterCPULimitMillis, resource.DecimalSI),
 					corev1.ResourceMemory: *resource.NewQuantity(mysqldExporterMemoryLimitBytes, resource.BinarySI),
 				},
-			},
-			// TODO(enisoc): Add readiness and liveness probes that make sense for mysqld-exporter.
-			//   This depends on the exact semantics of each of mysqld-exporter's HTTP handlers,
-			//   so we need to do more investigation. For now it's better to leave them empty.
-		}
-
-		if spec.MysqldExporter != nil {
-			update.ResourceRequirements(&mysqldExporterContainer.Resources, &spec.MysqldExporter.Resources)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/planetscale/vitess-operator/issues/311#issuecomment-2370883966, which was missed during the development and review of https://github.com/planetscale/vitess-operator/pull/494.

Fixes #311

We were merging the custom resources with the default resource setting, which led to empty field in the custom resource being filled by the default resources, even if we wanted these fields to be empty.

Here is what we get with the change introduced by the PR:
```yaml
            mysqldExporter:
              resources:
                limits:
                  memory: 125Mi
                requests:
                  cpu: 100m
                  memory: 50Mi
``` 

```
$ kubectl describe ...
  mysqld-exporter:
    Container ID:  
    Image:         prom/mysqld-exporter:v0.11.0
    Image ID:      
    Port:          9104/TCP
    Host Port:     0/TCP
    Command:
      /bin/mysqld_exporter
    Args:
      --config.my-cnf=/vt/vtdataroot/vt_2469782763/my.cnf
      --collect.info_schema.tables.databases=sys,_vt
    State:          Waiting
      Reason:       PodInitializing
    Ready:          False
    Restart Count:  0
    Limits:
      memory:  125Mi
    Requests:
      cpu:     100m
      memory:  50Mi
```