### PR TITLE
`vtorc`: pass `--cell` flag on Vitess v24+

### DIFF
--- a/docs/release-notes/2_18_0_summary.md
+++ b/docs/release-notes/2_18_0_summary.md
@@ -1,0 +1,13 @@
+## Major Changes
+
+### Table of Contents
+
+- **[VTOrc `--cell` flag auto-applied on Vitess v24+](#vtorc-cell-flag)**
+
+### <a id="vtorc-cell-flag"/>VTOrc `--cell` flag auto-applied on Vitess v24+</a>
+
+VTOrc deployments now receive `--cell=<cell>` automatically when the configured image tag parses to Vitess v24 or newer. This is required for Vitess v25+ where `--cell` is a hard requirement ([vitessio/vitess#20048](https://github.com/vitessio/vitess/pull/20048)) and was introduced in v24 ([vitessio/vitess#19047](https://github.com/vitessio/vitess/pull/19047)).
+
+The flag is **only** emitted when the version is parseable from the image tag (e.g. `vitess/lite:v24.0.0-mysql80`). Rolling tags such as `vitess/lite:mysql80` or `vitess/lite:latest`, or digest-only references, do not get the flag — pin a versioned tag, or set `cell` explicitly via `vitessOrchestrator.extraFlags` if you need it.
+
+Pre-v24 users are unaffected.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
+	github.com/blang/semver/v4 v4.0.0
 	github.com/google/uuid v1.6.0
 	github.com/planetscale/operator-sdk-libs v0.0.0-20220216002626-1af183733234
 	github.com/prometheus/client_golang v1.23.2
@@ -85,7 +86,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/aws/smithy-go v1.24.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect

--- a/pkg/operator/vitess/version.go
+++ b/pkg/operator/vitess/version.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitess
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var vitessTagMajorRegExp = regexp.MustCompile(`^v(\d+)\.`)
+
+// MajorVersionFromImage parses the Vitess major version from a Docker image
+// reference like "vitess/lite:v24.0.0-mysql80". Returns (major, true) when
+// the tag begins with "v<digits>." and (0, false) for unparseable tags
+// (rolling tags such as "mysql80" or "latest", digests, or empty input).
+func MajorVersionFromImage(image string) (int, bool) {
+	if image == "" {
+		return 0, false
+	}
+	// Drop digest portion if present (e.g. "repo:tag@sha256:...").
+	if at := strings.IndexByte(image, '@'); at >= 0 {
+		image = image[:at]
+	}
+	colon := strings.LastIndexByte(image, ':')
+	if colon < 0 {
+		return 0, false
+	}
+	tag := image[colon+1:]
+	m := vitessTagMajorRegExp.FindStringSubmatch(tag)
+	if m == nil {
+		return 0, false
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return major, true
+}

--- a/pkg/operator/vitess/version.go
+++ b/pkg/operator/vitess/version.go
@@ -17,16 +17,14 @@ limitations under the License.
 package vitess
 
 import (
-	"regexp"
-	"strconv"
 	"strings"
-)
 
-var vitessTagMajorRegExp = regexp.MustCompile(`^v(\d+)\.`)
+	"github.com/blang/semver/v4"
+)
 
 // MajorVersionFromImage parses the Vitess major version from a Docker image
 // reference like "vitess/lite:v24.0.0-mysql80". Returns (major, true) when
-// the tag begins with "v<digits>." and (0, false) for unparseable tags
+// the image carries a SemVer-compatible tag and (0, false) otherwise
 // (rolling tags such as "mysql80" or "latest", digests, or empty input).
 func MajorVersionFromImage(image string) (int, bool) {
 	if image == "" {
@@ -40,14 +38,9 @@ func MajorVersionFromImage(image string) (int, bool) {
 	if colon < 0 {
 		return 0, false
 	}
-	tag := image[colon+1:]
-	m := vitessTagMajorRegExp.FindStringSubmatch(tag)
-	if m == nil {
-		return 0, false
-	}
-	major, err := strconv.Atoi(m[1])
+	v, err := semver.ParseTolerant(image[colon+1:])
 	if err != nil {
 		return 0, false
 	}
-	return major, true
+	return int(v.Major), true
 }

--- a/pkg/operator/vitess/version_test.go
+++ b/pkg/operator/vitess/version_test.go
@@ -96,10 +96,16 @@ func TestMajorVersionFromImage(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "tag starts with digit but no v prefix",
+			name:   "tag without v prefix still parses as semver",
 			image:  "vitess/lite:24.0.0",
-			want:   0,
-			wantOK: false,
+			want:   24,
+			wantOK: true,
+		},
+		{
+			name:   "tag with only major still parses (tolerant)",
+			image:  "vitess/lite:v24",
+			want:   24,
+			wantOK: true,
 		},
 	}
 

--- a/pkg/operator/vitess/version_test.go
+++ b/pkg/operator/vitess/version_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMajorVersionFromImage(t *testing.T) {
+	tests := []struct {
+		name   string
+		image  string
+		want   int
+		wantOK bool
+	}{
+		{
+			name:   "clean v24 tag",
+			image:  "vitess/lite:v24.0.0",
+			want:   24,
+			wantOK: true,
+		},
+		{
+			name:   "v24 rc with mysql suffix",
+			image:  "vitess/lite:v24.0.0-rc1-mysql80",
+			want:   24,
+			wantOK: true,
+		},
+		{
+			name:   "v23 with mysql suffix",
+			image:  "vitess/lite:v23.0.5-mysql80",
+			want:   23,
+			wantOK: true,
+		},
+		{
+			name:   "large major version",
+			image:  "vitess/lite:v100.2.3",
+			want:   100,
+			wantOK: true,
+		},
+		{
+			name:   "tag and digest both present",
+			image:  "vitess/lite:v24.0.0@sha256:abc",
+			want:   24,
+			wantOK: true,
+		},
+		{
+			name:   "registry prefix with version",
+			image:  "registry.example.com/vitess/lite:v25.0.0-mysql80",
+			want:   25,
+			wantOK: true,
+		},
+		{
+			name:   "rolling mysql tag",
+			image:  "vitess/lite:mysql80",
+			want:   0,
+			wantOK: false,
+		},
+		{
+			name:   "latest tag",
+			image:  "vitess/lite:latest",
+			want:   0,
+			wantOK: false,
+		},
+		{
+			name:   "digest only",
+			image:  "vitess/lite@sha256:abc123",
+			want:   0,
+			wantOK: false,
+		},
+		{
+			name:   "no tag",
+			image:  "vitess/lite",
+			want:   0,
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			image:  "",
+			want:   0,
+			wantOK: false,
+		},
+		{
+			name:   "tag starts with digit but no v prefix",
+			image:  "vitess/lite:24.0.0",
+			want:   0,
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := MajorVersionFromImage(tc.image)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/operator/vtorc/deployment.go
+++ b/pkg/operator/vtorc/deployment.go
@@ -210,7 +210,7 @@ func UpdateDeployment(obj *appsv1.Deployment, spec *Spec) {
 }
 
 func (spec *Spec) flags() vitess.Flags {
-	return vitess.Flags{
+	flags := vitess.Flags{
 		"topo_implementation":        spec.GlobalLockserver.Implementation,
 		"topo_global_server_address": spec.GlobalLockserver.Address,
 		"topo_global_root":           spec.GlobalLockserver.RootPath,
@@ -220,4 +220,11 @@ func (spec *Spec) flags() vitess.Flags {
 
 		"logtostderr": true,
 	}
+	// --cell was introduced in Vitess v24 and is required in v25+. Only emit
+	// it when we can confirm the image is on a supported version; on rolling
+	// or unparseable tags users can still force it via ExtraFlags.
+	if major, ok := vitess.MajorVersionFromImage(spec.Image); ok && major >= 24 {
+		flags["cell"] = spec.Cell
+	}
+	return flags
 }

--- a/pkg/operator/vtorc/deployment_test.go
+++ b/pkg/operator/vtorc/deployment_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtorc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+)
+
+func newSpecForTest(image, cell string) *Spec {
+	return &Spec{
+		GlobalLockserver: planetscalev2.VitessLockserverParams{
+			Implementation: "etcd2",
+			Address:        "etcd:2379",
+			RootPath:       "/vitess/global",
+		},
+		Keyspace: "commerce",
+		Shard:    "-",
+		Cell:     cell,
+		Image:    image,
+	}
+}
+
+func TestSpecFlagsAlwaysIncludesBaseFlags(t *testing.T) {
+	spec := newSpecForTest("vitess/lite:v24.0.0-mysql80", "zone1")
+	flags := spec.flags()
+
+	for _, key := range []string{
+		"topo_implementation",
+		"topo_global_server_address",
+		"topo_global_root",
+		"port",
+		"clusters_to_watch",
+		"logtostderr",
+	} {
+		_, ok := flags[key]
+		assert.Truef(t, ok, "expected base flag %q to be present", key)
+	}
+
+	assert.Equal(t, "commerce/-", flags["clusters_to_watch"])
+}
+
+func TestSpecFlagsCellGatedByVitessVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		wantCell bool
+	}{
+		{
+			name:     "v24 emits cell",
+			image:    "vitess/lite:v24.0.0-mysql80",
+			wantCell: true,
+		},
+		{
+			name:     "v25 emits cell",
+			image:    "vitess/lite:v25.0.0-mysql80",
+			wantCell: true,
+		},
+		{
+			name:     "v24 rc emits cell",
+			image:    "vitess/lite:v24.0.0-rc1-mysql80",
+			wantCell: true,
+		},
+		{
+			name:     "v23 does not emit cell",
+			image:    "vitess/lite:v23.0.5-mysql80",
+			wantCell: false,
+		},
+		{
+			name:     "v22 does not emit cell",
+			image:    "vitess/lite:v22.0.0-mysql80",
+			wantCell: false,
+		},
+		{
+			name:     "rolling mysql tag does not emit cell",
+			image:    "vitess/lite:mysql80",
+			wantCell: false,
+		},
+		{
+			name:     "latest tag does not emit cell",
+			image:    "vitess/lite:latest",
+			wantCell: false,
+		},
+		{
+			name:     "empty image does not emit cell",
+			image:    "",
+			wantCell: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := newSpecForTest(tc.image, "zone1")
+			flags := spec.flags()
+
+			got, present := flags["cell"]
+			if tc.wantCell {
+				assert.True(t, present, "expected --cell flag to be present")
+				assert.Equal(t, "zone1", got)
+			} else {
+				assert.False(t, present, "expected --cell flag to be absent, got %v", got)
+			}
+		})
+	}
+}

--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -271,6 +271,9 @@ checkSemiSyncSetup
 checkMysqldExporterMetrics
 # Initially too durability policy should be specified
 verifyDurabilityPolicy "commerce" "semi_sync"
+# VTOrc --cell is gated on Vitess v24+ in the operator. The initial cluster
+# pins v24.0.0-rc1, so the flag must be on the vtorc pod.
+checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vtorc" 1 "--cell=zone1"
 upgradeToLatest
 verifyVtGateVersion "25.0.0"
 verifyResourceSpec


### PR DESCRIPTION
## What's this?

Resolves https://github.com/planetscale/vitess-operator/issues/786 — VTOrc's `--cell` flag is required in Vitess v25+ and the operator doesn't currently set it. After upgrading to v25 every VTOrc managed by this operator would `FAILED_PRECONDITION` at startup 😱

## Why version-gating instead of always passing it?

`--cell` was introduced in Vitess v24 _([vitessio/vitess#19047](https://github.com/vitessio/vitess/pull/19047))_ and became required in v25 _([vitessio/vitess#20048](https://github.com/vitessio/vitess/pull/20048))_. On `≤v23` the flag doesn't exist — and I verified against `upstream/release-22.0` that `vtorc` uses a plain cobra `Main` with no `FParseErrWhitelist` or `DisableFlagParsing` _(neither in `go/cmd/vtorc/cli/cli.go` nor `go/vt/servenv/`)_, so passing `--cell` to ≤v23 vtorc would CrashLoopBackOff with `unknown flag: --cell`. We need to only emit the flag when we know the binary supports it.

## How it works

1. New helper `vitess.MajorVersionFromImage(image)` parses the major version from the image tag _(handles `vitess/lite:v24.0.0-mysql80`, RC suffixes, digest-only refs, rolling tags)_
2. `vtorc.Spec.flags()` calls the helper against `spec.Image` and adds `"cell": spec.Cell` only when `ok && major >= 24`
3. `ExtraFlags` continues to override base flags _(the existing loop at `deployment.go:125-130` runs after the base map)_, so users on rolling tags or who need a custom value can still force it

`spec.Cell` is populated from `tabletPool.Cell` at `pkg/controller/vitessshard/reconcile_vtorc.go:145` — there's already one vtorc Deployment per `(cluster, keyspace, shard, cell)` tuple, so the value is always the cell that this particular vtorc is responsible for

## What's covered

| Image tag                              | Result            |
|----------------------------------------|-------------------|
| `vitess/lite:v25.0.0-mysql80`          | emits `--cell`    |
| `vitess/lite:v24.0.0-rc1-mysql80`      | emits `--cell`    |
| `vitess/lite:v23.0.5-mysql80`          | no `--cell`       |
| `vitess/lite:mysql80` _(rolling)_      | no `--cell`       |
| `vitess/lite:latest`                   | no `--cell`       |
| `vitess/lite@sha256:...` _(digest)_    | no `--cell`       |
| Empty / unparseable                    | no `--cell`       |

## Related Issue(s)

Resolves: https://github.com/planetscale/vitess-operator/issues/786

## Test plan

- [x] `go test ./pkg/operator/vitess/... ./pkg/operator/vtorc/... -count=1` _(12 cases for the version helper, 9 for the vtorc flag gate)_
- [x] `go build ./...` clean
- [x] `gofumpt -d` + `goimports -l` clean
- [ ] e2e suite isn't updated — it uses `vitess/lite:mysql80` _(rolling)_ which by design won't get `--cell`. When the e2e tag pins to a v25+ release it will start emitting automatically

## Release notes

Added a callout in `docs/release-notes/2_18_0_summary.md`

---

_Claude Code assisted with the implementation and prepared this PR summary — I provided direction and reviewed_