### PR TITLE
fix overwrite of cluster-level default images

### DIFF
--- a/pkg/apis/planetscale/v2/vitesskeyspace_defaults.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_defaults.go
@@ -53,20 +53,24 @@ func DefaultVitessOrchestrator(vtorc **VitessOrchestratorSpec) {
 // DefaultVitessKeyspaceImages fills in unspecified keyspace-level images from cluster-level defaults.
 // The clusterDefaults should have already had its unspecified fields filled in with operator defaults.
 func DefaultVitessKeyspaceImages(dst *VitessKeyspaceImages, clusterDefaults *VitessImages) {
+	// Deep copying the cluster-level defaults to prevent
+	// overriding any value for subsequent keyspaces.
+	defaults := clusterDefaults.DeepCopy()
+
 	if dst.Vttablet == "" {
-		dst.Vttablet = clusterDefaults.Vttablet
+		dst.Vttablet = defaults.Vttablet
 	}
 	if dst.Vtorc == "" {
-		dst.Vtorc = clusterDefaults.Vtorc
+		dst.Vtorc = defaults.Vtorc
 	}
 	if dst.Vtbackup == "" {
-		dst.Vtbackup = clusterDefaults.Vtbackup
+		dst.Vtbackup = defaults.Vtbackup
 	}
 	if dst.Mysqld == nil {
-		dst.Mysqld = clusterDefaults.Mysqld
+		dst.Mysqld = defaults.Mysqld
 	}
 	if dst.MysqldExporter == "" {
-		dst.MysqldExporter = clusterDefaults.MysqldExporter
+		dst.MysqldExporter = defaults.MysqldExporter
 	}
 }
 


### PR DESCRIPTION
As reported in https://github.com/planetscale/vitess-operator/issues/710, when a keyspace had keyspace-level image definition in its spec, it would overwirte the cluster-level image definition for any subsequent keyspaces.

This PR fixes the issues by doing a deep copy of the cluster-level image before assigning them to the keyspace.

Fixes https://github.com/planetscale/vitess-operator/issues/710.