### PR TITLE
Refactor end-to-end tests

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -2,7 +2,7 @@
 
 # Remove the docker container on which kind is running
 # Also removes the volume used by it
-docker container rm -v -f kind-${BUILDKITE_BUILD_ID}-control-plane
+docker container rm -v -f kind-${BUILDKITE_JOB_ID}-control-plane
 # Remove the docker image created for the local PR code
 docker image rm -f vitess-operator-pr:latest
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
     - make upgrade-test
     concurrency: 1
     concurrency_group: 'vtop/upgrade-downgrade-test'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       - docker#v3.12.0:
           image: "docker:latest"
@@ -37,7 +37,7 @@ steps:
     - make backup-restore-test
     concurrency: 1
     concurrency_group: 'vtop/backup-restore-test'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 20
     plugins:
       - docker#v3.12.0:
           image: "docker:latest"
@@ -56,7 +56,7 @@ steps:
       - make backup-schedule-test
     concurrency: 1
     concurrency_group: 'vtop/backup-schedule-test'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 20
     plugins:
       - docker#v3.12.0:
           image: "docker:latest"
@@ -75,7 +75,7 @@ steps:
     - make vtorc-vtadmin-test
     concurrency: 1
     concurrency_group: 'vtop/vtorc-vtadmin-test'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 20
     plugins:
       - docker#v3.12.0:
           image: "docker:latest"
@@ -94,7 +94,7 @@ steps:
     - make unmanaged-tablet-test
     concurrency: 1
     concurrency_group: 'vtop/unmanaged-tablet-test'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 20
     plugins:
       - docker#v3.12.0:
           image: "docker:latest"
@@ -113,7 +113,7 @@ steps:
     - make hpa-test
     concurrency: 1
     concurrency_group: 'vtop/hpa-test'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 20
     plugins:
       - docker#v3.12.0:
           image: "docker:latest"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,6 +25,15 @@ steps:
           propagate-environment: true
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
+    retry: &retry_policy_tests
+      # Automatically retry tests on unexpected Buildkite Agent exit codes
+      automatic:
+        - exit_status: -1 # Agent lost
+          limit: 2
+        - exit_status: 143 # Graceful agent termination
+          limit: 2
+        - exit_status: 255 # Forceful agent termination
+          limit: 2
 
   - name: "Backup Restore Test"
     command:
@@ -44,6 +53,8 @@ steps:
           propagate-environment: true
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
+    retry:
+      <<: *retry_policy_tests
 
   - name: "Backup Schedule Test"
     command:
@@ -63,6 +74,8 @@ steps:
           propagate-environment: true
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
+    retry:
+      <<: *retry_policy_tests
 
   - name: "VTOrc and VTAdmin Test"
     command:
@@ -82,6 +95,8 @@ steps:
           propagate-environment: true
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
+    retry:
+      <<: *retry_policy_tests
 
   - name: "Unmanaged Tablet Test"
     command:
@@ -101,6 +116,8 @@ steps:
           propagate-environment: true
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
+    retry:
+      <<: *retry_policy_tests
 
   - name: "HPA Test"
     command:
@@ -120,3 +137,5 @@ steps:
           propagate-environment: true
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
+    retry:
+      <<: *retry_policy_tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,8 +9,8 @@ env:
 steps:
   - name: "Upgrade Test"
     command:
-    - apk add g++ make bash gcompat curl mysql-client libc6-compat
-    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - apk add --no-progress --quiet g++ make bash gcompat curl mysql-client libc6-compat
+    - wget -q https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin
     - rm $GO_VERSION_FILE
@@ -37,8 +37,8 @@ steps:
 
   - name: "Backup Restore Test"
     command:
-    - apk add g++ make bash gcompat curl mysql-client libc6-compat
-    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - apk add --no-progress --quiet g++ make bash gcompat curl mysql-client libc6-compat
+    - wget -q https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin
     - rm $GO_VERSION_FILE
@@ -58,8 +58,8 @@ steps:
 
   - name: "Backup Schedule Test"
     command:
-      - apk add g++ make bash gcompat curl mysql-client libc6-compat
-      - wget https://golang.org/dl/$GO_VERSION_FILE
+      - apk add --no-progress --quiet g++ make bash gcompat curl mysql-client libc6-compat
+      - wget -q https://golang.org/dl/$GO_VERSION_FILE
       - tar -C /usr/local -xzf $GO_VERSION_FILE
       - export PATH=$PATH:/usr/local/go/bin:/bin
       - rm $GO_VERSION_FILE
@@ -79,8 +79,8 @@ steps:
 
   - name: "VTOrc and VTAdmin Test"
     command:
-    - apk add g++ make bash gcompat curl mysql-client libc6-compat chromium
-    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - apk add --no-progress --quiet g++ make bash gcompat curl mysql-client libc6-compat chromium
+    - wget -q https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin
     - rm $GO_VERSION_FILE
@@ -100,8 +100,8 @@ steps:
 
   - name: "Unmanaged Tablet Test"
     command:
-    - apk add g++ make bash gcompat curl mysql-client libc6-compat coreutils
-    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - apk add --no-progress --quiet g++ make bash gcompat curl mysql-client libc6-compat coreutils
+    - wget -q https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin
     - rm $GO_VERSION_FILE
@@ -121,8 +121,8 @@ steps:
 
   - name: "HPA Test"
     command:
-    - apk add g++ make bash gcompat curl mysql-client libc6-compat
-    - wget https://golang.org/dl/$GO_VERSION_FILE
+    - apk add --no-progress --quiet g++ make bash gcompat curl mysql-client libc6-compat
+    - wget -q https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin
     - rm $GO_VERSION_FILE

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ env:
 steps:
   - name: "Upgrade Test"
     command:
-    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
+    - apk add g++ make bash gcompat curl mysql-client libc6-compat
     - wget https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin
@@ -28,7 +28,7 @@ steps:
 
   - name: "Backup Restore Test"
     command:
-    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
+    - apk add g++ make bash gcompat curl mysql-client libc6-compat
     - wget https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin
@@ -47,7 +47,7 @@ steps:
 
   - name: "Backup Schedule Test"
     command:
-      - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
+      - apk add g++ make bash gcompat curl mysql-client libc6-compat
       - wget https://golang.org/dl/$GO_VERSION_FILE
       - tar -C /usr/local -xzf $GO_VERSION_FILE
       - export PATH=$PATH:/usr/local/go/bin:/bin
@@ -66,7 +66,7 @@ steps:
 
   - name: "VTOrc and VTAdmin Test"
     command:
-    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat chromium
+    - apk add g++ make bash gcompat curl mysql-client libc6-compat chromium
     - wget https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin
@@ -85,7 +85,7 @@ steps:
 
   - name: "Unmanaged Tablet Test"
     command:
-    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat chromium coreutils
+    - apk add g++ make bash gcompat curl mysql-client libc6-compat coreutils
     - wget https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin
@@ -104,7 +104,7 @@ steps:
 
   - name: "HPA Test"
     command:
-    - apk add g++ make bash gcompat curl mysql mysql-client libc6-compat
+    - apk add g++ make bash gcompat curl mysql-client libc6-compat
     - wget https://golang.org/dl/$GO_VERSION_FILE
     - tar -C /usr/local -xzf $GO_VERSION_FILE
     - export PATH=$PATH:/usr/local/go/bin:/bin

--- a/Makefile
+++ b/Makefile
@@ -61,26 +61,26 @@ e2e-test-setup:
 	./tools/get-e2e-test-deps.sh
 
 # Upgrade test
-upgrade-test: build e2e-test-setup
+upgrade-test: e2e-test-setup
 	echo "Running Upgrade test"
 	test/endtoend/upgrade_test.sh
 
-backup-restore-test: build e2e-test-setup
+backup-restore-test: e2e-test-setup
 	echo "Running Backup-Restore test"
 	test/endtoend/backup_restore_test.sh
 
-backup-schedule-test: build e2e-test-setup
+backup-schedule-test: e2e-test-setup
 	echo "Running Backup-Schedule test"
 	test/endtoend/backup_schedule_test.sh
 
-vtorc-vtadmin-test: build e2e-test-setup
+vtorc-vtadmin-test: e2e-test-setup
 	echo "Running VTOrc and VtAdmin test"
 	test/endtoend/vtorc_vtadmin_test.sh
 
-unmanaged-tablet-test: build e2e-test-setup
+unmanaged-tablet-test: e2e-test-setup
 	echo "Running Unmanaged Tablet test"
 	test/endtoend/unmanaged_tablet_test.sh
 
-hpa-test: build e2e-test-setup
+hpa-test: e2e-test-setup
 	echo "Running HPA test"
 	test/endtoend/hpa_test.sh

--- a/build/Dockerfile.release
+++ b/build/Dockerfile.release
@@ -16,7 +16,7 @@ FROM golang:1.24.2 AS build
 ENV GO111MODULE=on
 WORKDIR /go/src/planetscale.dev/vitess-operator
 COPY . /go/src/planetscale.dev/vitess-operator
-RUN CGO_ENABLED=0 go install /go/src/planetscale.dev/vitess-operator/cmd/manager
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go install /go/src/planetscale.dev/vitess-operator/cmd/manager
 
 # The rest is meant to mimic the output from operator-sdk's Dockerfile.
 # We just copy the binary we built inside Docker instead of from outside.

--- a/test/endtoend/backup_restore_test.sh
+++ b/test/endtoend/backup_restore_test.sh
@@ -89,8 +89,4 @@ resurrectShard
 checkSemiSyncSetup
 
 # Teardown
-echo "Removing the temporary directory"
-removeBackupFiles
-rm -rf "$STARTING_DIR/vtdataroot"
-echo "Deleting Kind cluster. This also deletes the volume associated with it"
-kind delete cluster --name kind-${BUILDKITE_BUILD_ID}
+teardownKindCluster

--- a/test/endtoend/backup_restore_test.sh
+++ b/test/endtoend/backup_restore_test.sh
@@ -14,9 +14,9 @@ function takedownShard() {
 function resurrectShard() {
   echo "Apply 101_initial_cluster_backup.yaml again"
   kubectl apply -f 101_initial_cluster_backup.yaml
+  checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
   checkPodStatusWithTimeout "example-zone1-vtctld(.*)1/1(.*)Running(.*)"
   checkPodStatusWithTimeout "example-zone1-vtgate(.*)1/1(.*)Running(.*)"
-  checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
   checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
 
   setupPortForwarding

--- a/test/endtoend/backup_restore_test.sh
+++ b/test/endtoend/backup_restore_test.sh
@@ -21,11 +21,7 @@ function resurrectShard() {
 
   sleep 10
 
-  killall kubectl
-  ./pf.sh > /dev/null 2>&1 &
-
-  sleep 10
-
+  setupPortForwarding
   waitForKeyspaceToBeServing commerce - 2
   sleep 5
 

--- a/test/endtoend/backup_restore_test.sh
+++ b/test/endtoend/backup_restore_test.sh
@@ -19,56 +19,9 @@ function resurrectShard() {
   checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
   checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
 
-  sleep 10
-
   setupPortForwarding
   waitForKeyspaceToBeServing commerce - 2
-  sleep 5
-
-  echo "show databases;" | mysql | grep "commerce" > /dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
-    echo "Could not find commerce database"
-    printMysqlErrorFiles
-    exit 1
-  fi
-
-  echo "show tables;" | mysql commerce | grep -E 'corder|customer|product' | wc -l | grep 3 > /dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
-    echo "Could not find commerce's tables"
-    printMysqlErrorFiles
-    exit 1
-  fi
-
-  assertSelect ../common/select_commerce_data.sql "commerce" << EOF
-Using commerce
-Customer
-+-------------+--------------------+
-| customer_id | email              |
-+-------------+--------------------+
-|           1 | alice@domain.com   |
-|           2 | bob@domain.com     |
-|           3 | charlie@domain.com |
-|           4 | dan@domain.com     |
-|           5 | eve@domain.com     |
-+-------------+--------------------+
-Product
-+----------+-------------+-------+
-| sku      | description | price |
-+----------+-------------+-------+
-| SKU-1001 | Monitor     |   100 |
-| SKU-1002 | Keyboard    |    30 |
-+----------+-------------+-------+
-COrder
-+----------+-------------+----------+-------+
-| order_id | customer_id | sku      | price |
-+----------+-------------+----------+-------+
-|        1 |           1 | SKU-1001 |   100 |
-|        2 |           2 | SKU-1002 |    30 |
-|        3 |           3 | SKU-1002 |    30 |
-|        4 |           4 | SKU-1002 |    30 |
-|        5 |           5 | SKU-1002 |    30 |
-+----------+-------------+----------+-------+
-EOF
+  verifyDataCommerce
 }
 
 # Test setup

--- a/test/endtoend/backup_restore_test.sh
+++ b/test/endtoend/backup_restore_test.sh
@@ -76,19 +76,9 @@ EOF
 }
 
 # Test setup
-STARTING_DIR="$PWD"
-echo "Make temporary directory for the test"
-mkdir -p -m 777 ./vtdataroot/backup
-echo "Building the docker image"
-docker build -f build/Dockerfile.release -t vitess-operator-pr:latest .
-setupKindConfig
-createKindCluster
+setupKindCluster
+cd test/endtoend/operator || exit 1
 
-cd "$PWD/test/endtoend/operator"
-killall kubectl
-setupKubectlAccessForCI
-
-createExampleNamespace
 get_started "operator-latest.yaml" "101_initial_cluster_backup.yaml"
 verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup

--- a/test/endtoend/backup_schedule_test.sh
+++ b/test/endtoend/backup_schedule_test.sh
@@ -3,14 +3,6 @@
 source ./tools/test.env
 source ./test/endtoend/utils.sh
 
-function takedownShard() {
-  echo "Apply 102_keyspace_teardown.yaml"
-  kubectl apply -f 102_keyspace_teardown.yaml
-
-  # wait for all the vttablets to disappear
-  checkPodStatusWithTimeout "example-vttablet-zone1" 0
-}
-
 function verifyListBackupsOutputWithSchedule() {
   echo -e "Check for VitessBackupSchedule status"
   checkVitessBackupScheduleStatusWithTimeout "example-vbsc-every-minute(.*)"

--- a/test/endtoend/backup_schedule_test.sh
+++ b/test/endtoend/backup_schedule_test.sh
@@ -46,8 +46,5 @@ verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup
 verifyListBackupsOutputWithSchedule
 
-echo "Removing the temporary directory"
-removeBackupFiles
-rm -rf "$STARTING_DIR/vtdataroot"
-echo "Deleting Kind cluster. This also deletes the volume associated with it"
-kind delete cluster --name kind-${BUILDKITE_BUILD_ID}
+# Teardown
+teardownKindCluster

--- a/test/endtoend/backup_schedule_test.sh
+++ b/test/endtoend/backup_schedule_test.sh
@@ -38,20 +38,9 @@ function verifyListBackupsOutputWithSchedule() {
 }
 
 # Test setup
-STARTING_DIR="$PWD"
-echo "Make temporary directory for the test"
-mkdir -p -m 777 ./vtdataroot/backup
-echo "Building the docker image"
-docker build -f build/Dockerfile.release -t vitess-operator-pr:latest .
-echo "Setting up the kind config"
-setupKindConfig
-createKindCluster
+setupKindCluster
+cd test/endtoend/operator || exit 1
 
-cd "$PWD/test/endtoend/operator"
-killall kubectl
-setupKubectlAccessForCI
-
-createExampleNamespace
 get_started "operator-latest.yaml" "101_initial_cluster_backup_schedule.yaml"
 verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup

--- a/test/endtoend/backup_schedule_test.sh
+++ b/test/endtoend/backup_schedule_test.sh
@@ -12,8 +12,6 @@ function verifyListBackupsOutputWithSchedule() {
   # Sleep for 10 minutes, after 10 minutes we should at least have 3 backups: 1 from the initial vtbackup pod
   # 1 minimum from the every minute schedule, and 1 from the every-five minute schedule
   for i in {1..600} ; do
-    # Ensure that we can view the backup files from the host.
-    docker exec -it $(docker container ls --format '{{.Names}}' | grep kind) chmod o+rwx -R /backup > /dev/null
     backupCount=$(kubectl get vtb -n example --no-headers | wc -l)
     echo "Found ${backupCount} backups"
     if [[ "${backupCount}" -ge 3 ]]; then

--- a/test/endtoend/hpa_test.sh
+++ b/test/endtoend/hpa_test.sh
@@ -46,5 +46,4 @@ verifyHpaWithTimeout "example-zone1-(\w+)\s+VitessCell/example-zone1-(\w+)\s+cpu
 verifyHpaCount 1
 
 # Teardown
-echo "Deleting Kind cluster. This also deletes the volume associated with it"
-kind delete cluster --name kind-${BUILDKITE_BUILD_ID}
+teardownKindCluster

--- a/test/endtoend/hpa_test.sh
+++ b/test/endtoend/hpa_test.sh
@@ -30,18 +30,9 @@ function verifyHpaWithTimeout() {
 }
 
 # Test setup
-echo "Building the docker image"
-docker build -f build/Dockerfile.release -t vitess-operator-pr:latest .
-echo "Creating Kind cluster"
-kind create cluster --wait 30s --name kind-${BUILDKITE_BUILD_ID} --image ${KIND_VERSION}
-echo "Loading docker image into Kind cluster"
-kind load docker-image vitess-operator-pr:latest --name kind-${BUILDKITE_BUILD_ID}
+setupKindCluster
+cd test/endtoend/operator || exit 1
 
-cd "$PWD/test/endtoend/operator"
-killall kubectl
-setupKubectlAccessForCI
-
-createExampleNamespace
 get_started "operator-latest.yaml" "101_initial_cluster_autoscale.yaml"
 verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup

--- a/test/endtoend/kindBackupConfig.yaml
+++ b/test/endtoend/kindBackupConfig.yaml
@@ -1,7 +1,0 @@
-apiVersion: kind.x-k8s.io/v1alpha4
-kind: Cluster
-nodes:
-  - role: control-plane
-    extraMounts:
-      - hostPath: PATH
-        containerPath: /backup

--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -12,9 +12,8 @@ spec:
     engine: xtrabackup
     locations:
       - volume:
-          hostPath:
-            path: /backup
-            type: Directory
+          persistentVolumeClaim:
+            claimName: vitess-backups
   images:
     vtctld: vitess/lite:v22.0.0-rc1
     vtgate: vitess/lite:v22.0.0-rc1
@@ -215,3 +214,15 @@ stringData:
 
     # We need to set super_read_only back to what it was before
     SET GLOBAL super_read_only=IFNULL(@original_super_read_only, 'ON');
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vitess-backups
+  namespace: example
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/test/endtoend/operator/101_initial_cluster.yaml
+++ b/test/endtoend/operator/101_initial_cluster.yaml
@@ -32,6 +32,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:
@@ -128,7 +130,7 @@ stringData:
     # enabled before.
     SET @original_super_read_only=IF(@@global.super_read_only=1, 'ON', 'OFF');
     SET GLOBAL super_read_only='OFF';
-    
+
     # Changes during the init db should not make it to the binlog.
     # They could potentially create errant transactions on replicas.
     SET sql_log_bin = 0;

--- a/test/endtoend/operator/101_initial_cluster_autoscale.yaml
+++ b/test/endtoend/operator/101_initial_cluster_autoscale.yaml
@@ -25,6 +25,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:
@@ -121,7 +123,7 @@ stringData:
     # enabled before.
     SET @original_super_read_only=IF(@@global.super_read_only=1, 'ON', 'OFF');
     SET GLOBAL super_read_only='OFF';
-    
+
     # Changes during the init db should not make it to the binlog.
     # They could potentially create errant transactions on replicas.
     SET sql_log_bin = 0;

--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -32,6 +32,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:
@@ -128,7 +130,7 @@ stringData:
     # enabled before.
     SET @original_super_read_only=IF(@@global.super_read_only=1, 'ON', 'OFF');
     SET GLOBAL super_read_only='OFF';
-    
+
     # Changes during the init db should not make it to the binlog.
     # They could potentially create errant transactions on replicas.
     SET sql_log_bin = 0;

--- a/test/endtoend/operator/101_initial_cluster_backup.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup.yaml
@@ -12,9 +12,8 @@ spec:
     engine: xtrabackup
     locations:
     - volume:
-        hostPath:
-          path: /backup
-          type: Directory
+        persistentVolumeClaim:
+          claimName: vitess-backups
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest
@@ -219,3 +218,15 @@ stringData:
 
     # We need to set super_read_only back to what it was before
     SET GLOBAL super_read_only=IFNULL(@original_super_read_only, 'ON');
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vitess-backups
+  namespace: example
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
@@ -12,9 +12,8 @@ spec:
     engine: xtrabackup
     locations:
     - volume:
-        hostPath:
-          path: /backup
-          type: Directory
+        persistentVolumeClaim:
+          claimName: vitess-backups
     schedules:
       - name: "every-minute"
         schedule: "* * * * *"
@@ -250,3 +249,15 @@ stringData:
 
     # We need to set super_read_only back to what it was before
     SET GLOBAL super_read_only=IFNULL(@original_super_read_only, 'ON');
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vitess-backups
+  namespace: example
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
+++ b/test/endtoend/operator/101_initial_cluster_backup_schedule.yaml
@@ -63,6 +63,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:
@@ -159,7 +161,7 @@ stringData:
     # enabled before.
     SET @original_super_read_only=IF(@@global.super_read_only=1, 'ON', 'OFF');
     SET GLOBAL super_read_only='OFF';
-    
+
     # Changes during the init db should not make it to the binlog.
     # They could potentially create errant transactions on replicas.
     SET sql_log_bin = 0;

--- a/test/endtoend/operator/101_initial_cluster_unmanaged_tablet.yaml
+++ b/test/endtoend/operator/101_initial_cluster_unmanaged_tablet.yaml
@@ -26,6 +26,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:

--- a/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
+++ b/test/endtoend/operator/101_initial_cluster_vtorc_vtadmin.yaml
@@ -26,6 +26,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:
@@ -221,7 +223,7 @@ stringData:
 
     RESET SLAVE ALL;
     RESET MASTER;
-    
+
     # We need to set super_read_only back to what it was before
     SET GLOBAL super_read_only=IFNULL(@original_super_read_only, 'ON');
   rbac.yaml: |

--- a/test/endtoend/operator/102_keyspace_teardown.yaml
+++ b/test/endtoend/operator/102_keyspace_teardown.yaml
@@ -32,6 +32,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:

--- a/test/endtoend/operator/102_keyspace_teardown.yaml
+++ b/test/endtoend/operator/102_keyspace_teardown.yaml
@@ -12,9 +12,8 @@ spec:
     engine: xtrabackup
     locations:
     - volume:
-        hostPath:
-          path: /backup
-          type: Directory
+        persistentVolumeClaim:
+          claimName: vitess-backups
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -28,6 +28,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:

--- a/test/endtoend/operator/201_customer_tablets.yaml
+++ b/test/endtoend/operator/201_customer_tablets.yaml
@@ -8,9 +8,8 @@ spec:
     engine: xtrabackup
     locations:
       - volume:
-          hostPath:
-            path: /backup
-            type: Directory
+          persistentVolumeClaim:
+            claimName: vitess-backups
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest

--- a/test/endtoend/operator/302_new_shards.yaml
+++ b/test/endtoend/operator/302_new_shards.yaml
@@ -28,6 +28,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:

--- a/test/endtoend/operator/302_new_shards.yaml
+++ b/test/endtoend/operator/302_new_shards.yaml
@@ -8,9 +8,8 @@ spec:
     engine: xtrabackup
     locations:
       - volume:
-          hostPath:
-            path: /backup
-            type: Directory
+          persistentVolumeClaim:
+            claimName: vitess-backups
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -28,6 +28,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:

--- a/test/endtoend/operator/306_down_shard_0.yaml
+++ b/test/endtoend/operator/306_down_shard_0.yaml
@@ -8,9 +8,8 @@ spec:
     engine: xtrabackup
     locations:
       - volume:
-          hostPath:
-            path: /backup
-            type: Directory
+          persistentVolumeClaim:
+            claimName: vitess-backups
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest

--- a/test/endtoend/operator/401_scheduled_backups.yaml
+++ b/test/endtoend/operator/401_scheduled_backups.yaml
@@ -8,9 +8,8 @@ spec:
     engine: xtrabackup
     locations:
       - volume:
-          hostPath:
-            path: /backup
-            type: Directory
+          persistentVolumeClaim:
+            claimName: vitess-backups
     schedules:
       - name: "commerce"
         schedule: "*/2 * * * *"

--- a/test/endtoend/operator/401_scheduled_backups.yaml
+++ b/test/endtoend/operator/401_scheduled_backups.yaml
@@ -62,6 +62,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:

--- a/test/endtoend/operator/cluster_autoscale.yaml
+++ b/test/endtoend/operator/cluster_autoscale.yaml
@@ -35,6 +35,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -32,6 +32,8 @@ spec:
           secret:
             name: example-cluster-config
             key: users.json
+      extraFlags:
+        tablet_refresh_interval: 10s
       replicas: 1
       resources:
         requests:

--- a/test/endtoend/operator/cluster_upgrade.yaml
+++ b/test/endtoend/operator/cluster_upgrade.yaml
@@ -12,9 +12,8 @@ spec:
     engine: xtrabackup
     locations:
       - volume:
-          hostPath:
-            path: /backup
-            type: Directory
+          persistentVolumeClaim:
+            claimName: vitess-backups
   images:
     vtctld: vitess/lite:latest
     vtgate: vitess/lite:latest

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -7784,4 +7784,9 @@ spec:
               cpu: 100m
               memory: 128Mi
       priorityClassName: vitess-operator-control-plane
+      securityContext:
+        # The fsGroup needs to be set to the default fsGroup of Vitess.
+        # It is inherited by the backup subcontroller and allows it to access
+        # the files created by Vitess on the shared persistent volume.
+        fsGroup: 999 # Default fsGroup of Vitess
       serviceAccountName: vitess-operator

--- a/test/endtoend/operator/operator.yaml
+++ b/test/endtoend/operator/operator.yaml
@@ -7783,4 +7783,9 @@ spec:
               cpu: 100m
               memory: 128Mi
       priorityClassName: vitess-operator-control-plane
+      securityContext:
+        # The fsGroup needs to be set to the default fsGroup of Vitess.
+        # It is inherited by the backup subcontroller and allows it to access
+        # the files created by Vitess on the shared persistent volume.
+        fsGroup: 999 # Default fsGroup of Vitess
       serviceAccountName: vitess-operator

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -18,10 +18,7 @@ function get_started_unmanaged() {
 
     sleep 10
     echo "Creating vschema and commerce SQL schema"
-
-    ./pf.sh > /dev/null 2>&1 &
-    sleep 5
-
+    setupPortForwarding
     waitForKeyspaceToBeServing commerce - 0
     sleep 5
 

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -16,71 +16,14 @@ function get_started_unmanaged() {
     checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-vttablet-zone1(.*)1/1(.*)Running(.*)"
 
-    sleep 10
-    echo "Creating vschema and commerce SQL schema"
     setupPortForwarding
     waitForKeyspaceToBeServing commerce - 0
-    sleep 5
 
     # Confirm that the custom sidecar DB name is in place for our
     # external/unmanaged keyspace.
     verifyCustomSidecarDBName "commerce" "_vt_ext" "external"
 
-    applySchemaWithRetry create_commerce_schema.sql commerce drop_all_commerce_tables.sql
-    vtctldclient ApplyVSchema --vschema-file="vschema_commerce_initial.json" commerce
-    if [[ $? -ne 0 ]]; then
-      echo "ApplySchema failed for initial commerce"
-      printMysqlErrorFiles
-      exit 1
-    fi
-    sleep 5
-
-    echo "show databases;" | mysql | grep "commerce" > /dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-      echo "Could not find commerce database"
-      printMysqlErrorFiles
-      exit 1
-    fi
-
-    echo "show tables;" | mysql commerce | grep -E 'corder|customer|product' | wc -l | grep 3 > /dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-      echo "Could not find commerce's tables"
-      printMysqlErrorFiles
-      exit 1
-    fi
-
-    insertWithRetry
-
-    assertSelect ../common/select_commerce_data.sql "commerce" << EOF
-Using commerce
-Customer
-+-------------+--------------------+
-| customer_id | email              |
-+-------------+--------------------+
-|           1 | alice@domain.com   |
-|           2 | bob@domain.com     |
-|           3 | charlie@domain.com |
-|           4 | dan@domain.com     |
-|           5 | eve@domain.com     |
-+-------------+--------------------+
-Product
-+----------+-------------+-------+
-| sku      | description | price |
-+----------+-------------+-------+
-| SKU-1001 | Monitor     |   100 |
-| SKU-1002 | Keyboard    |    30 |
-+----------+-------------+-------+
-COrder
-+----------+-------------+----------+-------+
-| order_id | customer_id | sku      | price |
-+----------+-------------+----------+-------+
-|        1 |           1 | SKU-1001 |   100 |
-|        2 |           2 | SKU-1002 |    30 |
-|        3 |           3 | SKU-1002 |    30 |
-|        4 |           4 | SKU-1002 |    30 |
-|        5 |           5 | SKU-1002 |    30 |
-+----------+-------------+----------+-------+
-EOF
+    verifyDataCommerce create
 }
 
 # Test setup

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -12,9 +12,9 @@ function get_started_unmanaged() {
     kubectl apply -f "101_initial_cluster_unmanaged_tablet.yaml"
     # Wait for the MySQL pod to be running first to avoid race conditions
     checkPodStatusWithTimeout "mysql-(.*)1/1(.*)Running(.*)" 1
+    checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-zone1-vtctld(.*)1/1(.*)Running(.*)"
     checkPodStatusWithTimeout "example-zone1-vtgate(.*)1/1(.*)Running(.*)"
-    checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-vttablet-zone1(.*)1/1(.*)Running(.*)"
 
     setupPortForwarding

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -87,18 +87,8 @@ EOF
 }
 
 # Test setup
-echo "Building the docker image"
-docker build -f build/Dockerfile.release -t vitess-operator-pr:latest .
-echo "Creating Kind cluster"
-kind create cluster --wait 30s --name kind-${BUILDKITE_BUILD_ID} --image ${KIND_VERSION}
-echo "Loading docker image into Kind cluster"
-kind load docker-image vitess-operator-pr:latest --name kind-${BUILDKITE_BUILD_ID}
-
-cd "$PWD/test/endtoend/operator"
-killall kubectl
-setupKubectlAccessForCI
-
-createExampleNamespace
+setupKindCluster
+cd test/endtoend/operator || exit 1
 
 # Check Unmanaged tablet is running properly
 get_started_unmanaged

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -3,7 +3,6 @@
 source ./tools/test.env
 source ./test/endtoend/utils.sh
 
-# get_started_unmanaged:
 function get_started_unmanaged() {
     echo "Apply latest operator-latest.yaml"
     kubectl apply -f "operator-latest.yaml"
@@ -11,6 +10,8 @@ function get_started_unmanaged() {
 
     echo "Apply 101_initial_cluster_unmanaged_tablet.yaml"
     kubectl apply -f "101_initial_cluster_unmanaged_tablet.yaml"
+    # Wait for the MySQL pod to be running first to avoid race conditions
+    checkPodStatusWithTimeout "mysql-(.*)1/1(.*)Running(.*)" 1
     checkPodStatusWithTimeout "example-zone1-vtctld(.*)1/1(.*)Running(.*)"
     checkPodStatusWithTimeout "example-zone1-vtgate(.*)1/1(.*)Running(.*)"
     checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3

--- a/test/endtoend/unmanaged_tablet_test.sh
+++ b/test/endtoend/unmanaged_tablet_test.sh
@@ -94,5 +94,4 @@ cd test/endtoend/operator || exit 1
 get_started_unmanaged
 
 # Teardown
-echo "Deleting Kind cluster. This also deletes the volume associated with it"
-kind delete cluster --name kind-${BUILDKITE_BUILD_ID}
+teardownKindCluster

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -293,17 +293,9 @@ EOF
 }
 
 # Test setup
-mkdir -p -m 777 ./vtdataroot/backup
-echo "Building the docker image"
-docker build -f build/Dockerfile.release -t vitess-operator-pr:latest .
-setupKindConfig
-createKindCluster
+setupKindCluster
+cd test/endtoend/operator || exit 1
 
-cd "$PWD/test/endtoend/operator"
-killall kubectl
-setupKubectlAccessForCI
-
-createExampleNamespace
 get_started "operator.yaml" "101_initial_cluster.yaml"
 verifyVtGateVersion "22.0.0"
 checkSemiSyncSetup

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -10,9 +10,7 @@ function move_tables() {
   checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 6
   checkPodStatusWithTimeout "example-customer-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
-  killall kubectl
-  ./pf.sh > /dev/null 2>&1 &
-
+  setupPortForwarding
   waitForKeyspaceToBeServing customer - 2
 
   sleep 10
@@ -89,10 +87,7 @@ function resharding() {
   checkPodStatusWithTimeout "example-customer-80-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
   checkPodStatusWithTimeout "example-customer-x-80-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
-  killall kubectl
-  ./pf.sh > /dev/null 2>&1 &
-  sleep 5
-
+  setupPortForwarding
   waitForKeyspaceToBeServing customer -80 2
   waitForKeyspaceToBeServing customer 80- 2
 
@@ -255,10 +250,8 @@ function upgradeToLatest() {
   waitAndVerifySetup
   verifyVtgateDeploymentStrategy
 
-  killall kubectl
-  ./pf.sh > /dev/null 2>&1 &
-
-  sleep 10
+  setupPortForwarding
+  waitForKeyspaceToBeServing commerce - 2
 
   assertSelect ../common/select_commerce_data.sql "commerce" << EOF
 Using commerce

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -6,14 +6,11 @@ source ./test/endtoend/utils.sh
 function move_tables() {
   echo "Apply 201_customer_tablets.yaml"
   kubectl apply -f 201_customer_tablets.yaml > /dev/null
-  sleep 300
-  checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 6
   checkPodStatusWithTimeout "example-customer-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
+  checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 6
 
   setupPortForwarding
   waitForKeyspaceToBeServing customer - 2
-
-  sleep 10
 
   echo "Execute MoveTables"
   vtctldclient LegacyVtctlCommand -- MoveTables --source commerce --tables 'customer,corder' Create customer.commerce2customer
@@ -92,8 +89,6 @@ function resharding() {
   waitForKeyspaceToBeServing customer 80- 2
 
   echo "Ready to reshard ..."
-  sleep 15
-
   vtctldclient LegacyVtctlCommand -- Reshard --source_shards '-' --target_shards '-80,80-' Create customer.cust2cust
   if [ $? -ne 0 ]; then
     echo "Reshard Create failed"

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -255,37 +255,7 @@ function upgradeToLatest() {
 
   setupPortForwarding
   waitForKeyspaceToBeServing commerce - 2
-
-  assertSelect ../common/select_commerce_data.sql "commerce" << EOF
-Using commerce
-Customer
-+-------------+--------------------+
-| customer_id | email              |
-+-------------+--------------------+
-|           1 | alice@domain.com   |
-|           2 | bob@domain.com     |
-|           3 | charlie@domain.com |
-|           4 | dan@domain.com     |
-|           5 | eve@domain.com     |
-+-------------+--------------------+
-Product
-+----------+-------------+-------+
-| sku      | description | price |
-+----------+-------------+-------+
-| SKU-1001 | Monitor     |   100 |
-| SKU-1002 | Keyboard    |    30 |
-+----------+-------------+-------+
-COrder
-+----------+-------------+----------+-------+
-| order_id | customer_id | sku      | price |
-+----------+-------------+----------+-------+
-|        1 |           1 | SKU-1001 |   100 |
-|        2 |           2 | SKU-1002 |    30 |
-|        3 |           3 | SKU-1002 |    30 |
-|        4 |           4 | SKU-1002 |    30 |
-|        5 |           5 | SKU-1002 |    30 |
-+----------+-------------+----------+-------+
-EOF
+  verifyDataCommerce
 }
 
 # Test setup

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -80,9 +80,9 @@ function resharding() {
 
   echo "Apply 302_new_shards.yaml"
   kubectl apply -f 302_new_shards.yaml
-  checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 12
   checkPodStatusWithTimeout "example-customer-80-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
   checkPodStatusWithTimeout "example-customer-x-80-zone1-vtorc(.*)1/1(.*)Running(.*)"
+  checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 12
 
   setupPortForwarding
   waitForKeyspaceToBeServing customer -80 2

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -179,7 +179,6 @@ function scheduledBackups() {
   checkVitessBackupScheduleStatusWithTimeout "example-vbsc-commerce(.*)"
   checkVitessBackupScheduleStatusWithTimeout "example-vbsc-customer(.*)"
 
-  docker exec -it $(docker container ls --format '{{.Names}}' | grep kind) chmod o+rwx -R /backup > /dev/null
   initialCommerceBackups=$(kubectl get vtb -n example --no-headers | grep "commerce-x-x" | wc -l)
   initialCustomerFirstShardBackups=$(kubectl get vtb -n example --no-headers | grep "customer-x-80" | wc -l)
   initialCustomerSecondShardBackups=$(kubectl get vtb -n example --no-headers | grep "customer-80-x" | wc -l)

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -229,7 +229,7 @@ function verifyVtgateDeploymentStrategy() {
 function upgradeToLatest() {
   echo "Upgrade Vitess Operator"
   kubectl apply -f operator-latest.yaml
-  checkPodSpecBySelectorWithTimeout "default" "app=vitess-operator" 1 "image: vitess-operator-pr:latest"
+  checkPodSpecBySelectorWithTimeout default "app=vitess-operator" 1 "image: vitess-operator-pr:latest"
   checkPodStatusWithTimeout "vitess-operator(.*)1/1(.*)Running(.*)"
 
   echo "Upgrade Vitess binaries"

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -312,8 +312,4 @@ resharding
 scheduledBackups
 
 # Teardown
-echo "Removing the temporary directory"
-removeBackupFiles
-rm -rf "$STARTING_DIR/vtdataroot"
-echo "Deleting Kind cluster. This also deletes the volume associated with it"
-kind delete cluster --name kind-${BUILDKITE_BUILD_ID}
+teardownKindCluster

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -508,7 +508,8 @@ function setupKindConfig() {
   fi
 
   local backup_dir="${checkout_path}/vtdataroot/backup"
-  mkdir -p "${backup_dir}"
+  # shellcheck disable=SC2174 # `-m` only applies to the deepest directory, but that's what we want
+  mkdir -p -m 0777 vtdataroot/backup
   sed "s,PATH,${backup_dir},1" test/endtoend/kindBackupConfig.yaml > vtdataroot/config.yaml
 }
 

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -312,6 +312,70 @@ function verifyCustomSidecarDBName() {
   done
 }
 
+function verifyDataCommerce() {
+  local create="${1:-}"
+
+  if [[ "${create}" == "create" ]]; then
+    echo "Creating VSchema and 'commerce' SQL schema"
+    applySchemaWithRetry create_commerce_schema.sql commerce drop_all_commerce_tables.sql
+    if ! vtctldclient ApplyVSchema --vschema-file=vschema_commerce_initial.json commerce; then
+      echo "ApplyVSchema failed for initial 'commerce'"
+      printMysqlErrorFiles
+      exit 1
+    fi
+  fi
+
+  if ! mysql --database=commerce --execute="show tables" > /dev/null 2>&1; then
+    echo "Could not find 'commerce' database"
+    printMysqlErrorFiles
+    exit 1
+  fi
+
+  local tables matching_tables_num
+  tables="$(mysql --database=commerce --execute="show tables")"
+  matching_tables_num="$(echo "${tables}" | grep -cE "corder|customer|product")"
+  if [[ "${matching_tables_num}" -ne 3 ]]; then
+    echo "Could not find 'commerce' tables"
+    printMysqlErrorFiles
+    exit 1
+  fi
+
+  if [[ "${create}" == "create" ]]; then
+    insertWithRetry
+  fi
+
+  assertSelect ../common/select_commerce_data.sql commerce << EOF
+Using commerce
+Customer
++-------------+--------------------+
+| customer_id | email              |
++-------------+--------------------+
+|           1 | alice@domain.com   |
+|           2 | bob@domain.com     |
+|           3 | charlie@domain.com |
+|           4 | dan@domain.com     |
+|           5 | eve@domain.com     |
++-------------+--------------------+
+Product
++----------+-------------+-------+
+| sku      | description | price |
++----------+-------------+-------+
+| SKU-1001 | Monitor     |   100 |
+| SKU-1002 | Keyboard    |    30 |
++----------+-------------+-------+
+COrder
++----------+-------------+----------+-------+
+| order_id | customer_id | sku      | price |
++----------+-------------+----------+-------+
+|        1 |           1 | SKU-1001 |   100 |
+|        2 |           2 | SKU-1002 |    30 |
+|        3 |           3 | SKU-1002 |    30 |
+|        4 |           4 | SKU-1002 |    30 |
+|        5 |           5 | SKU-1002 |    30 |
++----------+-------------+----------+-------+
+EOF
+}
+
 function waitForKeyspaceToBeServing() {
   ks=$1
   shard=$2
@@ -459,67 +523,9 @@ function get_started() {
     checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-commerce-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
-    sleep 10
-    echo "Creating vschema and commerce SQL schema"
     setupPortForwarding
     waitForKeyspaceToBeServing commerce - 2
-    sleep 5
-
-    applySchemaWithRetry create_commerce_schema.sql commerce drop_all_commerce_tables.sql
-    vtctldclient ApplyVSchema --vschema-file="vschema_commerce_initial.json" commerce
-    if [[ $? -ne 0 ]]; then
-      echo "ApplySchema failed for initial commerce"
-      printMysqlErrorFiles
-      exit 1
-    fi
-    sleep 5
-
-    echo "show databases;" | mysql | grep "commerce" > /dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-      echo "Could not find commerce database"
-      printMysqlErrorFiles
-      exit 1
-    fi
-
-    echo "show tables;" | mysql commerce | grep -E 'corder|customer|product' | wc -l | grep 3 > /dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-      echo "Could not find commerce's tables"
-      printMysqlErrorFiles
-      exit 1
-    fi
-
-    insertWithRetry
-
-    assertSelect ../common/select_commerce_data.sql "commerce" << EOF
-Using commerce
-Customer
-+-------------+--------------------+
-| customer_id | email              |
-+-------------+--------------------+
-|           1 | alice@domain.com   |
-|           2 | bob@domain.com     |
-|           3 | charlie@domain.com |
-|           4 | dan@domain.com     |
-|           5 | eve@domain.com     |
-+-------------+--------------------+
-Product
-+----------+-------------+-------+
-| sku      | description | price |
-+----------+-------------+-------+
-| SKU-1001 | Monitor     |   100 |
-| SKU-1002 | Keyboard    |    30 |
-+----------+-------------+-------+
-COrder
-+----------+-------------+----------+-------+
-| order_id | customer_id | sku      | price |
-+----------+-------------+----------+-------+
-|        1 |           1 | SKU-1001 |   100 |
-|        2 |           2 | SKU-1002 |    30 |
-|        3 |           3 | SKU-1002 |    30 |
-|        4 |           4 | SKU-1002 |    30 |
-|        5 |           5 | SKU-1002 |    30 |
-+----------+-------------+----------+-------+
-EOF
+    verifyDataCommerce create
 }
 
 function checkVitessBackupScheduleStatusWithTimeout() {

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -328,6 +328,11 @@ function assertSelect() {
   fi
 }
 
+function setupBuildContainerImage() {
+  echo "Building the container image"
+  docker build --file build/Dockerfile.release --tag vitess-operator-pr:latest .
+}
+
 function setupKubectlAccessForCI() {
   if [[ "$BUILDKITE_BUILD_ID" != "0" ]]; then
     # The script is being run from buildkite, so we need to do stuff

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -6,7 +6,7 @@
 # set -x
 shopt -s expand_aliases
 alias vtctldclient="vtctldclient --server=localhost:15999"
-alias mysql="mysql -h 127.0.0.1 -P 15306 -u user"
+alias mysql="mysql --skip-ssl-verify-server-cert -h 127.0.0.1 -P 15306 -u user"
 BUILDKITE_JOB_ID="${BUILDKITE_JOB_ID:-0}"
 
 function checkSemiSyncSetup() {

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -298,7 +298,7 @@ function verifyCustomSidecarDBName() {
     container=""
     mysqlCMD="mysql --protocol=tcp -P3306 -NB -u root -ppassword -e \"show databases like '${db_name}'\" 2>/dev/null"
     selector="app=mysql"
-  fi 
+  fi
   local pods pod
   pods=$(kubectl get pods -n example --no-headers --selector="${selector}" -o custom-columns=":metadata.name")
   for pod in $(echo "${pods}"); do
@@ -312,8 +312,9 @@ function verifyCustomSidecarDBName() {
   done
 }
 
+# shellcheck disable=SC2120 # function has an optional argument
 function verifyDataCommerce() {
-  local create="${1:-}"
+  local create="${1:-}" # Pass `create` to create the schema and insert data
 
   if [[ "${create}" == "create" ]]; then
     echo "Creating VSchema and 'commerce' SQL schema"

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -426,6 +426,7 @@ function setupPortForwarding() {
   local port_vtadmin_api=14001
   local port_vtctld_grpc=15999
 
+  echo "Setting up port forwarding"
   killall kubectl > /dev/null 2>&1 || true
   sleep 2
 
@@ -447,6 +448,8 @@ function setupPortForwarding() {
       sleep 1
     done
   fi
+
+  echo "Port forwarding is ready"
 }
 
 function teardownKindCluster() {

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -534,11 +534,11 @@ function get_started() {
 
     echo "Apply $2"
     kubectl apply -f "$2"
+    checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-zone1-vtctld(.*)1/1(.*)Running(.*)"
     checkPodStatusWithTimeout "example-zone1-vtgate(.*)1/1(.*)Running(.*)"
-    checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
-    checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-commerce-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
+    checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
 
     setupPortForwarding
     waitForKeyspaceToBeServing commerce - 2

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -85,8 +85,6 @@ function removeBackupFiles() {
 # $1: keyspace-shard for which the backup needs to be taken
 function takeBackup() {
   keyspaceShard=$1
-  initialBackupCount=$(kubectl get vtb -n example --no-headers | wc -l)
-  finalBackupCount=$((initialBackupCount+1))
 
   # Issue the BackupShard command to vtctldclient.
   vtctldclient BackupShard "$keyspaceShard"
@@ -115,13 +113,6 @@ function verifyListBackupsOutput() {
   done
   echo -e "ERROR: GetBackups output not correct - $out. $backupCount backups expected."
   exit 1
-}
-
-function dockerContainersInspect() {
-  for container in $(docker container ls --format '{{.Names}}') ; do
-    echo "Container - $container"
-    docker container inspect "$container"
-  done
 }
 
 function checkPodSpecBySelectorWithTimeout() {

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -355,6 +355,17 @@ function setupKubectlAccessForCI() {
   fi
 }
 
+function teardownKindCluster() {
+  local vtdataroot_dir="../../vtdataroot"
+
+  echo "Removing backup files and temporary directories"
+  removeBackupFiles
+  rm -rf "${vtdataroot_dir}"
+
+  echo "Deleting the Kind cluster. This also deletes the volume associated with it."
+  kind delete cluster --name "kind-${BUILDKITE_BUILD_ID}"
+}
+
 function setupKindConfig() {
   echo "Setting up the Kind config"
   local checkout_path

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -62,17 +62,6 @@ function printMysqlErrorFiles() {
   done
 }
 
-function printBackupLogFiles() {
-  for vtbackup in $(kubectl get pods -n example --no-headers -o custom-columns=":metadata.name" | grep "vtbackup") ; do
-    echo "Printing logs of $vtbackup"
-    kubectl logs -n example "$vtbackup"
-    echo "Description of $vtbackup"
-    kubectl describe pod -n example "$vtbackup"
-    echo "User in $vtbackup"
-    kubectl exec -n example "$vtbackup" -- whoami
-  done
-}
-
 # takeBackup:
 # $1: keyspace-shard for which the backup needs to be taken
 function takeBackup() {

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -393,7 +393,14 @@ function assertSelect() {
 
 function setupBuildContainerImage() {
   echo "Building the container image"
-  docker build --file build/Dockerfile.release --tag vitess-operator-pr:latest .
+
+  # Clean up build output in CI
+  local progress="auto"
+  if [[ "${BUILDKITE_JOB_ID}" != "0" ]]; then
+    progress="plain"
+  fi
+
+  docker build --progress "${progress}" --file build/Dockerfile.release --tag vitess-operator-pr:latest .
 }
 
 function setupKindCluster() {

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -431,10 +431,7 @@ function get_started() {
 
     sleep 10
     echo "Creating vschema and commerce SQL schema"
-
-    ./pf.sh > /dev/null 2>&1 &
-    sleep 5
-
+    setupPortForwarding
     waitForKeyspaceToBeServing commerce - 2
     sleep 5
 

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -355,6 +355,21 @@ function setupKubectlAccessForCI() {
   fi
 }
 
+function setupPortForwarding() {
+  local port_mysql=15306
+  local port_vtctld_grpc=15999
+
+  killall kubectl > /dev/null 2>&1 || true
+  sleep 2
+  ./pf.sh > /dev/null 2>&1 &
+
+  # Wait for ports to be ready
+  vtctldclient --server="localhost:${port_vtctld_grpc}" --action_timeout=10s GetTablets > /dev/null 2>&1
+  until mysql --database=mysql --execute="select @@hostname" --host=127.0.0.1 --port="${port_mysql}" --user=user > /dev/null 2>&1; do
+    sleep 1
+  done
+}
+
 function teardownKindCluster() {
   local vtdataroot_dir="../../vtdataroot"
 

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -333,6 +333,14 @@ function setupBuildContainerImage() {
   docker build --file build/Dockerfile.release --tag vitess-operator-pr:latest .
 }
 
+function setupKindCluster() {
+  setupBuildContainerImage
+  setupKindConfig
+  createKindCluster
+  setupKubectlAccessForCI
+  createExampleNamespace
+}
+
 function setupKubectlAccessForCI() {
   if [[ "$BUILDKITE_BUILD_ID" != "0" ]]; then
     # The script is being run from buildkite, so we need to do stuff

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -230,18 +230,9 @@ function curlPostRequest() {
 }
 
 # Test setup
-echo "Building the docker image"
-docker build -f build/Dockerfile.release -t vitess-operator-pr:latest .
-echo "Creating Kind cluster"
-kind create cluster --wait 30s --name kind-${BUILDKITE_BUILD_ID} --image ${KIND_VERSION}
-echo "Loading docker image into Kind cluster"
-kind load docker-image vitess-operator-pr:latest --name kind-${BUILDKITE_BUILD_ID}
+setupKindCluster
+cd test/endtoend/operator || exit 1
 
-cd "$PWD/test/endtoend/operator"
-killall kubectl
-setupKubectlAccessForCI
-
-createExampleNamespace
 get_started_vtorc_vtadmin
 verifyVtGateVersion "23.0.0"
 checkSemiSyncSetup

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -11,12 +11,12 @@ function get_started_vtorc_vtadmin() {
 
     echo "Apply 101_initial_cluster_vtorc_vtadmin.yaml"
     kubectl apply -f "101_initial_cluster_vtorc_vtadmin.yaml"
+    checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-zone1-vtctld(.*)1/1(.*)Running(.*)"
     checkPodStatusWithTimeout "example-zone1-vtgate(.*)1/1(.*)Running(.*)"
-    checkPodStatusWithTimeout "example-etcd(.*)1/1(.*)Running(.*)" 3
+    checkPodStatusWithTimeout "example-commerce-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
     checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
     checkPodStatusWithTimeout "example-zone1-vtadmin(.*)2/2(.*)Running(.*)"
-    checkPodStatusWithTimeout "example-commerce-x-x-zone1-vtorc(.*)1/1(.*)Running(.*)"
 
     ensurePodResourcesSet "example-zone1-vtadmin"
 

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -245,5 +245,4 @@ verifyVtadminSetup
 verifyVTOrcSetup
 
 # Teardown
-echo "Deleting Kind cluster. This also deletes the volume associated with it"
-kind delete cluster --name kind-${BUILDKITE_BUILD_ID}
+teardownKindCluster

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -27,63 +27,7 @@ function get_started_vtorc_vtadmin() {
     sleep 5
 
     waitForKeyspaceToBeServing commerce - 2
-    sleep 5
-
-    applySchemaWithRetry create_commerce_schema.sql commerce drop_all_commerce_tables.sql
-    vtctldclient ApplyVSchema --vschema-file="vschema_commerce_initial.json" commerce
-    if [[ $? -ne 0 ]]; then
-      echo "ApplySchema failed for initial commerce"
-      printMysqlErrorFiles
-      exit 1
-    fi
-    sleep 5
-
-    echo "show databases;" | mysql | grep "commerce" > /dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-      echo "Could not find commerce database"
-      printMysqlErrorFiles
-      exit 1
-    fi
-
-    echo "show tables;" | mysql commerce | grep -E 'corder|customer|product' | wc -l | grep 3 > /dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-      echo "Could not find commerce's tables"
-      printMysqlErrorFiles
-      exit 1
-    fi
-
-    insertWithRetry
-
-    assertSelect ../common/select_commerce_data.sql "commerce" << EOF
-Using commerce
-Customer
-+-------------+--------------------+
-| customer_id | email              |
-+-------------+--------------------+
-|           1 | alice@domain.com   |
-|           2 | bob@domain.com     |
-|           3 | charlie@domain.com |
-|           4 | dan@domain.com     |
-|           5 | eve@domain.com     |
-+-------------+--------------------+
-Product
-+----------+-------------+-------+
-| sku      | description | price |
-+----------+-------------+-------+
-| SKU-1001 | Monitor     |   100 |
-| SKU-1002 | Keyboard    |    30 |
-+----------+-------------+-------+
-COrder
-+----------+-------------+----------+-------+
-| order_id | customer_id | sku      | price |
-+----------+-------------+----------+-------+
-|        1 |           1 | SKU-1001 |   100 |
-|        2 |           2 | SKU-1002 |    30 |
-|        3 |           3 | SKU-1002 |    30 |
-|        4 |           4 | SKU-1002 |    30 |
-|        5 |           5 | SKU-1002 |    30 |
-+----------+-------------+----------+-------+
-EOF
+    verifyDataCommerce create
 }
 
 # verifyVtadminSetup verifies that we can query the vtadmin api end point

--- a/test/endtoend/vtorc_vtadmin_test.sh
+++ b/test/endtoend/vtorc_vtadmin_test.sh
@@ -20,12 +20,7 @@ function get_started_vtorc_vtadmin() {
 
     ensurePodResourcesSet "example-zone1-vtadmin"
 
-    sleep 10
-    echo "Creating vschema and commerce SQL schema"
-
-    ./pf_vtadmin.sh > /dev/null 2>&1 &
-    sleep 5
-
+    setupPortForwarding with_vtadmin
     waitForKeyspaceToBeServing commerce - 2
     verifyDataCommerce create
 }

--- a/tools/get-e2e-test-deps.sh
+++ b/tools/get-e2e-test-deps.sh
@@ -19,7 +19,7 @@ KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL:-https://dl.k8s.io}"
 # Download kubectl if needed.
 if [ ! -f "kubectl-${KUBE_VERSION}" ]; then
     echo "Downloading kubectl ${KUBE_VERSION}..."
-    curl -L "${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/bin/linux/amd64/kubectl" > "kubectl-${KUBE_VERSION}"
+    curl --silent -L "${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/bin/linux/amd64/kubectl" > "kubectl-${KUBE_VERSION}"
     chmod +x "kubectl-${KUBE_VERSION}"
 fi
 echo "Using kubectl ${KUBE_VERSION}."
@@ -29,7 +29,7 @@ ln -sf "kubectl-${KUBE_VERSION}" kubectl
 if ! command -v kind &> /dev/null
 then
     echo "Downloading kind..."
-    curl -L https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64 > "kind"
+    curl --silent -L https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64 > "kind"
     chmod +x "kind"
     echo "Installed kind"
 else
@@ -42,7 +42,7 @@ then
   echo "Downloading vtctldclient..."
   version=21.0.0-rc1
   file=vitess-${version}-7908b43.tar.gz
-  wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
+  wget -q https://github.com/vitessio/vitess/releases/download/v${version}/${file}
   tar -xzf ${file}
   cd ${file/.tar.gz/}
   cp -r ./bin/* ../


### PR DESCRIPTION
The end-to-end tests have been pretty flaky lately, which makes it harder to trust them and [slows down pull requests](https://github.com/planetscale/vitess-operator/pull/629#issuecomment-2468858310). Let's try to get this fixed! Here, I focused on the initial Kind cluster setup, port forwarding, teardown, and some of the most temperamental parts of the test suite. Quick summary of the changes:

* Added a cache mount for Go module and build caches in the Docker image. On my machine, this frees up disk space and cuts image build time from 40+ seconds to 1–5 seconds, depending on the code changes.
* Moved the Kind cluster setup steps into a function, DRYing up the code [across all tests](https://github.com/planetscale/vitess-operator/commit/c48bcaea78a7a2122814f8164a6c8f14f752123f).
* Did the same for the [teardown](https://github.com/planetscale/vitess-operator/commit/12aaabfc8bc40c10d06c1ad37267bae5bdac0514) logic.
* Replaced `hostPath` volumes with `persistentVolumeClaim` volumes. That [simplified](https://github.com/planetscale/vitess-operator/pull/700/commits/64c3fd1b5bf4099f492e8c2d670ddd47b00ef49a) the code, cluster setup, file permissions, and removed occasional `chmod`-ing of backup directories.
* Made port forwarding more robust by waiting for expected ports to become ready to serve requests. That helped remove a few `sleep`s from the tests.
* Reduced VTGate's `tablet_refresh_interval` from 60 to 10 seconds (same as in vttestserver), which speeds up the initial Vitess cluster setup and upgrades.
* Added a post-upgrade cluster spec verification step. Combined with the previous point, that stabilized the most frequently failing upgrade test.
* Moved `commerce` keyspace verification commands into a function, DRYing up a [decent chunk](https://github.com/planetscale/vitess-operator/commit/cc61186550433fffae2ac956ced1f570988a8bb0) of the code.
* Removed the local binary build as it isn't used in the tests.
* Decreased the timeouts of Buildkite jobs and added retries on unexpected Buildkite Agent failures.
* Added support for running the tests in environments where multiple Buildkite Agents share a single Docker service.
* Reduced the output when installing or downloading the tools. Fixed the output when building the Docker image. Reduced MySQL client warnings.
* Other minor tweaks that help with test stability and general cleanup.

I ran some "before" and "after" comparisons. On my machine, the average time for 7 test runs on the `main` branch was 36 minutes 1 second, with a standard deviation of 1 minute 4 seconds. After these changes, the average dropped to 27 minutes 57 seconds, with a standard deviation of 1 minute 1 second. More importantly though, I haven't seen any of the flakiness that was happening before. Will see what CI says and make further improvements if needed.

The diff of this pull request is pretty big, and it's much easier to review commit-by-commit. I decided not to split it into multiple pull requests because I was worried that flaky failures in intermediate ones would stall all of them. 😅

Related to https://github.com/planetscale/vitess-operator/issues/582.