### PR TITLE
Use vtbackup in scheduled backups

### DIFF
--- a/deploy/crds/planetscale.com_vitessbackupschedules.yaml
+++ b/deploy/crds/planetscale.com_vitessbackupschedules.yaml
@@ -114,8 +114,6 @@ spec:
                       example: commerce
                       type: string
                     name:
-                      enum:
-                      - BackupShard
                       type: string
                     shard:
                       example: '-'
@@ -165,6 +163,11 @@ spec:
               lastScheduledTime:
                 format: date-time
                 type: string
+              lastScheduledTimes:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                type: object
             type: object
         type: object
     served: true

--- a/deploy/crds/planetscale.com_vitessbackupschedules.yaml
+++ b/deploy/crds/planetscale.com_vitessbackupschedules.yaml
@@ -38,6 +38,7 @@ spec:
               cluster:
                 type: string
               concurrencyPolicy:
+                default: Forbid
                 enum:
                 - Allow
                 - Forbid

--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -168,6 +168,7 @@ spec:
                             type: string
                           type: object
                         concurrencyPolicy:
+                          default: Forbid
                           enum:
                           - Allow
                           - Forbid

--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -240,8 +240,6 @@ spec:
                                 example: commerce
                                 type: string
                               name:
-                                enum:
-                                - BackupShard
                                 type: string
                               shard:
                                 example: '-'

--- a/docs/api.md
+++ b/docs/api.md
@@ -2591,7 +2591,7 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 <td>
 <em>(Optional)</em>
 <p>A list of pointers to currently running jobs.
-This field is deprecated and no longer used in &gt;= v2.15. It will be removed in a future release.</p>
+This field is deprecated and no longer used in versions &gt;= v2.15. It will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -2606,7 +2606,7 @@ Kubernetes meta/v1.Time
 <td>
 <em>(Optional)</em>
 <p>Information when was the last time the job was successfully scheduled.
-This field is deprecated and no longer used in &gt;= v2.15. It will be removed in a future release.
+This field is deprecated and no longer used in versions &gt;= v2.15. It will be removed in a future release.
 Please use lastScheduledTimes instead which maps the last schedule time to each VitessBackupScheduleStrategy
 in the VitessBackupSchedule.</p>
 </td>
@@ -2622,8 +2622,8 @@ map[string]*k8s.io/apimachinery/pkg/apis/meta/v1.Time
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastScheduledTimes lists for every VitessBackupScheduleStrategy what is the last schedule we executed.
-It does not list when the last execution started, but to which scheduled time it corresponds.</p>
+<p>A list of the last schedule we executed for each VitessBackupScheduleStrategy.
+Note that these are not the times when the last execution started, only the scheduled times.</p>
 </td>
 </tr>
 </tbody>
@@ -2749,7 +2749,7 @@ string
 <p>Strategy defines how we are going to take a backup.
 If you want to take several backups within the same schedule you can add more items
 to the Strategy list. Each VitessBackupScheduleStrategy will be executed within different
-K8S Jobs. This is useful if you want to have a single schedule backing up multiple shards
+kubernetes jobs. This is useful if you want to have a single schedule backing up multiple shards
 at the same time.</p>
 </td>
 </tr>

--- a/docs/api.md
+++ b/docs/api.md
@@ -647,16 +647,6 @@ SecretSource
 </tr>
 </tbody>
 </table>
-<h3 id="planetscale.com/v2.BackupStrategyName">BackupStrategyName
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#planetscale.com/v2.VitessBackupScheduleStrategy">VitessBackupScheduleStrategy</a>)
-</p>
-<p>
-<p>BackupStrategyName describes the vtctldclient command that will be used to take a backup.
-When scheduling a backup, you must specify at least one strategy.</p>
-</p>
 <h3 id="planetscale.com/v2.CephBackupLocation">CephBackupLocation
 </h3>
 <p>
@@ -2600,7 +2590,8 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 </td>
 <td>
 <em>(Optional)</em>
-<p>A list of pointers to currently running jobs.</p>
+<p>A list of pointers to currently running jobs.
+This field is deprecated and no longer used in &gt;= v2.15. It will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -2614,7 +2605,25 @@ Kubernetes meta/v1.Time
 </td>
 <td>
 <em>(Optional)</em>
-<p>Information when was the last time the job was successfully scheduled.</p>
+<p>Information when was the last time the job was successfully scheduled.
+This field is deprecated and no longer used in &gt;= v2.15. It will be removed in a future release.
+Please use lastScheduledTimes instead which maps the last schedule time to each VitessBackupScheduleStrategy
+in the VitessBackupSchedule.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastScheduledTimes</code><br>
+<em>
+<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#*k8s.io/apimachinery/pkg/apis/meta/v1.time--">
+map[string]*k8s.io/apimachinery/pkg/apis/meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LastScheduledTimes lists for every VitessBackupScheduleStrategy what is the last schedule we executed.
+It does not list when the last execution started, but to which scheduled time it corresponds.</p>
 </td>
 </tr>
 </tbody>
@@ -2642,9 +2651,7 @@ command line that will be executed in the Job&rsquo;s pod.</p>
 <td>
 <code>name</code><br>
 <em>
-<a href="#planetscale.com/v2.BackupStrategyName">
-BackupStrategyName
-</a>
+string
 </em>
 </td>
 <td>
@@ -2741,11 +2748,9 @@ string
 <td>
 <p>Strategy defines how we are going to take a backup.
 If you want to take several backups within the same schedule you can add more items
-to the Strategy list. Each VitessBackupScheduleStrategy will be executed by the same
-kubernetes job. This is useful if for instance you have one schedule, and you want to
-take a backup of all shards in a keyspace and don&rsquo;t want to re-create a second schedule.
-All the VitessBackupScheduleStrategy are concatenated into a single shell command that
-is executed when the Job&rsquo;s container starts.</p>
+to the Strategy list. Each VitessBackupScheduleStrategy will be executed within different
+K8S Jobs. This is useful if you want to have a single schedule backing up multiple shards
+at the same time.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api.md
+++ b/docs/api.md
@@ -2828,8 +2828,8 @@ ConcurrencyPolicy
 <em>(Optional)</em>
 <p>ConcurrencyPolicy specifies ho to treat concurrent executions of a Job.
 Valid values are:
-- &ldquo;Allow&rdquo; (default): allows CronJobs to run concurrently;
-- &ldquo;Forbid&rdquo;: forbids concurrent runs, skipping next run if previous run hasn&rsquo;t finished yet;
+- &ldquo;Allow&rdquo;: allows CronJobs to run concurrently;
+- &ldquo;Forbid&rdquo; (default): forbids concurrent runs, skipping next run if previous run hasn&rsquo;t finished yet;
 - &ldquo;Replace&rdquo;: cancels currently running job and replaces it with a new one.</p>
 </td>
 </tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -2830,8 +2830,8 @@ ConcurrencyPolicy
 <em>(Optional)</em>
 <p>ConcurrencyPolicy specifies ho to treat concurrent executions of a Job.
 Valid values are:
-- &ldquo;Allow&rdquo; (default): allows CronJobs to run concurrently;
-- &ldquo;Forbid&rdquo;: forbids concurrent runs, skipping next run if previous run hasn&rsquo;t finished yet;
+- &ldquo;Allow&rdquo;: allows CronJobs to run concurrently;
+- &ldquo;Forbid&rdquo; (default): forbids concurrent runs, skipping next run if previous run hasn&rsquo;t finished yet;
 - &ldquo;Replace&rdquo;: cancels currently running job and replaces it with a new one.</p>
 </td>
 </tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -649,16 +649,6 @@ SecretSource
 </tr>
 </tbody>
 </table>
-<h3 id="planetscale.com/v2.BackupStrategyName">BackupStrategyName
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#planetscale.com/v2.VitessBackupScheduleStrategy">VitessBackupScheduleStrategy</a>)
-</p>
-<p>
-<p>BackupStrategyName describes the vtctldclient command that will be used to take a backup.
-When scheduling a backup, you must specify at least one strategy.</p>
-</p>
 <h3 id="planetscale.com/v2.CephBackupLocation">CephBackupLocation
 </h3>
 <p>
@@ -2602,7 +2592,8 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 </td>
 <td>
 <em>(Optional)</em>
-<p>A list of pointers to currently running jobs.</p>
+<p>A list of pointers to currently running jobs.
+This field is deprecated and no longer used in &gt;= v2.15. It will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -2616,7 +2607,25 @@ Kubernetes meta/v1.Time
 </td>
 <td>
 <em>(Optional)</em>
-<p>Information when was the last time the job was successfully scheduled.</p>
+<p>Information when was the last time the job was successfully scheduled.
+This field is deprecated and no longer used in &gt;= v2.15. It will be removed in a future release.
+Please use lastScheduledTimes instead which maps the last schedule time to each VitessBackupScheduleStrategy
+in the VitessBackupSchedule.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastScheduledTimes</code><br>
+<em>
+<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#*k8s.io/apimachinery/pkg/apis/meta/v1.time--">
+map[string]*k8s.io/apimachinery/pkg/apis/meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LastScheduledTimes lists for every VitessBackupScheduleStrategy what is the last schedule we executed.
+It does not list when the last execution started, but to which scheduled time it corresponds.</p>
 </td>
 </tr>
 </tbody>
@@ -2644,9 +2653,7 @@ command line that will be executed in the Job&rsquo;s pod.</p>
 <td>
 <code>name</code><br>
 <em>
-<a href="#planetscale.com/v2.BackupStrategyName">
-BackupStrategyName
-</a>
+string
 </em>
 </td>
 <td>
@@ -2743,11 +2750,9 @@ string
 <td>
 <p>Strategy defines how we are going to take a backup.
 If you want to take several backups within the same schedule you can add more items
-to the Strategy list. Each VitessBackupScheduleStrategy will be executed by the same
-kubernetes job. This is useful if for instance you have one schedule, and you want to
-take a backup of all shards in a keyspace and don&rsquo;t want to re-create a second schedule.
-All the VitessBackupScheduleStrategy are concatenated into a single shell command that
-is executed when the Job&rsquo;s container starts.</p>
+to the Strategy list. Each VitessBackupScheduleStrategy will be executed within different
+K8S Jobs. This is useful if you want to have a single schedule backing up multiple shards
+at the same time.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -2593,7 +2593,7 @@ The PullPolicy used will be the same as the one used to pull the vtctld image.</
 <td>
 <em>(Optional)</em>
 <p>A list of pointers to currently running jobs.
-This field is deprecated and no longer used in &gt;= v2.15. It will be removed in a future release.</p>
+This field is deprecated and no longer used in versions &gt;= v2.15. It will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -2608,7 +2608,7 @@ Kubernetes meta/v1.Time
 <td>
 <em>(Optional)</em>
 <p>Information when was the last time the job was successfully scheduled.
-This field is deprecated and no longer used in &gt;= v2.15. It will be removed in a future release.
+This field is deprecated and no longer used in versions &gt;= v2.15. It will be removed in a future release.
 Please use lastScheduledTimes instead which maps the last schedule time to each VitessBackupScheduleStrategy
 in the VitessBackupSchedule.</p>
 </td>
@@ -2624,8 +2624,8 @@ map[string]*k8s.io/apimachinery/pkg/apis/meta/v1.Time
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastScheduledTimes lists for every VitessBackupScheduleStrategy what is the last schedule we executed.
-It does not list when the last execution started, but to which scheduled time it corresponds.</p>
+<p>A list of the last schedule we executed for each VitessBackupScheduleStrategy.
+Note that these are not the times when the last execution started, only the scheduled times.</p>
 </td>
 </tr>
 </tbody>
@@ -2751,7 +2751,7 @@ string
 <p>Strategy defines how we are going to take a backup.
 If you want to take several backups within the same schedule you can add more items
 to the Strategy list. Each VitessBackupScheduleStrategy will be executed within different
-K8S Jobs. This is useful if you want to have a single schedule backing up multiple shards
+kubernetes jobs. This is useful if you want to have a single schedule backing up multiple shards
 at the same time.</p>
 </td>
 </tr>

--- a/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
@@ -136,11 +136,12 @@ type VitessBackupScheduleTemplate struct {
 
 	// ConcurrencyPolicy specifies ho to treat concurrent executions of a Job.
 	// Valid values are:
-	// - "Allow" (default): allows CronJobs to run concurrently;
-	// - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
+	// - "Allow": allows CronJobs to run concurrently;
+	// - "Forbid" (default): forbids concurrent runs, skipping next run if previous run hasn't finished yet;
 	// - "Replace": cancels currently running job and replaces it with a new one.
 	// +optional
 	// +kubebuilder:example="Forbid"
+	// +kubebuilder:default="Forbid"
 	ConcurrencyPolicy ConcurrencyPolicy `json:"concurrencyPolicy,omitempty"`
 
 	// AllowedMissedRuns defines how many missed run of the schedule will be allowed before giving up on finding the last job.

--- a/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
@@ -34,16 +34,6 @@ const (
 	ForbidConcurrent ConcurrencyPolicy = "Forbid"
 )
 
-// BackupStrategyName describes the vtctldclient command that will be used to take a backup.
-// When scheduling a backup, you must specify at least one strategy.
-// +kubebuilder:validation:Enum=BackupShard
-type BackupStrategyName string
-
-const (
-	// BackupShard will use the "vtctldclient BackupShard" command to take a backup
-	BackupShard BackupStrategyName = "BackupShard"
-)
-
 // VitessBackupSchedule is the Schema for the VitessBackupSchedule API.
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
@@ -98,12 +88,12 @@ type VitessBackupScheduleTemplate struct {
 
 	// Strategy defines how we are going to take a backup.
 	// If you want to take several backups within the same schedule you can add more items
-	// to the Strategy list. Each VitessBackupScheduleStrategy will be executed by the same
-	// kubernetes job. This is useful if for instance you have one schedule, and you want to
-	// take a backup of all shards in a keyspace and don't want to re-create a second schedule.
-	// All the VitessBackupScheduleStrategy are concatenated into a single shell command that
-	// is executed when the Job's container starts.
+	// to the Strategy list. Each VitessBackupScheduleStrategy will be executed within different
+	// K8S Jobs. This is useful if you want to have a single schedule backing up multiple shards
+	// at the same time.
 	// +kubebuilder:validation:MinItems=1
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Strategy []VitessBackupScheduleStrategy `json:"strategies"`
 
 	// Resources specify the compute resources to allocate for every Jobs's pod.
@@ -181,7 +171,7 @@ type VitessBackupScheduleTemplate struct {
 // command line that will be executed in the Job's pod.
 type VitessBackupScheduleStrategy struct {
 	// Name of the backup strategy.
-	Name BackupStrategyName `json:"name"`
+	Name string `json:"name"`
 
 	// Keyspace defines the keyspace on which we want to take the backup.
 	// +kubebuilder:example="commerce"
@@ -199,12 +189,32 @@ type VitessBackupScheduleStrategy struct {
 // VitessBackupScheduleStatus defines the observed state of VitessBackupSchedule
 type VitessBackupScheduleStatus struct {
 	// A list of pointers to currently running jobs.
+	// This field is deprecated and no longer used in >= v2.15. It will be removed in a future release.
 	// +optional
 	Active []corev1.ObjectReference `json:"active,omitempty"`
 
 	// Information when was the last time the job was successfully scheduled.
+	// This field is deprecated and no longer used in >= v2.15. It will be removed in a future release.
+	// Please use lastScheduledTimes instead which maps the last schedule time to each VitessBackupScheduleStrategy
+	// in the VitessBackupSchedule.
 	// +optional
 	LastScheduledTime *metav1.Time `json:"lastScheduledTime,omitempty"`
+
+	// LastScheduledTimes lists for every VitessBackupScheduleStrategy what is the last schedule we executed.
+	// It does not list when the last execution started, but to which scheduled time it corresponds.
+	// +optional
+	LastScheduledTimes map[string]*metav1.Time `json:"lastScheduledTimes,omitempty"`
+}
+
+// NewVitessBackupScheduleStatus creates a new status with default values.
+func NewVitessBackupScheduleStatus(status VitessBackupScheduleStatus) VitessBackupScheduleStatus {
+	newStatus := VitessBackupScheduleStatus{
+		LastScheduledTimes: status.LastScheduledTimes,
+	}
+	if status.LastScheduledTimes == nil {
+		newStatus.LastScheduledTimes = make(map[string]*metav1.Time)
+	}
+	return newStatus
 }
 
 func init() {

--- a/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
@@ -89,7 +89,7 @@ type VitessBackupScheduleTemplate struct {
 	// Strategy defines how we are going to take a backup.
 	// If you want to take several backups within the same schedule you can add more items
 	// to the Strategy list. Each VitessBackupScheduleStrategy will be executed within different
-	// K8S Jobs. This is useful if you want to have a single schedule backing up multiple shards
+	// kubernetes jobs. This is useful if you want to have a single schedule backing up multiple shards
 	// at the same time.
 	// +kubebuilder:validation:MinItems=1
 	// +patchMergeKey=name
@@ -189,19 +189,19 @@ type VitessBackupScheduleStrategy struct {
 // VitessBackupScheduleStatus defines the observed state of VitessBackupSchedule
 type VitessBackupScheduleStatus struct {
 	// A list of pointers to currently running jobs.
-	// This field is deprecated and no longer used in >= v2.15. It will be removed in a future release.
+	// This field is deprecated and no longer used in versions >= v2.15. It will be removed in a future release.
 	// +optional
 	Active []corev1.ObjectReference `json:"active,omitempty"`
 
 	// Information when was the last time the job was successfully scheduled.
-	// This field is deprecated and no longer used in >= v2.15. It will be removed in a future release.
+	// This field is deprecated and no longer used in versions >= v2.15. It will be removed in a future release.
 	// Please use lastScheduledTimes instead which maps the last schedule time to each VitessBackupScheduleStrategy
 	// in the VitessBackupSchedule.
 	// +optional
 	LastScheduledTime *metav1.Time `json:"lastScheduledTime,omitempty"`
 
-	// LastScheduledTimes lists for every VitessBackupScheduleStrategy what is the last schedule we executed.
-	// It does not list when the last execution started, but to which scheduled time it corresponds.
+	// A list of the last schedule we executed for each VitessBackupScheduleStrategy.
+	// Note that these are not the times when the last execution started, only the scheduled times.
 	// +optional
 	LastScheduledTimes map[string]*metav1.Time `json:"lastScheduledTimes,omitempty"`
 }

--- a/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/planetscale/v2/zz_generated.deepcopy.go
@@ -7,6 +7,7 @@ package v2
 import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -854,6 +855,13 @@ func (in *VitessBackupScheduleStatus) DeepCopyInto(out *VitessBackupScheduleStat
 	if in.LastScheduledTime != nil {
 		in, out := &in.LastScheduledTime, &out.LastScheduledTime
 		*out = (*in).DeepCopy()
+	}
+	if in.LastScheduledTimes != nil {
+		in, out := &in.LastScheduledTimes, &out.LastScheduledTimes
+		*out = make(map[string]*metav1.Time, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
 	}
 }
 

--- a/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
+++ b/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
@@ -577,8 +577,9 @@ func (r *ReconcileVitessBackupsSchedule) createJob(
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		return nil, fmt.Errorf("PVC already exists for job %s", job.Name)
 	}
-
 	return job, nil
 }
 
@@ -595,7 +596,7 @@ func (r *ReconcileVitessBackupsSchedule) createJobPod(
 		return nil, nil, err
 	}
 
-	_, completeBackups, err := vitessbackup.GetBackups(ctx, vbsc.Namespace, vbsc.Spec.Cluster, strategy.Keyspace, vkr.SafeName(),
+	_, completedBackups, err := vitessbackup.GetBackups(ctx, vbsc.Namespace, vbsc.Spec.Cluster, strategy.Keyspace, vkr.SafeName(),
 		func(ctx context.Context, allBackupsList *planetscalev2.VitessBackupList, listOpts *client.ListOptions) error {
 			return r.client.List(ctx, allBackupsList, listOpts)
 		},
@@ -605,7 +606,7 @@ func (r *ReconcileVitessBackupsSchedule) createJobPod(
 	}
 
 	backupType := vitessbackup.TypeUpdate
-	if len(completeBackups) == 0 {
+	if len(completedBackups) == 0 {
 		if vts.Status.HasMaster == corev1.ConditionTrue {
 			backupType = vitessbackup.TypeFirstBackup
 		} else {

--- a/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
+++ b/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
@@ -59,8 +59,7 @@ import (
 )
 
 const (
-	controllerName   = "vitessbackupschedule-controller"
-	vtctldclientPath = "/vt/bin/vtctldclient"
+	controllerName = "vitessbackupschedule-controller"
 )
 
 var (
@@ -627,18 +626,6 @@ func (r *ReconcileVitessBackupsSchedule) createJobPod(
 
 	p.Spec.Affinity = vbsc.Spec.Affinity
 	return p, vtbackupSpec, nil
-}
-
-func createVtctldClientCommand(cmd *strings.Builder, serverAddr string, extraFlags map[string]string, keyspace, shard string) {
-	cmd.WriteString(fmt.Sprintf("%s %s BackupShard", vtctldclientPath, serverAddr))
-
-	// Add any flags
-	for key, value := range extraFlags {
-		cmd.WriteString(fmt.Sprintf(" --%s=%s", key, value))
-	}
-
-	// Add keyspace/shard
-	cmd.WriteString(fmt.Sprintf(" %s/%s", keyspace, shard))
 }
 
 func (r *ReconcileVitessBackupsSchedule) getVtctldServiceName(ctx context.Context, vbsc *planetscalev2.VitessBackupSchedule, cluster string) (svcName string, svcPort int32, err error) {

--- a/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
+++ b/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
@@ -608,7 +608,7 @@ func (r *ReconcileVitessBackupsSchedule) createJobPod(
 	backupType := vitessbackup.TypeUpdate
 	if len(completedBackups) == 0 {
 		if vts.Status.HasMaster == corev1.ConditionTrue {
-			backupType = vitessbackup.TypeFirstBackup
+			return nil, nil, fmt.Errorf("this shard has 0 backup and a running primary, the schedule cannot create an empty backup, please create a backup manually first")
 		} else {
 			backupType = vitessbackup.TypeInit
 		}

--- a/pkg/controller/vitessshard/reconcile_backup_job.go
+++ b/pkg/controller/vitessshard/reconcile_backup_job.go
@@ -84,7 +84,7 @@ func (r *ReconcileVitessShard) reconcileBackupJob(ctx context.Context, vts *plan
 		// scratch (not from any tablet). If we're wrong and a backup exists
 		// already, the idempotent vtbackup "initial backup" mode will just do
 		// nothing and return success.
-		backupType := vitessbackup.TypeUpdate
+		backupType := vitessbackup.TypeFirstBackup
 		if vts.Status.HasMaster != corev1.ConditionTrue {
 			backupType = vitessbackup.TypeInit
 		}

--- a/pkg/controller/vitessshard/reconcile_backup_job.go
+++ b/pkg/controller/vitessshard/reconcile_backup_job.go
@@ -78,17 +78,13 @@ func (r *ReconcileVitessShard) reconcileBackupJob(ctx context.Context, vts *plan
 		Name:      initPodName,
 	}
 
-	if len(completeBackups) == 0 {
+	if len(completeBackups) == 0 && vts.Status.HasMaster != corev1.ConditionTrue {
 		// Until we see at least one complete backup, we attempt to create an
 		// "initial backup", which is a special imaginary backup created from
 		// scratch (not from any tablet). If we're wrong and a backup exists
 		// already, the idempotent vtbackup "initial backup" mode will just do
 		// nothing and return success.
-		backupType := vitessbackup.TypeFirstBackup
-		if vts.Status.HasMaster != corev1.ConditionTrue {
-			backupType = vitessbackup.TypeInit
-		}
-		initSpec := MakeVtbackupSpec(initPodKey, vts, labels, backupType)
+		initSpec := MakeVtbackupSpec(initPodKey, vts, labels, vitessbackup.TypeInit)
 		if initSpec != nil {
 			podKeys = append(podKeys, initPodKey)
 			if initSpec.TabletSpec.DataVolumePVCSpec != nil {
@@ -245,7 +241,6 @@ func vtbackupSpec(key client.ObjectKey, vts *planetscalev2.VitessShard, parentLa
 
 	return &vttablet.BackupSpec{
 		InitialBackup:     backupType == vitessbackup.TypeInit,
-		AllowFirstBackup:  backupType == vitessbackup.TypeFirstBackup,
 		MinBackupInterval: minBackupInterval,
 		MinRetentionTime:  minRetentionTime,
 		MinRetentionCount: minRetentionCount,

--- a/pkg/operator/vitessbackup/labels.go
+++ b/pkg/operator/vitessbackup/labels.go
@@ -24,8 +24,6 @@ const (
 
 	// TypeInit is a backup taken to initialize an empty shard.
 	TypeInit = "init"
-	// TypeFirstBackup is a backup taken when no other backup exist in an existing shard.
-	TypeFirstBackup = "empty"
 	// TypeUpdate is a backup taken to update the latest backup for a shard.
 	TypeUpdate = "update"
 )

--- a/pkg/operator/vitessbackup/labels.go
+++ b/pkg/operator/vitessbackup/labels.go
@@ -24,6 +24,8 @@ const (
 
 	// TypeInit is a backup taken to initialize an empty shard.
 	TypeInit = "init"
+	// TypeFirstBackup is a backup taken when no other backup exist in an existing shard.
+	TypeFirstBackup = "empty"
 	// TypeUpdate is a backup taken to update the latest backup for a shard.
 	TypeUpdate = "update"
 )

--- a/pkg/operator/vttablet/flags.go
+++ b/pkg/operator/vttablet/flags.go
@@ -104,7 +104,6 @@ func init() {
 			// vtbackup-specific flags.
 			"concurrency":         vtbackupConcurrency,
 			"initial_backup":      backupSpec.InitialBackup,
-			"allow_first_backup":  backupSpec.AllowFirstBackup,
 			"min_backup_interval": backupSpec.MinBackupInterval,
 			"min_retention_time":  backupSpec.MinRetentionTime,
 			"min_retention_count": backupSpec.MinRetentionCount,

--- a/pkg/operator/vttablet/flags.go
+++ b/pkg/operator/vttablet/flags.go
@@ -104,6 +104,7 @@ func init() {
 			// vtbackup-specific flags.
 			"concurrency":         vtbackupConcurrency,
 			"initial_backup":      backupSpec.InitialBackup,
+			"allow_first_backup":  backupSpec.AllowFirstBackup,
 			"min_backup_interval": backupSpec.MinBackupInterval,
 			"min_retention_time":  backupSpec.MinRetentionTime,
 			"min_retention_count": backupSpec.MinRetentionCount,

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -61,8 +61,6 @@ type BackupSpec struct {
 	// aren't any. Instead, bootstrap the shard with a backup of an empty
 	// database.
 	InitialBackup bool
-	// AllowFirstBackup enables vtbackup to take a backup even if none exist.
-	AllowFirstBackup bool
 	// MinBackupInterval is the minimum spacing between backups.
 	// A new backup will only be taken if it's been at least this long since the
 	// most recent backup.

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -61,6 +61,8 @@ type BackupSpec struct {
 	// aren't any. Instead, bootstrap the shard with a backup of an empty
 	// database.
 	InitialBackup bool
+	// AllowFirstBackup enables vtbackup to take a backup even if none exist.
+	AllowFirstBackup bool
 	// MinBackupInterval is the minimum spacing between backups.
 	// A new backup will only be taken if it's been at least this long since the
 	// most recent backup.

--- a/test/endtoend/backup_schedule_test.sh
+++ b/test/endtoend/backup_schedule_test.sh
@@ -17,9 +17,9 @@ function verifyListBackupsOutputWithSchedule() {
   checkVitessBackupScheduleStatusWithTimeout "example-vbsc-every-five-minute(.*)"
 
   echo -e "Check for number of backups in the cluster"
-  # Sleep for 7 minutes, after 7 minutes we should at least have 3 backups: 1 from the initial vtbackup pod
+  # Sleep for 10 minutes, after 10 minutes we should at least have 3 backups: 1 from the initial vtbackup pod
   # 1 minimum from the every minute schedule, and 1 from the every-five minute schedule
-  for i in {1..420} ; do
+  for i in {1..600} ; do
     # Ensure that we can view the backup files from the host.
     docker exec -it $(docker container ls --format '{{.Names}}' | grep kind) chmod o+rwx -R /backup > /dev/null
     backupCount=$(kubectl get vtb --no-headers | wc -l)
@@ -35,7 +35,7 @@ function verifyListBackupsOutputWithSchedule() {
   fi
 
   echo -e "Check for Jobs' pods"
-  # Here check explicitly that the every five minute schedule ran at least once during the 7 minutes sleep
+  # Here check explicitly that the every five minute schedule ran at least once during the 10 minutes sleep
   checkPodExistWithTimeout "example-vbsc-every-minute-(.*)0/1(.*)Completed(.*)"
   checkPodExistWithTimeout "example-vbsc-every-five-minute-(.*)0/1(.*)Completed(.*)"
 }

--- a/test/endtoend/backup_schedule_test.sh
+++ b/test/endtoend/backup_schedule_test.sh
@@ -31,14 +31,14 @@ function verifyListBackupsOutputWithSchedule() {
   checkVitessBackupScheduleStatusWithTimeout "example-vbsc-every-five-minute(.*)"
 
   echo -e "Check for number of backups in the cluster"
-  # Sleep for 6 minutes, during this time we should have at the very minimum 7 backups.
-  # At least: 6 backups from the every-minute schedule, and 1 backup from the every-five-minute schedule.
+  # Sleep for 6 minutes, after 6 minutes we should at least have 3 backups: 1 from the initial vtbackup pod
+  # 1 minimum from the every minute schedule, and 1 from the every-five minute schedule
   sleep 360
 
   backupCount=$(kubectl get vtb --no-headers | wc -l)
-  if [[ "${backupCount}" -lt 7 ]]; then
-    echo "Did not find at least 7 backups"
-    return 0
+  if [[ "${backupCount}" -lt 3 ]]; then
+    echo "Did not find at least 3 backups"
+    exit 1
   fi
 
   echo -e "Check for Jobs' pods"

--- a/test/endtoend/backup_schedule_test.sh
+++ b/test/endtoend/backup_schedule_test.sh
@@ -31,27 +31,26 @@ function verifyListBackupsOutputWithSchedule() {
   checkVitessBackupScheduleStatusWithTimeout "example-vbsc-every-five-minute(.*)"
 
   echo -e "Check for number of backups in the cluster"
-  # Sleep for over 6 minutes, during this time we should have at the very minimum
-  # 7 backups. At least: 6 backups from the every-minute schedule, and 1 backup
-  # from the every-five-minute schedule.
-  for i in {1..6} ; do
+  # Sleep for 6 minutes, after 6 minutes we should at least have 3 backups: 1 from the initial vtbackup pod
+  # 1 minimum from the every minute schedule, and 1 from the every-five minute schedule
+  for i in {1..360} ; do
     # Ensure that we can view the backup files from the host.
     docker exec -it $(docker container ls --format '{{.Names}}' | grep kind) chmod o+rwx -R /backup > /dev/null
     backupCount=$(kubectl get vtb --no-headers | wc -l)
     echo "Found ${backupCount} backups"
-    if [[ "${backupCount}" -ge 7 ]]; then
+    if [[ "${backupCount}" -ge 3 ]]; then
       break
     fi
-    sleep 100
+    sleep 1
   done
-  if [[ "${backupCount}" -lt 7 ]]; then
-    echo "Did not find at least 7 backups"
+  if [[ "${backupCount}" -lt 3 ]]; then
+    echo "Did not find at least 3 backups"
     exit 1
   fi
 
   echo -e "Check for Jobs' pods"
-  checkPodStatusWithTimeout "example-vbsc-every-minute-(.*)0/1(.*)Completed(.*)" 3
-  checkPodStatusWithTimeout "example-vbsc-every-five-minute-(.*)0/1(.*)Completed(.*)" 2
+  checkPodExistWithTimeout "example-vbsc-every-minute-(.*)0/1(.*)Completed(.*)"
+  checkPodExistWithTimeout "example-vbsc-every-five-minute-(.*)0/1(.*)Completed(.*)"
 }
 
 # Test setup

--- a/test/endtoend/backup_schedule_test.sh
+++ b/test/endtoend/backup_schedule_test.sh
@@ -25,19 +25,16 @@ function verifyListBackupsOutputWithSchedule() {
     backupCount=$(kubectl get vtb --no-headers | wc -l)
     echo "Found ${backupCount} backups"
     if [[ "${backupCount}" -ge 3 ]]; then
-      break
+      echo -e "Check for Jobs' pods"
+      # Here check explicitly that the every five minute schedule ran at least once during the 10 minutes sleep
+      checkPodExistWithTimeout "example-vbsc-every-minute-(.*)0/1(.*)Completed(.*)"
+      checkPodExistWithTimeout "example-vbsc-every-five-minute-(.*)0/1(.*)Completed(.*)"
+      return
     fi
     sleep 1
   done
-  if [[ "${backupCount}" -ge 3 ]]; then
-    echo "Did not find at least 3 backups"
-    exit 1
-  fi
-
-  echo -e "Check for Jobs' pods"
-  # Here check explicitly that the every five minute schedule ran at least once during the 10 minutes sleep
-  checkPodExistWithTimeout "example-vbsc-every-minute-(.*)0/1(.*)Completed(.*)"
-  checkPodExistWithTimeout "example-vbsc-every-five-minute-(.*)0/1(.*)Completed(.*)"
+  echo "Did not find at least 3 backups"
+  exit 1
 }
 
 # Test setup

--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -7,6 +7,13 @@ kind: VitessCluster
 metadata:
   name: example
 spec:
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          hostPath:
+            path: /backup
+            type: Directory
   images:
     vtctld: vitess/lite:v21.0.0
     vtgate: vitess/lite:v21.0.0
@@ -14,7 +21,7 @@ spec:
     vtorc: vitess/lite:v21.0.0
     vtbackup: vitess/lite:v21.0.0
     mysqld:
-      mysql80Compatible: mysql:8.0.40
+      mysql80Compatible: vitess/lite:v21.0.0
     mysqldExporter: prom/mysqld-exporter:v0.14.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
@@ -52,7 +52,7 @@ spec:
     vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.40
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.14.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
@@ -27,7 +27,7 @@ spec:
         failedJobsHistoryLimit: 3
         jobTimeoutMinute: 5
         strategies:
-          - name: BackupShard
+          - name: commerce-x
             keyspace: "commerce"
             shard: "-"
       - name: "every-five-minute"
@@ -42,7 +42,7 @@ spec:
         failedJobsHistoryLimit: 3
         jobTimeoutMinute: 5
         strategies:
-          - name: BackupShard
+          - name: commerce-x
             keyspace: "commerce"
             shard: "-"
   images:

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -3,6 +3,13 @@ kind: VitessCluster
 metadata:
   name: example
 spec:
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          hostPath:
+            path: /backup
+            type: Directory
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
@@ -10,7 +17,7 @@ spec:
     vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.40
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.14.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -3,6 +3,13 @@ kind: VitessCluster
 metadata:
   name: example
 spec:
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          hostPath:
+            path: /backup
+            type: Directory
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
@@ -10,7 +17,7 @@ spec:
     vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.40
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.14.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/401_scheduled_backups.yaml
+++ b/test/endtoend/operator/401_scheduled_backups.yaml
@@ -11,27 +11,8 @@ spec:
             path: /backup
             type: Directory
     schedules:
-      - name: "customer"
-        schedule: "* * * * *"
-        resources:
-          requests:
-            cpu: 100m
-            memory: 1024Mi
-          limits:
-            memory: 1024Mi
-        successfulJobsHistoryLimit: 2
-        failedJobsHistoryLimit: 3
-        jobTimeoutMinute: 5
-        suspend: true
-        strategies:
-          - name: BackupShard
-            keyspace: "customer"
-            shard: "80-"
-          - name: BackupShard
-            keyspace: "customer"
-            shard: "-80"
       - name: "commerce"
-        schedule: "* * * * *"
+        schedule: "*/2 * * * *"
         resources:
           requests:
             cpu: 100m
@@ -42,9 +23,27 @@ spec:
         failedJobsHistoryLimit: 3
         jobTimeoutMinute: 5
         strategies:
-          - name: BackupShard
+          - name: commerce_x
             keyspace: "commerce"
             shard: "-"
+      - name: "customer"
+        schedule: "*/2 * * * *"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1024Mi
+          limits:
+            memory: 1024Mi
+        successfulJobsHistoryLimit: 2
+        failedJobsHistoryLimit: 3
+        jobTimeoutMinute: 5
+        strategies:
+          - name: customer_80-x
+            keyspace: "customer"
+            shard: "80-"
+          - name: customer_x-80
+            keyspace: "customer"
+            shard: "-80"
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest

--- a/test/endtoend/operator/401_scheduled_backups.yaml
+++ b/test/endtoend/operator/401_scheduled_backups.yaml
@@ -10,6 +10,41 @@ spec:
           hostPath:
             path: /backup
             type: Directory
+    schedules:
+      - name: "customer"
+        schedule: "* * * * *"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1024Mi
+          limits:
+            memory: 1024Mi
+        successfulJobsHistoryLimit: 2
+        failedJobsHistoryLimit: 3
+        jobTimeoutMinute: 5
+        suspend: true
+        strategies:
+          - name: BackupShard
+            keyspace: "customer"
+            shard: "80-"
+          - name: BackupShard
+            keyspace: "customer"
+            shard: "-80"
+      - name: "commerce"
+        schedule: "* * * * *"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1024Mi
+          limits:
+            memory: 1024Mi
+        successfulJobsHistoryLimit: 2
+        failedJobsHistoryLimit: 3
+        jobTimeoutMinute: 5
+        strategies:
+          - name: BackupShard
+            keyspace: "commerce"
+            shard: "-"
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
@@ -50,7 +85,6 @@ spec:
   keyspaces:
   - name: commerce
     durabilityPolicy: semi_sync
-    turndownPolicy: Immediate
     vitessOrchestrator:
       resources:
         limits:
@@ -60,6 +94,7 @@ spec:
           memory: 128Mi
       extraFlags:
         instance-poll-time: 3s
+    turndownPolicy: Immediate
     partitionings:
     - equal:
         parts: 1
@@ -75,15 +110,11 @@ spec:
               extraFlags:
                 db_charset: utf8mb4
               resources:
-                limits:
-                  memory: 256Mi
                 requests:
                   cpu: 100m
                   memory: 256Mi
             mysqld:
               resources:
-                limits:
-                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi
@@ -94,7 +125,6 @@ spec:
                   storage: 10Gi
   - name: customer
     durabilityPolicy: semi_sync
-    turndownPolicy: Immediate
     vitessOrchestrator:
       resources:
         limits:
@@ -104,38 +134,8 @@ spec:
           memory: 128Mi
       extraFlags:
         instance-poll-time: 3s
+    turndownPolicy: Immediate
     partitionings:
-    - equal:
-        parts: 1
-        shardTemplate:
-          databaseInitScriptSecret:
-            name: example-cluster-config
-            key: init_db.sql
-          tabletPools:
-          - cell: zone1
-            type: replica
-            replicas: 3
-            vttablet:
-              extraFlags:
-                db_charset: utf8mb4
-              resources:
-                limits:
-                  memory: 256Mi
-                requests:
-                  cpu: 100m
-                  memory: 256Mi
-            mysqld:
-              resources:
-                limits:
-                  memory: 1024Mi
-                requests:
-                  cpu: 100m
-                  memory: 512Mi
-            dataVolumeClaimTemplate:
-              accessModes: ["ReadWriteOnce"]
-              resources:
-                requests:
-                  storage: 10Gi
     - equal:
         parts: 2
         shardTemplate:
@@ -150,15 +150,11 @@ spec:
               extraFlags:
                 db_charset: utf8mb4
               resources:
-                limits:
-                  memory: 256Mi
                 requests:
                   cpu: 100m
                   memory: 256Mi
             mysqld:
               resources:
-                limits:
-                  memory: 1024Mi
                 requests:
                   cpu: 100m
                   memory: 512Mi

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -7,6 +7,13 @@ kind: VitessCluster
 metadata:
   name: example
 spec:
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          hostPath:
+            path: /backup
+            type: Directory
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
@@ -14,7 +21,7 @@ spec:
     vtorc: vitess/lite:latest
     vtbackup: vitess/lite:latest
     mysqld:
-      mysql80Compatible: mysql:8.0.40
+      mysql80Compatible: vitess/lite:latest
     mysqldExporter: prom/mysqld-exporter:v0.14.0
   cells:
   - name: zone1

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -492,8 +492,6 @@ spec:
                         example: commerce
                         type: string
                       name:
-                        enum:
-                          - BackupShard
                         type: string
                       shard:
                         example: '-'
@@ -543,6 +541,11 @@ spec:
                 lastScheduledTime:
                   format: date-time
                   type: string
+                lastScheduledTimes:
+                  additionalProperties:
+                    format: date-time
+                    type: string
+                  type: object
               type: object
           type: object
       served: true
@@ -2101,8 +2104,6 @@ spec:
                                   example: commerce
                                   type: string
                                 name:
-                                  enum:
-                                    - BackupShard
                                   type: string
                                 shard:
                                   example: '-'

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -416,6 +416,7 @@ spec:
                 cluster:
                   type: string
                 concurrencyPolicy:
+                  default: Forbid
                   enum:
                     - Allow
                     - Forbid
@@ -2028,6 +2029,7 @@ spec:
                               type: string
                             type: object
                           concurrencyPolicy:
+                            default: Forbid
                             enum:
                               - Allow
                               - Forbid

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -194,7 +194,7 @@ function scheduledBackups() {
   initialCustomerFirstShardBackups=$(kubectl get vtb --no-headers | grep "customer-x-80" | wc -l)
   initialCustomerSecondShardBackups=$(kubectl get vtb --no-headers | grep "customer-80-x" | wc -l)
 
-  for i in {1..300} ; do
+  for i in {1..60} ; do
     commerceBackups=$(kubectl get vtb --no-headers | grep "commerce-x-x" | wc -l)
     customerFirstShardBackups=$(kubectl get vtb --no-headers | grep "customer-x-80" | wc -l)
     customerSecondShardBackups=$(kubectl get vtb --no-headers | grep "customer-80-x" | wc -l)
@@ -281,7 +281,7 @@ cd "$PWD/test/endtoend/operator"
 killall kubectl
 setupKubectlAccessForCI
 
-get_started "operator-latest.yaml" "101_initial_cluster.yaml"
+get_started "operator.yaml" "101_initial_cluster.yaml"
 verifyVtGateVersion "21.0.0"
 checkSemiSyncSetup
 # Initially too durability policy should be specified

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -247,7 +247,7 @@ function waitForKeyspaceToBeServing() {
     fi
     echo "Shard $ks/$shard is not fully serving. Output: $out"
     echo "Retrying (attempt #$i) ..."
-    sleep 10
+    sleep 1
   done
 }
 
@@ -396,4 +396,18 @@ COrder
 |        5 |           5 | SKU-1002 |    30 |
 +----------+-------------+----------+-------+
 EOF
+}
+
+function checkVitessBackupScheduleStatusWithTimeout() {
+  regex=$1
+
+  for i in {1..1200} ; do
+    if [[ $(kubectl get VitessBackupSchedule | grep -E "${regex}" | wc -l) -eq 1 ]]; then
+      echo "$regex found"
+      return
+    fi
+    sleep 1
+  done
+  echo -e "ERROR: checkPodStatusWithTimeout timeout to find pod matching:\ngot:\n$out\nfor regex: $regex"
+  exit 1
 }

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -155,6 +155,28 @@ function checkPodStatusWithTimeout() {
   exit 1
 }
 
+function checkPodExistWithTimeout() {
+  regex=$1
+
+  # We use this for loop instead of `kubectl wait` because we don't have access to the full pod name
+  # and `kubectl wait` does not support regex to match resource name.
+  for i in {1..1200} ; do
+    out=$(kubectl get pods)
+    echo "$out" | grep -E "$regex" > /dev/null 2>&1
+    if [[ $? -eq 0 ]]; then
+      echo "$regex found"
+      return
+    fi
+    sleep 1
+  done
+  echo -e "ERROR: checkPodStatusWithTimeout timeout to find pod matching:\ngot:\n$out\nfor regex: $regex"
+  echo "$regex" | grep "vttablet" > /dev/null 2>&1
+  if [[ $? -eq 0 ]]; then
+    printMysqlErrorFiles
+  fi
+  exit 1
+}
+
 # ensurePodResourcesSet:
 # $1: regex used to match pod names
 function ensurePodResourcesSet() {


### PR DESCRIPTION
## Context

This Pull Request modifies the scheduled backup feature that was introduced in https://github.com/planetscale/vitess-operator/pull/553. The implementation in the original PR is rather simple and was a "v1". The CRD `VitessBackupSchedule` was introduced, giving the option to end-users to configure different `VitessBackupScheduleStrategy`, which instruct vitess-operator which keyspace/shard the user wants to backup. All the strategies in a `VitessBackupSchedule` were merged together to form a single `vtctldclient` command that would be executed in a K8S's `Job` following the schedule set in the `VitessBackupSchedule` CRD.

While this approach works, it has limitation: it uses `vtctldclient Backup` which will temporarily take out a serving tablet from the serving tablet pool and use it to take the backup. While this limitation is documented in the release notes, we want to encourage people to use `vtbackup` as an alternative.

## Proposed Change

This Pull Request modifies the `VitessBackupSchedule` controller to create one Kubernetes `Job` per `VitessBackupScheduleStrategy` defined the `VitessBackupSchedule` by the user - instead of merging all strategies into a single `Job`. Each `Job` will now create a `vtbackup` pod - instead of creating a pod where a `vtctldclient` command was executed.

### Changes

- Since `vtbackup` can only backup a single keyspace/shard, we need one `Job` per strategy, meaning that now each `VitessBackupSchedule` manages multiple `Job` resources (one per strategy), which was not the case before.

- The previous code logic relied heavily on the CRD's Status to schedule next runs, this logic was removed to make Status purely informative to only the end users, not the vitess-operator. Moreover, the previous logic was updating the Status of the resource on, almost, every request without knowing if we actually need to update the Status. This was modified to only update the Status when needed and make it ignore conflicts.

- The reconciling loop of `VitessBackupSchedule` was, at times, not returning the correct result+error expected by the controller-runtime `TypedReconciler` interface, leading to unnecessary re-queue of requests or missed re-queues. The logic has been modified to return correct values. A periodic resync of the controller has also been added to safeguard potential issues and to ensure resources (`Jobs`, PVCs, etc) are cleaned up correctly no matter what.

- The upgrade test has been modified to also run the `401_scheduled_backups.yaml` manifest.

- The default `ConcurrentPolicy` of the `Jobs` has been modified from `Allow` to `Forbid`. With the new strategies requiring far more resources and time to complete, this new default makes sense. This value is still configurable by end-users.

- Previously, the `vtbackup` created with every `VitessShard` was always attempting to do an initial backup (`--initial_backup`), which would fail if the `VitessBackup` definition was added after the `VitessShard` started running. That logic has been slightly modified so the vitess-operator is more aware of the current state of the `VitessShard` before creating the `vtbackup` pod. If there is already a primary in the shard, it will not be an initial backup, but an `--allow_first_backup` backup - as we only create this pod if there is no backup for this shard. The `VitessBackupSchedule` relies on the same logic to determine the type of backup it has to run, either: initial, allow first, or normal. Concurrency issues between the initial `vtbackup` pod and the first scheduled run of a `VitessBackupSchedule` is, depending on the schedule, likely. In such situation both `vtbackup` pods come up with the `--initial_backup` flag set to true. One of the two pods will simply fail early.

## Related PRs

- Documentation: https://github.com/vitessio/website/pull/1946
- Vitess examples: https://github.com/vitessio/vitess/pull/17869
