### PR TITLE
Remove usage of deleted flag in tests

### DIFF
--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -56,7 +56,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1

--- a/test/endtoend/operator/101_initial_cluster_autoscale.yaml
+++ b/test/endtoend/operator/101_initial_cluster_autoscale.yaml
@@ -56,7 +56,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1

--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -63,7 +63,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1

--- a/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
@@ -94,7 +94,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1

--- a/test/endtoend/operator/101_initial_cluster_unmanaged_tablet.yaml
+++ b/test/endtoend/operator/101_initial_cluster_unmanaged_tablet.yaml
@@ -57,7 +57,7 @@ spec:
           cpu: 10m
           memory: 64Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -52,7 +52,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1
@@ -96,7 +96,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1

--- a/test/endtoend/operator/302_new_shards.yaml
+++ b/test/endtoend/operator/302_new_shards.yaml
@@ -52,7 +52,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1
@@ -96,7 +96,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -51,7 +51,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     turndownPolicy: Immediate
     partitionings:
     - equal:
@@ -91,7 +91,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     turndownPolicy: Immediate
     partitionings:
     - equal:

--- a/test/endtoend/operator/cluster_autoscale.yaml
+++ b/test/endtoend/operator/cluster_autoscale.yaml
@@ -66,7 +66,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -56,7 +56,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
-        recovery-period-block-duration: 5s
+        instance-poll-time: 3s
     partitionings:
     - equal:
         parts: 1


### PR DESCRIPTION
### Description

The flag `recovery-period-block-duration` had been deprecated a while ago, and it has been deleted in the PR https://github.com/vitessio/vitess/pull/17218. This PR removes its usage in our tests and replaces them with a different supported flag.