### PR TITLE
Allow multiple tablet pools of the same type

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8162,10 +8162,8 @@ string
 </td>
 <td>
 <p>Name is the pool&rsquo;s unique name within the (cell,type) pair.
-This field is optional, and defaults to an empty.
-Assigning different names to this field enables the existence of multiple pools with a specific tablet type in a given cell,
-which can be beneficial for unmanaged tablets.
-Hence, you must specify ExternalDatastore when assigning a name to this field.</p>
+This field is optional, and defaults to an empty string.
+Assigning different names to this field enables the existence of multiple pools with a specific tablet type in a given cell.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -8164,10 +8164,8 @@ string
 </td>
 <td>
 <p>Name is the pool&rsquo;s unique name within the (cell,type) pair.
-This field is optional, and defaults to an empty.
-Assigning different names to this field enables the existence of multiple pools with a specific tablet type in a given cell,
-which can be beneficial for unmanaged tablets.
-Hence, you must specify ExternalDatastore when assigning a name to this field.</p>
+This field is optional, and defaults to an empty string.
+Assigning different names to this field enables the existence of multiple pools with a specific tablet type in a given cell.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/planetscale/v2/labels.go
+++ b/pkg/apis/planetscale/v2/labels.go
@@ -36,7 +36,6 @@ const (
 	// TabletTypeLabel is the key for identifying the Vitess target tablet type for a Pod.
 	TabletTypeLabel = LabelPrefix + "/" + "tablet-type"
 	// TabletPoolNameLabel is the key for identifying the Vitess target pool name within the (cell,type) pair.
-	// This label is applicable to Vitess-unmanaged keyspaces.
 	TabletPoolNameLabel = LabelPrefix + "/" + "pool-name"
 	// TabletIndexLabel is the key for identifying the index of a Vitess tablet within its pool.
 	TabletIndexLabel = LabelPrefix + "/" + "tablet-index"

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -172,10 +172,8 @@ type VitessShardTabletPool struct {
 	Type VitessTabletPoolType `json:"type"`
 
 	// Name is the pool's unique name within the (cell,type) pair.
-	// This field is optional, and defaults to an empty.
-	// Assigning different names to this field enables the existence of multiple pools with a specific tablet type in a given cell,
-	// which can be beneficial for unmanaged tablets.
-	// Hence, you must specify ExternalDatastore when assigning a name to this field.
+	// This field is optional, and defaults to an empty string.
+	// Assigning different names to this field enables the existence of multiple pools with a specific tablet type in a given cell.
 	// +kubebuilder:default=""
 	Name string `json:"name,omitempty"`
 

--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -18,6 +18,7 @@ package vitessshard
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strconv"
 	"time"
@@ -35,6 +36,7 @@ import (
 
 	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
 	"planetscale.dev/vitess-operator/pkg/operator/drain"
+	"planetscale.dev/vitess-operator/pkg/operator/environment"
 	"planetscale.dev/vitess-operator/pkg/operator/k8s"
 	"planetscale.dev/vitess-operator/pkg/operator/reconciler"
 	"planetscale.dev/vitess-operator/pkg/operator/results"
@@ -80,7 +82,10 @@ func (r *ReconcileVitessShard) reconcileTablets(ctx context.Context, vts *planet
 	}()
 
 	// Compute the set of all desired tablets based on the config.
-	tablets := vttabletSpecs(vts, labels)
+	tablets, err := vttabletSpecs(vts, labels)
+	if err != nil {
+		resultBuilder.Error(err)
+	}
 
 	// Generate podKeys (object names) for all desired tablet pods and pvcKeys for desired PVCs.
 	//
@@ -111,7 +116,7 @@ func (r *ReconcileVitessShard) reconcileTablets(ctx context.Context, vts *planet
 	}
 
 	// Reconcile vttablet PVCs. Note that we use the same keys as the corresponding Pods.
-	err := r.reconciler.ReconcileObjectSet(ctx, vts, pvcKeys, labels, reconciler.Strategy{
+	err = r.reconciler.ReconcileObjectSet(ctx, vts, pvcKeys, labels, reconciler.Strategy{
 		Kind: &corev1.PersistentVolumeClaim{},
 
 		New: func(key client.ObjectKey) runtime.Object {
@@ -266,10 +271,11 @@ func (r *ReconcileVitessShard) reconcileTablets(ctx context.Context, vts *planet
 }
 
 // vttabletSpecs creates a list of vttablet Specs for a VitessShard.
-func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]string) []*vttablet.Spec {
+func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]string) ([]*vttablet.Spec, error) {
 	keyspaceName := vts.Labels[planetscalev2.KeyspaceLabel]
 
 	var tablets []*vttablet.Spec
+	seenUIDs := make(map[uint32]string)
 
 	for poolIndex := range vts.Spec.TabletPools {
 		pool := &vts.Spec.TabletPools[poolIndex]
@@ -285,9 +291,16 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 			}
 
 			// If TabletPools has multiple pools within the same (cell,type) pair, we need to add a pool name to the UID generator.
-			if pool.ExternalDatastore != nil && 0 < len(pool.Name) {
+			// The optional --default_pool_name flag treats the specified pool as unnamed for UID-generation purposes.
+			if !environment.IsDefaultPoolName(pool.Name) {
 				tabletAlias.Uid = vttablet.UIDWithPoolName(pool.Cell, keyspaceName, vts.Spec.KeyRange, pool.Type, uint32(tabletIndex), pool.Name)
 			}
+
+			// Additional guard against duplicate UIDs
+			if seenPool, seenUID := seenUIDs[tabletAlias.Uid]; seenUID {
+				return nil, fmt.Errorf("failed to generate tablet uid for cell %q: tablet uid %d was already generated for pool %q", pool.Cell, tabletAlias.Uid, seenPool)
+			}
+			seenUIDs[tabletAlias.Uid] = pool.Name
 
 			// Copy parent labels map and add tablet-specific labels.
 			labels := make(map[string]string, len(parentLabels)+4)
@@ -298,9 +311,7 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 			labels[planetscalev2.TabletUidLabel] = strconv.FormatUint(uint64(tabletAlias.Uid), 10)
 			labels[planetscalev2.TabletTypeLabel] = string(pool.Type)
 			labels[planetscalev2.TabletIndexLabel] = strconv.FormatUint(uint64(tabletIndex), 10)
-			if pool.ExternalDatastore != nil {
-				labels[planetscalev2.TabletPoolNameLabel] = pool.Name
-			}
+			labels[planetscalev2.TabletPoolNameLabel] = pool.Name
 
 			// Merge ExtraVitessFlags into the tablet spec ExtraFlags field.
 			extraFlags := make(map[string]string)
@@ -354,7 +365,7 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 		}
 	}
 
-	return tablets
+	return tablets, nil
 }
 
 func isTabletPrimary(ctx context.Context, vts *planetscalev2.VitessShard, tabletAlias topodatapb.TabletAlias) (bool, error) {

--- a/pkg/controller/vitessshard/reconcile_tablets_test.go
+++ b/pkg/controller/vitessshard/reconcile_tablets_test.go
@@ -1,0 +1,346 @@
+/*
+Copyright 2019 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitessshard
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+	"planetscale.dev/vitess-operator/pkg/operator/environment"
+	"planetscale.dev/vitess-operator/pkg/operator/vttablet"
+)
+
+func newVitessShard(keyspace string, keyRange planetscalev2.VitessKeyRange, pools []planetscalev2.VitessShardTabletPool) *planetscalev2.VitessShard {
+	return &planetscalev2.VitessShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				planetscalev2.KeyspaceLabel: keyspace,
+			},
+		},
+		Spec: planetscalev2.VitessShardSpec{
+			KeyRange: keyRange,
+			VitessShardTemplate: planetscalev2.VitessShardTemplate{
+				TabletPools: pools,
+			},
+		},
+	}
+}
+
+// tabletsForPool returns the tablet specs belonging to the named pool, using
+// the pool-name label that vttabletSpecs stamps on every tablet.
+func tabletsForPool(tablets []*vttablet.Spec, poolName string) []*vttablet.Spec {
+	var out []*vttablet.Spec
+	for _, tablet := range tablets {
+		if tablet.Labels[planetscalev2.TabletPoolNameLabel] == poolName {
+			out = append(out, tablet)
+		}
+	}
+	return out
+}
+
+func TestDefaultPoolNamePreservesUID(t *testing.T) {
+	cell := "zone1"
+	keyspace := "commerce"
+	keyRange := planetscalev2.VitessKeyRange{Start: "", End: ""}
+	tabletType := planetscalev2.ReplicaPoolType
+
+	shard := newVitessShard(keyspace, keyRange, []planetscalev2.VitessShardTabletPool{
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "",
+			Replicas: 2,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+	})
+
+	tablets, err := vttabletSpecs(shard, map[string]string{})
+	if err != nil {
+		t.Fatalf("vttabletSpecs returned unexpected error: %v", err)
+	}
+
+	if len(tablets) != 2 {
+		t.Fatalf("expected 1 tablet, got %d", len(tablets))
+	}
+
+	for i, tabletIdx := range []uint32{1, 2} {
+		expectedUID := vttablet.UID(cell, keyspace, keyRange, tabletType, tabletIdx)
+		namedUID := vttablet.UIDWithPoolName(cell, keyspace, keyRange, tabletType, tabletIdx, "")
+
+		if expectedUID == namedUID {
+			t.Fatal("expected UID() and UIDWithPoolName() to produce different values")
+		}
+
+		if tablets[i].Alias.Uid != expectedUID {
+			t.Errorf("got %d, want %d", tablets[i].Alias.Uid, expectedUID)
+		}
+	}
+}
+
+func TestOverriddenDefaultPoolNamePreservesUID(t *testing.T) {
+	cell := "zone1"
+	keyspace := "commerce"
+	keyRange := planetscalev2.VitessKeyRange{Start: "", End: ""}
+	tabletType := planetscalev2.ReplicaPoolType
+
+	environment.SetDefaultPoolName("default")
+	defer environment.SetDefaultPoolName("")
+
+	shard := newVitessShard(keyspace, keyRange, []planetscalev2.VitessShardTabletPool{
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "default",
+			Replicas: 2,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+	})
+
+	tablets, err := vttabletSpecs(shard, map[string]string{})
+	if err != nil {
+		t.Fatalf("vttabletSpecs returned unexpected error: %v", err)
+	}
+
+	if len(tablets) != 2 {
+		t.Fatalf("expected 1 tablet, got %d", len(tablets))
+	}
+
+	for i, tabletIdx := range []uint32{1, 2} {
+		expectedUID := vttablet.UID(cell, keyspace, keyRange, tabletType, tabletIdx)
+		namedUID := vttablet.UIDWithPoolName(cell, keyspace, keyRange, tabletType, tabletIdx, "default")
+
+		if expectedUID == namedUID {
+			t.Fatal("expected UID() and UIDWithPoolName() to produce different values")
+		}
+
+		if tablets[i].Alias.Uid != expectedUID {
+			t.Fatalf("default pool name should produce same UID as unnamed pool: got %d, want %d", tablets[i].Alias.Uid, expectedUID)
+		}
+	}
+}
+
+func TestNonDefaultPoolNameGetsUniqueUID(t *testing.T) {
+	cell := "zone1"
+	keyspace := "commerce"
+	keyRange := planetscalev2.VitessKeyRange{Start: "", End: ""}
+	tabletType := planetscalev2.ReplicaPoolType
+
+	unnamedUID := vttablet.UID(cell, keyspace, keyRange, tabletType, 1)
+	namedUID := vttablet.UIDWithPoolName(cell, keyspace, keyRange, tabletType, 1, "fast-storage")
+
+	environment.SetDefaultPoolName("default")
+	defer environment.SetDefaultPoolName("")
+
+	shard := newVitessShard(keyspace, keyRange, []planetscalev2.VitessShardTabletPool{
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "fast-storage",
+			Replicas: 1,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+	})
+
+	tablets, err := vttabletSpecs(shard, map[string]string{})
+	if err != nil {
+		t.Fatalf("vttabletSpecs returned unexpected error: %v", err)
+	}
+
+	if len(tablets) != 1 {
+		t.Fatalf("expected 1 tablet, got %d", len(tablets))
+	}
+
+	if tablets[0].Alias.Uid == unnamedUID {
+		t.Error("non-default pool name should not produce the same UID as an unnamed pool")
+	}
+	if tablets[0].Alias.Uid != namedUID {
+		t.Errorf("non-default pool name should use UIDWithPoolName: got %d, want %d", tablets[0].Alias.Uid, namedUID)
+	}
+}
+
+func TestMultiplePoolsSameCellType(t *testing.T) {
+	cell := "zone1"
+	keyspace := "commerce"
+	keyRange := planetscalev2.VitessKeyRange{Start: "", End: ""}
+	tabletType := planetscalev2.ReplicaPoolType
+
+	environment.SetDefaultPoolName("default")
+	defer environment.SetDefaultPoolName("")
+
+	shard := newVitessShard(keyspace, keyRange, []planetscalev2.VitessShardTabletPool{
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "default",
+			Replicas: 2,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "fast-storage",
+			Replicas: 2,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+	})
+
+	tablets, err := vttabletSpecs(shard, map[string]string{})
+	if err != nil {
+		t.Fatalf("vttabletSpecs returned unexpected error: %v", err)
+	}
+
+	if len(tablets) != 4 {
+		t.Fatalf("expected 4 tablets, got %d", len(tablets))
+	}
+
+	defaultTablets := tabletsForPool(tablets, "default")
+	if len(defaultTablets) != 2 {
+		t.Fatalf("expected 2 tablets in default pool, got %d", len(defaultTablets))
+	}
+
+	for _, tablet := range defaultTablets {
+		expectedUID := vttablet.UID(cell, keyspace, keyRange, tabletType, uint32(tablet.Index))
+		if tablet.Alias.Uid != expectedUID {
+			t.Errorf("default pool tablet %d: got UID %d, want %d (same as unnamed)", tablet.Index, tablet.Alias.Uid, expectedUID)
+		}
+	}
+
+	// Verify "fast-storage" pool tablets use UIDWithPoolName()
+	fastTablets := tabletsForPool(tablets, "fast-storage")
+	if len(fastTablets) != 2 {
+		t.Fatalf("expected 2 tablets in fast-storage pool, got %d", len(fastTablets))
+	}
+
+	for _, tablet := range fastTablets {
+		expectedUID := vttablet.UIDWithPoolName(cell, keyspace, keyRange, tabletType, uint32(tablet.Index), "fast-storage")
+		if tablet.Alias.Uid != expectedUID {
+			t.Errorf("fast-storage pool tablet %d: got UID %d, want %d", tablet.Index, tablet.Alias.Uid, expectedUID)
+		}
+	}
+}
+
+func TestMultipleDefaultPoolsReturnsError(t *testing.T) {
+	cell := "zone1"
+	keyspace := "commerce"
+	keyRange := planetscalev2.VitessKeyRange{Start: "", End: ""}
+	tabletType := planetscalev2.ReplicaPoolType
+
+	environment.SetDefaultPoolName("default")
+	defer environment.SetDefaultPoolName("")
+
+	shard := newVitessShard(keyspace, keyRange, []planetscalev2.VitessShardTabletPool{
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "default",
+			Replicas: 1,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "default",
+			Replicas: 1,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+	})
+
+	if _, err := vttabletSpecs(shard, map[string]string{}); err == nil {
+		t.Fatal("expected an error for multiple default pools, got nil")
+	}
+}
+
+func TestDuplicatePoolNameReturnsError(t *testing.T) {
+	cell := "zone1"
+	keyspace := "commerce"
+	keyRange := planetscalev2.VitessKeyRange{Start: "", End: ""}
+	tabletType := planetscalev2.ReplicaPoolType
+
+	environment.SetDefaultPoolName("default")
+	defer environment.SetDefaultPoolName("")
+
+	shard := newVitessShard(keyspace, keyRange, []planetscalev2.VitessShardTabletPool{
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "fast-storage",
+			Replicas: 1,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "fast-storage",
+			Replicas: 1,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+	})
+
+	if _, err := vttabletSpecs(shard, map[string]string{}); err == nil {
+		t.Fatal("expected an error for duplicate pool names, got nil")
+	}
+}
+
+func TestPoolNameLabelAlwaysSet(t *testing.T) {
+	cell := "zone1"
+	keyspace := "commerce"
+	keyRange := planetscalev2.VitessKeyRange{Start: "", End: ""}
+	tabletType := planetscalev2.ReplicaPoolType
+
+	environment.SetDefaultPoolName("default")
+	defer environment.SetDefaultPoolName("")
+
+	shard := newVitessShard(keyspace, keyRange, []planetscalev2.VitessShardTabletPool{
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "default",
+			Replicas: 2,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+		{
+			Cell:     cell,
+			Type:     tabletType,
+			Name:     "fast-storage",
+			Replicas: 2,
+			Vttablet: planetscalev2.VttabletSpec{},
+		},
+	})
+
+	tablets, err := vttabletSpecs(shard, map[string]string{})
+	if err != nil {
+		t.Fatalf("vttabletSpecs returned unexpected error: %v", err)
+	}
+
+	if len(tablets) != 4 {
+		t.Fatalf("expected 4 tablets, got %d", len(tablets))
+	}
+
+	for _, i := range []int{0, 1} {
+		if got := tablets[i].Labels[planetscalev2.TabletPoolNameLabel]; got != "default" {
+			t.Errorf("expected pool-name label to be %q, got %q", "default", got)
+		}
+	}
+
+	for _, i := range []int{2, 3} {
+		if got := tablets[i].Labels[planetscalev2.TabletPoolNameLabel]; got != "fast-storage" {
+			t.Errorf("expected pool-name label to be %q, got %q", "fast-storage", got)
+		}
+	}
+}

--- a/pkg/operator/environment/environment.go
+++ b/pkg/operator/environment/environment.go
@@ -33,6 +33,7 @@ import (
 var (
 	reconcileTimeout   time.Duration
 	MySQLServerVersion = "8.0.40-Vitess"
+	defaultPoolName    string
 	// truncateUILen truncate queries in debug UIs to the given length. 0 means unlimited.
 	truncateUILen = 512
 	// truncateErrLen truncate queries in error logs to the given length. 0 means unlimited.
@@ -44,6 +45,7 @@ func FlagSet() *pflag.FlagSet {
 	operatorFlagSet := pflag.NewFlagSet("operator", pflag.ExitOnError)
 
 	operatorFlagSet.DurationVar(&reconcileTimeout, "reconcile_timeout", 10*time.Minute, "Maximum time that any controller will spend trying to reconcile a single object before giving up.")
+	operatorFlagSet.StringVar(&defaultPoolName, "default_pool_name", "", "Pool name to treat as unnamed (equivalent to \"\") for UID generation. Use this when migrating a named pool that previously had no name-aware UID generation.")
 
 	operatorFlagSet.StringVar(&planetscalev2.DefaultVitessPriorityClass, "default_vitess_priority_class", planetscalev2.DefaultVitessPriorityClass, "Default PriorityClass to use for Pods that run Vitess components. An empty value means don't use any PriorityClass.")
 	operatorFlagSet.StringVar(&planetscalev2.DefaultVitessServiceAccount, "default_vitess_service_account", planetscalev2.DefaultVitessServiceAccount, "Default ServiceAccount to use for Pods that run Vitess components. An empty value means let Kubernetes fill in a default.")
@@ -63,6 +65,17 @@ func FlagSet() *pflag.FlagSet {
 // ReconcileTimeout returns the global maximum reconcile timeout for all controllers.
 func ReconcileTimeout() time.Duration {
 	return reconcileTimeout
+}
+
+// IsDefaultPoolName returns true if the given pool name should be treated as unnamed
+// for UID generation, preserving backward compatibility with existing tablet UIDs.
+func IsDefaultPoolName(name string) bool {
+	return name == defaultPoolName
+}
+
+// SetDefaultPoolName sets the default pool name. Intended for use in tests.
+func SetDefaultPoolName(name string) {
+	defaultPoolName = name
 }
 
 // VtEnvironment gets the vitess environment to be used in the operator.

--- a/pkg/operator/vttablet/spec.go
+++ b/pkg/operator/vttablet/spec.go
@@ -85,6 +85,7 @@ func (spec *Spec) poolLabels() map[string]string {
 	labels := spec.shardLabels()
 	labels[planetscalev2.CellLabel] = spec.Labels[planetscalev2.CellLabel]
 	labels[planetscalev2.TabletTypeLabel] = spec.Labels[planetscalev2.TabletTypeLabel]
+	labels[planetscalev2.TabletPoolNameLabel] = spec.Labels[planetscalev2.TabletPoolNameLabel]
 	return labels
 }
 


### PR DESCRIPTION
Removes the external data store requirement for multiple tabletpools.

Also adds `--default_pool_names` flag which can optionally be supplied to keep backwards compatible behaviour for the specified pools.