### PR TITLE
deploy: pin operator resources to an explicit namespace

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vitess-operator
+  namespace: default
 spec:
   replicas: 1
   selector:

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vitess-operator
+  namespace: default
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -8011,6 +8011,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vitess-operator
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -8168,6 +8169,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vitess-operator
+  namespace: default
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## Description

The operator `Deployment` and one of the `ServiceAccount`s in `deploy/` (and in `test/endtoend/operator/operator-latest.yaml`) carry no explicit namespace, while the `ClusterRoleBinding` subject is pinned to `namespace: default`.

As a result the manifests only work when kubectl's current namespace happens to be `default`. With any other current namespace — a shared cluster with a team-scoped kubeconfig, or an explicit `kubectl apply -n` — the operator starts in a namespace the ClusterRoleBinding does not cover and crash-loops with:

```
Failed to get Pod ... is forbidden:
User "system:serviceaccount:<ns>:vitess-operator" cannot get resource "pods"
in API group "" in the namespace "<ns>"
```

(Observed with v2.17.0 while setting up a PoC; everything else in the same manifests is already namespace-explicit — the backup-storage RBAC and the second ServiceAccount pin `example`, the ClusterRoleBinding subject pins `default` — so these were the only two resources left floating with the kubectl context.)

This PR pins the remaining resources to `namespace: default`, matching the ClusterRoleBinding subject and the `WATCH_NAMESPACE="default,example"` layout, so the manifests are invariant to the current kubectl context. Users who deliberately install the operator elsewhere already have to edit the ClusterRoleBinding subject and `WATCH_NAMESPACE`; with this change the coupling is at least visible in one grep.

Note: `examples/operator/operator.yaml` in vitessio/vitess carries the same pattern — happy to follow up there once the direction is agreed.
