### PR TITLE
[main] Bump version.go to 2.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ compatible with certain Vitess and Kubernetes versions, as shown in this table:
 | `v2.12.*`               | `v19.0.*`                   | `v1.25.*`, `v1.26.*`, `v1.27.*`, or `v1.28.*` |
 | `v2.13.*`               | `v20.0.*`                   | `v1.25.*`, `v1.26.*`, `v1.27.*`, or `v1.28.*` |
 | `v2.14.*`               | `v21.0.*`                   | `v1.29.*`, `v1.30.*`, `v1.31.*`               |
+| `v2.15.*`               | `v22.0.*`                   | `v1.30.*`, `v1.31.*`, `v1.32.*`               |
 | `latest`                | `latest`                    | `v1.30.*`, `v1.31.*`, `v1.32.*`               |
 
 If for some reason you must attempt to use versions outside the recommend

--- a/test/endtoend/backup_restore_test.sh
+++ b/test/endtoend/backup_restore_test.sh
@@ -90,7 +90,7 @@ setupKubectlAccessForCI
 
 createExampleNamespace
 get_started "operator-latest.yaml" "101_initial_cluster_backup.yaml"
-verifyVtGateVersion "22.0.0"
+verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup
 takeBackup "commerce/-"
 verifyListBackupsOutput

--- a/test/endtoend/backup_schedule_test.sh
+++ b/test/endtoend/backup_schedule_test.sh
@@ -53,7 +53,7 @@ setupKubectlAccessForCI
 
 createExampleNamespace
 get_started "operator-latest.yaml" "101_initial_cluster_backup_schedule.yaml"
-verifyVtGateVersion "22.0.0"
+verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup
 verifyListBackupsOutputWithSchedule
 

--- a/test/endtoend/hpa_test.sh
+++ b/test/endtoend/hpa_test.sh
@@ -43,7 +43,7 @@ setupKubectlAccessForCI
 
 createExampleNamespace
 get_started "operator-latest.yaml" "101_initial_cluster_autoscale.yaml"
-verifyVtGateVersion "22.0.0"
+verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup
 
 verifyHpaCount 0

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -310,7 +310,7 @@ checkSemiSyncSetup
 # Initially too durability policy should be specified
 verifyDurabilityPolicy "commerce" "semi_sync"
 upgradeToLatest
-verifyVtGateVersion "22.0.0"
+verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup
 # After upgrading, we verify that the durability policy is still semi_sync
 verifyDurabilityPolicy "commerce" "semi_sync"

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -243,7 +243,7 @@ setupKubectlAccessForCI
 
 createExampleNamespace
 get_started_vtorc_vtadmin
-verifyVtGateVersion "22.0.0"
+verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup
 
 # Check Vtadmin is setup

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 PlanetScale Inc.
+Copyright 2025 PlanetScale Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,5 +20,5 @@ package version
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
 var (
-	Version = "2.14.0"
+	Version = "2.15.0"
 )


### PR DESCRIPTION
This Pull Request bumps the version/version.go file to 2.15.0

> This Pull Request is part of https://github.com/vitessio/vitess/issues/18023