### PR TITLE
[main] Bump version.go to 2.16.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -20,5 +20,5 @@ package version
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
 var (
-	Version = "2.15.0"
+	Version = "2.16.0"
 )


### PR DESCRIPTION
This Pull Request bumps the version/version.go file to 2.16.0

> This Pull Request is part of https://github.com/vitessio/vitess/issues/18594