### PR TITLE
[release-2.16] Back to dev mode after the release of `v2.16.0`

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -20,5 +20,5 @@ package version
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
 var (
-	Version = "2.16.0"
+	Version = "2.16.1"
 )


### PR DESCRIPTION
This Pull Request updates the release-2.16 branch to go back to dev mode after the release of v2.16.0.

> This Pull Request is part of https://github.com/vitessio/vitess/issues/18854