### PR TITLE
[release-2.15] Update Golang version to `v1.24.2`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ agents:
   queue: "public"
 
 env:
-  GO_VERSION_FILE: "go1.24.1.linux-amd64.tar.gz"
+  GO_VERSION_FILE: "go1.24.2.linux-amd64.tar.gz"
 
 # Mount the docker.sock as to the docker container, so that we are able to
 # run docker build command and kind is spawned as a sibling container.

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.24.1
+        go-version: 1.24.2
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/make-generate-and-diff.yaml
+++ b/.github/workflows/make-generate-and-diff.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.24.1
+        go-version: 1.24.2
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.24.1
+        go-version: 1.24.2
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/upgrade-vitess-dependency.yaml
+++ b/.github/workflows/upgrade-vitess-dependency.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.24.1
+          go-version: 1.24.2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/build/Dockerfile.release
+++ b/build/Dockerfile.release
@@ -11,7 +11,7 @@
 # without messing up file permissions, since the Docker container doesn't run as
 # your actual user.
 
-FROM golang:1.24.1 AS build
+FROM golang:1.24.2 AS build
 
 ENV GO111MODULE=on
 WORKDIR /go/src/planetscale.dev/vitess-operator

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module planetscale.dev/vitess-operator
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
This Pull Request updates the Golang version to 1.24.2.

> This Pull Request is part of https://github.com/vitessio/vitess/issues/18023