### PR TITLE
Fix `mysql` alias in end-to-end utils

### DIFF
--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -6,8 +6,15 @@
 # set -x
 shopt -s expand_aliases
 alias vtctldclient="vtctldclient --server=localhost:15999"
-alias mysql="mysql --skip-ssl-verify-server-cert -h 127.0.0.1 -P 15306 -u user"
 BUILDKITE_JOB_ID="${BUILDKITE_JOB_ID:-0}"
+
+# Suppress warnings when using MariaDB Client
+mysql_version="$(mysql --version 2>/dev/null)"
+if [[ "${mysql_version}" =~ "MariaDB" ]]; then
+  alias mysql="mariadb --skip-ssl-verify-server-cert -h 127.0.0.1 -P 15306 -u user"
+else
+  alias mysql="mysql -h 127.0.0.1 -P 15306 -u user"
+fi
 
 function checkSemiSyncSetup() {
   for vttablet in $(kubectl get pods -n example --no-headers -o custom-columns=":metadata.name" | grep "vttablet") ; do


### PR DESCRIPTION
In https://github.com/planetscale/vitess-operator/pull/700 / https://github.com/planetscale/vitess-operator/pull/700/commits/4d35938fd48f0d733b03bf7d8a456176ffaff604, I added `--skip-ssl-verify-server-cert` to the `mysql` alias. Sadly, this broke tests on Oracle MySQL Client as it doesn't support this flag. Tests running in Buildkite are using MariaDB Client, so they are fine.

Additionally, MariaDB Client complains if it isn't invoked using `mariadb`:

> `mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead`

This change addresses both issues.