### PR TITLE
Make `--s3_backup_aws_min_partsize` optional

### DIFF
--- a/pkg/operator/vitessbackup/storage_s3.go
+++ b/pkg/operator/vitessbackup/storage_s3.go
@@ -31,8 +31,12 @@ func s3BackupFlags(s3 *planetscalev2.S3BackupLocation, clusterName string) vites
 		"s3_backup_storage_bucket":      s3.Bucket,
 		"s3_backup_storage_root":        rootKeyPrefix(s3.KeyPrefix, clusterName),
 		"s3_backup_force_path_style":    s3.ForcePathStyle,
-		"s3_backup_aws_min_partsize":    s3.MinPartSize,
 	}
+
+	if s3.MinPartSize > 0 {
+		flags["s3_backup_aws_min_partsize"] = s3.MinPartSize
+	}
+
 	if len(s3.Endpoint) > 0 {
 		flags["s3_backup_aws_endpoint"] = s3.Endpoint
 	}


### PR DESCRIPTION
This PR does not set the S3 AWS min partsize flag when its value is 0. Having a value of 0 means we will be using the default in Vitess, so better not set the flag, this fixes incompatibility issues between v2.15.0 and v21.0.0.

Fixes https://github.com/planetscale/vitess-operator/issues/701