### PR TITLE
Upgrade default etcd version to 3.5.17

### DIFF
--- a/docs/release-notes/2_15_0_summary.md
+++ b/docs/release-notes/2_15_0_summary.md
@@ -1,0 +1,20 @@
+## Major Changes
+
+### etcd Upgrade Path
+
+We have changed the default etcd version to `3.5.17`.
+
+You can upgrade by changing your YAML file to use the new Docker Image (`quay.io/coreos/etcd:v3.5.17`).
+
+### MySQL Upgrade Path
+
+With the latest version of Vitess (`v22.0.0`) the default MySQL version changed from `8.0.30` to `8.0.40`.
+
+In order for you to correctly upgrade, there is a certain path to follow:
+
+1. Add `innodb_fast_shutdown=0` to your extra cnf in your YAML file.
+2. Apply this file.
+3. Wait for all the pods to be healthy.
+4. Then change your YAML file to use the new Docker Image (`mysql:8.0.40`).
+5. Remove `innodb_fast_shutdown=0` from your extra cnf in your YAML file.
+6. Apply this file.

--- a/docs/release-notes/2_9_0_summary.md
+++ b/docs/release-notes/2_9_0_summary.md
@@ -18,7 +18,7 @@ Meaning that the `vitess/lite:v15.0.2` and `vitess/lite:v16.0.0` are running dif
 If you want to remain on MySQL 5.7, we invite you to use `vitess/lite:v16.0.0-mysql57`.
 
 Otherwise, if you were already running MySQL 8.0, with for instance `vitess/lite:v15.0.2-mysql80`, note that here the patch version of MySQL will also change between `v15` and `v16`.
-In `v16.0.0` we are bumping the patch version of MySQL 80 from `8.0.23` to `8.0.30`.
+In `v16.0.0` we are bumping the patch version of MySQL 8.0 from `8.0.23` to `8.0.30`.
 In order for you to correctly upgrade, there is a certain path to follow:
 
 1. Add `innodb_fast_shutdown=0` to your extra cnf in your YAML file.

--- a/pkg/apis/planetscale/v2/defaults.go
+++ b/pkg/apis/planetscale/v2/defaults.go
@@ -182,5 +182,5 @@ var (
 	// DefaultEtcdImage is the image to use for etcd when the CRD doesn't specify.
 	// This value can be configured at operator startup time with the
 	// --default_etcd_image flag.
-	DefaultEtcdImage = "quay.io/coreos/etcd:v3.5.9"
+	DefaultEtcdImage = "quay.io/coreos/etcd:v3.5.17"
 )

--- a/tools/get-kube-binaries.sh
+++ b/tools/get-kube-binaries.sh
@@ -14,7 +14,7 @@ KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL:-https://dl.k8s.io}"
 
 # This should be the etcd version downloaded by kubernetes/hack/lib/etcd.sh
 # as of the above Kubernetes version.
-ETCD_VERSION="${ETCD_VERSION:-v3.3.15}"
+ETCD_VERSION="${ETCD_VERSION:-v3.5.17}"
 ETCD_RELEASE_URL="${ETCD_RELEASE_URL:-https://github.com/coreos/etcd/releases/download}"
 
 DIR="${BASH_SOURCE%/*}"


### PR DESCRIPTION
This PR upgrades the default etcd version to 3.5.17.

Corresponding PR on vitess: https://github.com/vitessio/vitess/pull/17653