### PR TITLE
Correct CreateKeyspace behavior to support custom sidecar DB names

### DIFF
--- a/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
+++ b/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -52,6 +51,7 @@ func (r *reconcileHandler) reconcileKeyspaceInformation(ctx context.Context) (re
 		// We should create the record
 		if topo.IsErrType(err, topo.NoNode) {
 			// Create a normal keyspace with the requested durability policy
+			// and sidecar DB name (if any).
 			_, err := r.wr.VtctldServer().CreateKeyspace(ctx, &vtctldatapb.CreateKeyspaceRequest{
 				Name:             keyspaceName,
 				Type:             topodatapb.KeyspaceType_NORMAL,

--- a/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
+++ b/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
@@ -47,10 +47,9 @@ func (r *reconcileHandler) reconcileKeyspaceInformation(ctx context.Context) (re
 
 	keyspaceInfo, err := topoServer.GetKeyspace(ctx, keyspaceName)
 	if err != nil {
-		// The keyspace information record does not exist in the topo server.
-		// We should create the record
 		if topo.IsErrType(err, topo.NoNode) {
-			// Create a normal keyspace with the requested durability policy
+			// The keyspace record does not exist in the topo server. Let's
+			// create a normal keyspace with the requested durability policy
 			// and sidecar DB name (if any).
 			_, err := r.wr.VtctldServer().CreateKeyspace(ctx, &vtctldatapb.CreateKeyspaceRequest{
 				Name:             keyspaceName,

--- a/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
+++ b/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go
@@ -18,6 +18,7 @@ package vitesskeyspace
 
 import (
 	"context"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -49,7 +50,7 @@ func (r *reconcileHandler) reconcileKeyspaceInformation(ctx context.Context) (re
 	if err != nil {
 		// The keyspace information record does not exist in the topo server.
 		// We should create the record
-		if !topo.IsErrType(err, topo.NoNode) {
+		if topo.IsErrType(err, topo.NoNode) {
 			// Create a normal keyspace with the requested durability policy
 			_, err := r.wr.VtctldServer().CreateKeyspace(ctx, &vtctldatapb.CreateKeyspaceRequest{
 				Name:             keyspaceName,

--- a/test/endtoend/operator/101_initial_cluster_unmanaged_tablet.yaml
+++ b/test/endtoend/operator/101_initial_cluster_unmanaged_tablet.yaml
@@ -48,6 +48,7 @@ spec:
   keyspaces:
   - name: commerce
     durabilityPolicy: none
+    sidecarDbName: _vt_ext
     turndownPolicy: Immediate
     vitessOrchestrator:
       resources:

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -25,6 +25,10 @@ function get_started_unmanaged() {
     waitForKeyspaceToBeServing commerce - 0
     sleep 5
 
+    # Confirm that the custom sidecar DB name is in place for our
+    # external/unmanaged keyspace.
+    verifyCustomSidecarDBName "commerce" "_vt_ext" "true"
+
     applySchemaWithRetry create_commerce_schema.sql commerce drop_all_commerce_tables.sql
     vtctldclient ApplyVSchema --vschema-file="vschema_commerce_initial.json" commerce
     if [[ $? -ne 0 ]]; then

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -27,7 +27,7 @@ function get_started_unmanaged() {
 
     # Confirm that the custom sidecar DB name is in place for our
     # external/unmanaged keyspace.
-    verifyCustomSidecarDBName "commerce" "_vt_ext" "true"
+    verifyCustomSidecarDBName "commerce" "_vt_ext" "external"
 
     applySchemaWithRetry create_commerce_schema.sql commerce drop_all_commerce_tables.sql
     vtctldclient ApplyVSchema --vschema-file="vschema_commerce_initial.json" commerce

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -250,8 +250,8 @@ function verifyCustomSidecarDBName() {
   fi 
   local pods=$(kubectl get pods --no-headers --selector="${selector}" -o custom-columns=":metadata.name")
   for pod in $(echo "${pods}"); do
-    local tdb=$(eval "kubectl exec ${pod} ${container} -- ${mysqlCMD}")
-    if [[ "${tdb}" != "${db_name}" ]]; then
+    local sdb=$(eval "kubectl exec ${pod} ${container} -- ${mysqlCMD}")
+    if [[ "${sdb}" != "${db_name}" ]]; then
       echo "Custom sidecar DB name ${db_name} not being used in ${pod} pod"
       exit 1
     fi

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -214,7 +214,7 @@ function verifyDurabilityPolicy() {
 
 # verifyCustomSidecarDBName verifies that the custom sidecar DB name
 # is set in the keyspace's topo record and that it is being used on
-# all tablets/mysqld instances in the keyspace.
+# all tablet/mysqld instances in the keyspace.
 # The first parameter must be the keyspace and the second the expected
 # sidecar DB name. The third parameter is optional and if passed (any
 # value) then it is assumed that there is no mysqld container in the
@@ -225,7 +225,7 @@ function verifyCustomSidecarDBName() {
   local db_name=$2
   local external=$3
   if [[ -z "${keyspace}" || -z "${db_name}" ]]; then
-    echo "The keyspace or sidecar DB name are empty; usage: verifyCustomSidecarDBName <keyspace> <db_name>"
+    echo "The keyspace or sidecar DB name are empty; usage: verifyCustomSidecarDBName <keyspace> <db_name> [external]"
     exit 1
   fi
 

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -249,7 +249,7 @@ function verifyCustomSidecarDBName() {
     selector="app=mysql"
   fi 
   local pods=$(kubectl get pods --no-headers --selector="${selector}" -o custom-columns=":metadata.name")
-  for pod in $(echo "${pods}"); do
+  for local pod in $(echo "${pods}"); do
     local sdb=$(eval "kubectl exec ${pod} ${container} -- ${mysqlCMD}")
     if [[ "${sdb}" != "${db_name}" ]]; then
       echo "Custom sidecar DB name ${db_name} not being used in ${pod} pod"

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -249,7 +249,7 @@ function verifyCustomSidecarDBName() {
     selector="app=mysql"
   fi 
   local pods=$(kubectl get pods --no-headers --selector="${selector}" -o custom-columns=":metadata.name")
-  for local pod in $(echo "${pods}"); do
+  for pod in $(echo "${pods}"); do
     local sdb=$(eval "kubectl exec ${pod} ${container} -- ${mysqlCMD}")
     if [[ "${sdb}" != "${db_name}" ]]; then
       echo "Custom sidecar DB name ${db_name} not being used in ${pod} pod"

--- a/test/integration/vitesscluster/topology_test.go
+++ b/test/integration/vitesscluster/topology_test.go
@@ -113,13 +113,9 @@ func populateTopo(f *framework.Fixture, ts *topo.Server) {
 		f.Fatalf("Can't create keyspace: %v", err)
 	}
 
-	// To test shard and tablet pruning, we have to first create the actual
-	// desired keyspace and desired shards (which won't be pruned) because the
-	// operator doesn't do that. Normally the vttablets do that, but Vitess is
-	// not actually running here.
-	if err := ts.CreateKeyspace(f.Context(), "keyspace1", &topodatapb.Keyspace{}); err != nil {
-		f.Fatalf("Can't create keyspace: %v", err)
-	}
+	// To test shard and tablet pruning, we have to first create the desired
+	// shards (which won't be pruned) because the operator doesn't do that.
+	// Normally the vttablets do that, but Vitess is not actually running here.
 	if err := ts.CreateShard(f.Context(), "keyspace1", "-80"); err != nil {
 		f.Fatalf("Can't create shard: %v", err)
 	}


### PR DESCRIPTION
This is a follow-up to https://github.com/planetscale/vitess-operator/pull/662.

We did not update any tests in that PR so we did not realize that while the code added there was correct, the new feature/support added there did not work due to a latent bug that had been lurking in the operator for a long time but gone unnoticed. That latent bug was here: https://github.com/planetscale/vitess-operator/blob/f31cb56d616b877145612cc9c064d25d8f43c187/pkg/controller/vitesskeyspace/reconcile_keyspace_information.go#L48-L59

It *should* have issued the `CreateKeyspace` RPC if the error returned *was* the topo `NoNode` error. But instead, it had that check negated. Due to this, that `CreateKeyspace` block was never executed and instead the keyspace was later created by the first tablet that started up within the keyspace. The other keyspace configuration options were then later applied when the next reconcile job ran. The SidecarDB name, however, is immutable in a Keyspace and thus could not be updated and was thus never applied.

In this PR we correct that logic and add a test to confirm that the support for the custom sidecar DB name works from end to end.