### PR TITLE
[release-2.15] Back to dev mode after the release of `v2.15.1`

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -20,5 +20,5 @@ package version
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
 var (
-	Version = "2.15.1"
+	Version = "2.15.2"
 )


### PR DESCRIPTION
This Pull Request updates the release-2.15 branch to go back to dev mode after the release of v2.15.1.