### PR TITLE
add comment in crd about hex width

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5814,6 +5814,11 @@ int32
 <td>
 <p>HexWidth is the number of hex characters to use for the shard range start and end.
 If not set or set to 0, it will be automatically computed based on the number of requested shards.</p>
+<p>WARNING: DO NOT change the hex width in a partitioning after deploying.
+That&rsquo;s effectively deleting the old partitioning and adding a new one,
+which can lead to downtime or data loss. Instead, add an additional
+partitioning with the desired hex width, perform a resharding
+migration, and then remove the old partitioning.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -5816,6 +5816,11 @@ int32
 <td>
 <p>HexWidth is the number of hex characters to use for the shard range start and end.
 If not set or set to 0, it will be automatically computed based on the number of requested shards.</p>
+<p>WARNING: DO NOT change the hex width in a partitioning after deploying.
+That&rsquo;s effectively deleting the old partitioning and adding a new one,
+which can lead to downtime or data loss. Instead, add an additional
+partitioning with the desired hex width, perform a resharding
+migration, and then remove the old partitioning.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/planetscale/v2/vitesskeyspace_methods_test.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_methods_test.go
@@ -64,7 +64,7 @@ func TestTranslationToVitessKeyRange(t *testing.T) {
 			},
 		},
 		{
-			hexWidth: 4,
+			hexWidth: 2,
 			parts:    7,
 			want: []VitessKeyRange{
 				{"", "2492"},
@@ -77,7 +77,7 @@ func TestTranslationToVitessKeyRange(t *testing.T) {
 			},
 		},
 		{
-			hexWidth: 4,
+			hexWidth: 2,
 			parts:    8,
 			want: []VitessKeyRange{
 				{"", "2000"},

--- a/pkg/apis/planetscale/v2/vitesskeyspace_methods_test.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_methods_test.go
@@ -64,7 +64,7 @@ func TestTranslationToVitessKeyRange(t *testing.T) {
 			},
 		},
 		{
-			hexWidth: 2,
+			hexWidth: 4,
 			parts:    7,
 			want: []VitessKeyRange{
 				{"", "2492"},
@@ -77,7 +77,7 @@ func TestTranslationToVitessKeyRange(t *testing.T) {
 			},
 		},
 		{
-			hexWidth: 2,
+			hexWidth: 4,
 			parts:    8,
 			want: []VitessKeyRange{
 				{"", "2000"},

--- a/pkg/apis/planetscale/v2/vitesskeyspace_types.go
+++ b/pkg/apis/planetscale/v2/vitesskeyspace_types.go
@@ -359,6 +359,13 @@ type VitessKeyspaceEqualPartitioning struct {
 
 	// HexWidth is the number of hex characters to use for the shard range start and end.
 	// If not set or set to 0, it will be automatically computed based on the number of requested shards.
+	//
+	// WARNING: DO NOT change the hex width in a partitioning after deploying.
+	//          That's effectively deleting the old partitioning and adding a new one,
+	//          which can lead to downtime or data loss. Instead, add an additional
+	//          partitioning with the desired hex width, perform a resharding
+	//          migration, and then remove the old partitioning.
+	//
 	// +kubebuilder:default=0
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65536


### PR DESCRIPTION
Follow up of #723.

Adding a comment about hexWidth, warning users they should not modify and apply this unless they are creating a new partition and going through a proper migration / reshard process.