### PR TITLE
Add volumeSnapshot backup method to VitessBackupSchedule

### DIFF
--- a/deploy/crds/planetscale.com_vitessbackupschedules.yaml
+++ b/deploy/crds/planetscale.com_vitessbackupschedules.yaml
@@ -40,6 +40,7 @@ spec:
                 enum:
                 - vtbackup
                 - vtctldclient
+                - volumeSnapshot
                 type: string
               cluster:
                 type: string
@@ -131,6 +132,8 @@ spec:
                       type: string
                     shard:
                       example: '-'
+                      type: string
+                    volumeSnapshotClassName:
                       type: string
                   required:
                   - name

--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -172,6 +172,7 @@ spec:
                           enum:
                           - vtbackup
                           - vtctldclient
+                          - volumeSnapshot
                           type: string
                         concurrencyPolicy:
                           default: Forbid
@@ -257,6 +258,8 @@ spec:
                                 type: string
                               shard:
                                 example: '-'
+                                type: string
+                              volumeSnapshotClassName:
                                 type: string
                             required:
                             - name

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -101,6 +101,16 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers

--- a/docs/api.md
+++ b/docs/api.md
@@ -2778,7 +2778,8 @@ This is populated for both cron-based and frequency-based schedules.</p>
 <p>
 <p>VitessBackupScheduleStrategy defines how we are going to take a backup.
 The VitessBackupSchedule controller uses this data to build either a vtbackup
-pod or a vtctldclient command, depending on the configured BackupMethod.</p>
+pod, a vtctldclient command, or a VolumeSnapshot, depending on the configured
+BackupMethod.</p>
 </p>
 <table class="table table-striped">
 <thead class="thead-dark">
@@ -2851,6 +2852,20 @@ map[string]string
 <em>(Optional)</em>
 <p>ExtraFlags is a map of additional flags passed to vtctldclient&rsquo;s BackupShard command.
 This field is only used when backupMethod is &ldquo;vtctldclient&rdquo;; it is ignored for &ldquo;vtbackup&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeSnapshotClassName</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VolumeSnapshotClassName is the name of the VolumeSnapshotClass to use when
+taking snapshots. If empty, the cluster&rsquo;s default snapshot class is used.
+This field is only used when backupMethod is &ldquo;volumeSnapshot&rdquo;.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -2780,7 +2780,8 @@ This is populated for both cron-based and frequency-based schedules.</p>
 <p>
 <p>VitessBackupScheduleStrategy defines how we are going to take a backup.
 The VitessBackupSchedule controller uses this data to build either a vtbackup
-pod or a vtctldclient command, depending on the configured BackupMethod.</p>
+pod, a vtctldclient command, or a VolumeSnapshot, depending on the configured
+BackupMethod.</p>
 </p>
 <table class="table table-striped">
 <thead class="thead-dark">
@@ -2853,6 +2854,20 @@ map[string]string
 <em>(Optional)</em>
 <p>ExtraFlags is a map of additional flags passed to vtctldclient&rsquo;s BackupShard command.
 This field is only used when backupMethod is &ldquo;vtctldclient&rdquo;; it is ignored for &ldquo;vtbackup&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeSnapshotClassName</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VolumeSnapshotClassName is the name of the VolumeSnapshotClass to use when
+taking snapshots. If empty, the cluster&rsquo;s default snapshot class is used.
+This field is only used when backupMethod is &ldquo;volumeSnapshot&rdquo;.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
@@ -37,7 +37,7 @@ const (
 )
 
 // BackupMethod defines the method used to take scheduled backups.
-// +kubebuilder:validation:Enum=vtbackup;vtctldclient
+// +kubebuilder:validation:Enum=vtbackup;vtctldclient;volumeSnapshot
 type BackupMethod string
 
 const (
@@ -50,6 +50,18 @@ const (
 	// Kubernetes Job sends a BackupShard command to vtctld, which tells a running
 	// serving replica to take the backup. No PVC is needed.
 	BackupMethodVtctldclient BackupMethod = "vtctldclient"
+
+	// BackupMethodVolumeSnapshot takes a CSI VolumeSnapshot of the data volume
+	// of one non-primary tablet in the target shard. No Kubernetes Job is
+	// created: the controller creates the VolumeSnapshot object directly at the
+	// scheduled time. The resulting snapshot is crash-consistent, not
+	// application-consistent: restoring it relies on InnoDB crash recovery,
+	// which is only safe when the target tablet runs with durable settings
+	// (sync_binlog=1 and innodb_flush_log_at_trx_commit=1, the Vitess defaults)
+	// and all MySQL data (datadir, redo logs, binlogs) lives on a single volume.
+	// Snapshots taken this way do not appear in Vitess BackupStorage and are not
+	// visible to "vtctldclient GetBackups".
+	BackupMethodVolumeSnapshot BackupMethod = "volumeSnapshot"
 )
 
 // ConcurrencyPolicy describes how the concurrency of new jobs created by VitessBackupSchedule
@@ -230,7 +242,8 @@ type VitessBackupScheduleTemplate struct {
 
 // VitessBackupScheduleStrategy defines how we are going to take a backup.
 // The VitessBackupSchedule controller uses this data to build either a vtbackup
-// pod or a vtctldclient command, depending on the configured BackupMethod.
+// pod, a vtctldclient command, or a VolumeSnapshot, depending on the configured
+// BackupMethod.
 type VitessBackupScheduleStrategy struct {
 	// Name of the backup strategy.
 	Name string `json:"name"`
@@ -256,6 +269,12 @@ type VitessBackupScheduleStrategy struct {
 	// This field is only used when backupMethod is "vtctldclient"; it is ignored for "vtbackup".
 	// +optional
 	ExtraFlags map[string]string `json:"extraFlags,omitempty"`
+
+	// VolumeSnapshotClassName is the name of the VolumeSnapshotClass to use when
+	// taking snapshots. If empty, the cluster's default snapshot class is used.
+	// This field is only used when backupMethod is "volumeSnapshot".
+	// +optional
+	VolumeSnapshotClassName string `json:"volumeSnapshotClassName,omitempty"`
 }
 
 // VitessBackupScheduleStatus defines the observed state of VitessBackupSchedule

--- a/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
+++ b/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
@@ -310,16 +310,42 @@ func (r *ReconcileVitessBackupsSchedule) reconcileStrategy(
 		Start: start,
 		End:   end,
 	}
-	jobs, mostRecentTime, err := r.getJobsList(ctx, req, vbsc, strategy.Keyspace, vkr.SafeName())
-	if err != nil {
-		// We had an error reading the jobs, we can requeue.
-		return resultBuilder.Error(err)
+	method := vbsc.Spec.BackupMethod
+	if method == "" {
+		method = planetscalev2.BackupMethodVtbackup
 	}
+	// List the objects created by previous runs of this strategy. The volumeSnapshot
+	// method creates VolumeSnapshot objects directly instead of Jobs, so history and
+	// concurrency accounting is done on those objects.
+	var (
+		jobs           jobsList
+		snaps          snapshotsList
+		mostRecentTime *time.Time
+		activeCount    int
+	)
+	if method == planetscalev2.BackupMethodVolumeSnapshot {
+		var err error
+		snaps, mostRecentTime, err = r.getSnapshotsList(ctx, req, vbsc, strategy.Keyspace, vkr.SafeName())
+		if err != nil {
+			// We had an error reading the snapshots, we can requeue.
+			return resultBuilder.Error(err)
+		}
+		activeCount = len(snaps.pending)
+	} else {
+		var err error
+		jobs, mostRecentTime, err = r.getJobsList(ctx, req, vbsc, strategy.Keyspace, vkr.SafeName())
+		if err != nil {
+			// We had an error reading the jobs, we can requeue.
+			return resultBuilder.Error(err)
+		}
+		activeCount = len(jobs.active)
+	}
+
 	lastScheduledTime := vbsc.Status.LastScheduledTimes[strategy.Name]
 	repairedLastScheduledTime := false
 	if mostRecentTime != nil && (lastScheduledTime == nil || lastScheduledTime.Time.Before(*mostRecentTime)) {
-		// Repair status from the Job annotation if Job creation succeeded but the
-		// status update did not.
+		// Repair status from the scheduled object's annotation if creation succeeded
+		// but the status update did not.
 		lastScheduledTime = &metav1.Time{Time: *mostRecentTime}
 		vbsc.Status.LastScheduledTimes[strategy.Name] = lastScheduledTime
 		repairedLastScheduledTime = true
@@ -331,19 +357,25 @@ func (r *ReconcileVitessBackupsSchedule) reconcileStrategy(
 		mostRecentTime = &statusTime
 	}
 
-	// We must clean up old jobs to not overcrowd the number of Pods and Jobs in the cluster.
+	// We must clean up old runs to not overcrowd the number of Pods and Jobs in the cluster.
 	// This will be done according to both failedJobsHistoryLimit and successfulJobsHistoryLimit fields.
-	// Keep the Jobs for one more reconcile when an annotation repaired the status, so a
+	// Keep them for one more reconcile when an annotation repaired the status, so a
 	// conflicting status update cannot remove the only durable record of the scheduled run.
 	if !repairedLastScheduledTime {
-		r.cleanupJobsWithLimit(ctx, jobs.failed, vbsc.GetFailedJobsLimit())
-		r.cleanupJobsWithLimit(ctx, jobs.successful, vbsc.GetSuccessfulJobsLimit())
+		if method == planetscalev2.BackupMethodVolumeSnapshot {
+			r.cleanupSnapshotsWithLimit(ctx, snaps.failed, vbsc.GetFailedJobsLimit())
+			r.cleanupSnapshotsWithLimit(ctx, snaps.ready, vbsc.GetSuccessfulJobsLimit())
+		} else {
+			r.cleanupJobsWithLimit(ctx, jobs.failed, vbsc.GetFailedJobsLimit())
+			r.cleanupJobsWithLimit(ctx, jobs.successful, vbsc.GetSuccessfulJobsLimit())
+		}
 	}
 
-	err = r.removeTimeoutJobs(ctx, jobs.active, vbsc.Name, vbsc.Spec.JobTimeoutMinutes, now)
-	if err != nil {
-		// We had an error while removing timed out jobs, we can requeue
-		return resultBuilder.Error(err)
+	if method != planetscalev2.BackupMethodVolumeSnapshot {
+		if err := r.removeTimeoutJobs(ctx, jobs.active, vbsc.Name, vbsc.Spec.JobTimeoutMinutes, now); err != nil {
+			// We had an error while removing timed out jobs, we can requeue
+			return resultBuilder.Error(err)
+		}
 	}
 
 	// Determine the effective cron schedule string.
@@ -392,9 +424,32 @@ func (r *ReconcileVitessBackupsSchedule) reconcileStrategy(
 		return resultBuilder.Result()
 	}
 
-	// Check concurrency policy and skip this job if we have ForbidConcurrent set plus an active job
-	if vbsc.Spec.ConcurrencyPolicy == planetscalev2.ForbidConcurrent && len(jobs.active) > 0 {
-		log.Infof("concurrency policy blocks concurrent runs: skipping, number of active jobs: %d", len(jobs.active))
+	// Check concurrency policy and skip this run if we have ForbidConcurrent set plus an active run
+	if vbsc.Spec.ConcurrencyPolicy == planetscalev2.ForbidConcurrent && activeCount > 0 {
+		log.Infof("concurrency policy blocks concurrent runs: skipping, number of active runs: %d", activeCount)
+		vbsc.Status.NextScheduledTimes[strategy.Name] = &metav1.Time{Time: nextRun}
+		return resultBuilder.Result()
+	}
+
+	if method == planetscalev2.BackupMethodVolumeSnapshot {
+		meta, _ := scheduledObjectMeta(vbsc, strategy, missedRun, vkr, method)
+		snap, err := r.createVolumeSnapshot(ctx, vbsc, strategy, meta)
+		if err != nil {
+			// Target selection can fail transiently (e.g. no non-primary tablet
+			// available right now); skip this run and try again at the next one.
+			log.WithError(err).Info("skipping scheduled volume snapshot")
+			vbsc.Status.NextScheduledTimes[strategy.Name] = &metav1.Time{Time: nextRun}
+			return resultBuilder.Result()
+		}
+		if err = r.client.Create(ctx, snap); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				log.Infof("VolumeSnapshot %s already exists, will retry in %s", snap.GetName(), requeueAfter.String())
+				return resultBuilder.Result()
+			}
+			return resultBuilder.Error(err)
+		}
+		log.Infof("created new VolumeSnapshot: %s, next run scheduled in %s", snap.GetName(), requeueAfter.String())
+		vbsc.Status.LastScheduledTimes[strategy.Name] = &metav1.Time{Time: missedRun}
 		vbsc.Status.NextScheduledTimes[strategy.Name] = &metav1.Time{Time: nextRun}
 		return resultBuilder.Result()
 	}
@@ -647,6 +702,27 @@ func (r *ReconcileVitessBackupsSchedule) createJob(
 		method = planetscalev2.BackupMethodVtbackup
 	}
 
+	meta, labels := scheduledObjectMeta(vbsc, strategy, scheduledTime, vkr, method)
+
+	switch method {
+	case planetscalev2.BackupMethodVtctldclient:
+		return r.createVtctldclientJob(ctx, vbsc, strategy, meta)
+	default:
+		return r.createVtbackupJob(ctx, vbsc, strategy, meta.Name, meta, vkr, labels)
+	}
+}
+
+// scheduledObjectMeta builds the ObjectMeta shared by all objects created for
+// one scheduled run of a strategy (Jobs or VolumeSnapshots). It also returns
+// the base labels (without the schedule's own labels merged in) for callers
+// that need to propagate them to child objects.
+func scheduledObjectMeta(
+	vbsc planetscalev2.VitessBackupSchedule,
+	strategy planetscalev2.VitessBackupScheduleStrategy,
+	scheduledTime time.Time,
+	vkr planetscalev2.VitessKeyRange,
+	method planetscalev2.BackupMethod,
+) (metav1.ObjectMeta, map[string]string) {
 	name := names.JoinWithConstraints(names.ServiceConstraints, vbsc.Name, strategy.Keyspace, vkr.SafeName(), strconv.Itoa(int(scheduledTime.Unix())))
 
 	labels := map[string]string{
@@ -671,12 +747,7 @@ func (r *ReconcileVitessBackupsSchedule) createJob(
 	maps.Copy(meta.Labels, vbsc.Labels)
 	maps.Copy(meta.Labels, labels)
 
-	switch method {
-	case planetscalev2.BackupMethodVtctldclient:
-		return r.createVtctldclientJob(ctx, vbsc, strategy, meta)
-	default:
-		return r.createVtbackupJob(ctx, vbsc, strategy, name, meta, vkr, labels)
-	}
+	return meta, labels
 }
 
 func (r *ReconcileVitessBackupsSchedule) createVtbackupJob(

--- a/pkg/controller/vitessbackupschedule/volumesnapshot_backup.go
+++ b/pkg/controller/vitessbackupschedule/volumesnapshot_backup.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitessbackupschedule
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"vitess.io/vitess/go/vt/topo/topoproto"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+	"planetscale.dev/vitess-operator/pkg/operator/vttablet"
+)
+
+var (
+	volumeSnapshotGVK = schema.GroupVersionKind{
+		Group:   "snapshot.storage.k8s.io",
+		Version: "v1",
+		Kind:    "VolumeSnapshot",
+	}
+	volumeSnapshotListGVK = schema.GroupVersionKind{
+		Group:   "snapshot.storage.k8s.io",
+		Version: "v1",
+		Kind:    "VolumeSnapshotList",
+	}
+)
+
+// snapshotsList classifies the VolumeSnapshots owned by a schedule for one
+// shard, mirroring jobsList for the Job-based methods.
+type snapshotsList struct {
+	// ready snapshots have status.readyToUse == true.
+	ready []*unstructured.Unstructured
+	// failed snapshots carry a status.error and are not ready.
+	failed []*unstructured.Unstructured
+	// pending snapshots have no terminal status yet.
+	pending []*unstructured.Unstructured
+}
+
+// getSnapshotsList lists the VolumeSnapshots previously created by this
+// schedule for the given keyspace/shard and computes the most recent scheduled
+// time, mirroring getJobsList.
+func (r *ReconcileVitessBackupsSchedule) getSnapshotsList(
+	ctx context.Context,
+	req ctrl.Request,
+	vbsc planetscalev2.VitessBackupSchedule,
+	keyspace string,
+	shardSafeName string,
+) (snapshotsList, *time.Time, error) {
+	existing := &unstructured.UnstructuredList{}
+	existing.SetGroupVersionKind(volumeSnapshotListGVK)
+
+	err := r.client.List(ctx, existing, client.InNamespace(req.Namespace), client.MatchingLabels{
+		planetscalev2.BackupScheduleLabel: vbsc.Name,
+		planetscalev2.ClusterLabel:        vbsc.Spec.Cluster,
+		planetscalev2.KeyspaceLabel:       keyspace,
+		planetscalev2.ShardLabel:          shardSafeName,
+	})
+	if err != nil && !apierrors.IsNotFound(err) {
+		log.WithError(err).Error("unable to list VolumeSnapshots in cluster")
+		return snapshotsList{}, nil, err
+	}
+
+	var snaps snapshotsList
+	var mostRecentTime *time.Time
+
+	for i := range existing.Items {
+		snap := &existing.Items[i]
+		switch {
+		case snapshotReady(snap):
+			snaps.ready = append(snaps.ready, snap)
+		case snapshotHasError(snap):
+			snaps.failed = append(snaps.failed, snap)
+		default:
+			snaps.pending = append(snaps.pending, snap)
+		}
+
+		timeRaw := snap.GetAnnotations()[scheduledTimeAnnotation]
+		if timeRaw == "" {
+			continue
+		}
+		scheduledTime, err := time.Parse(time.RFC3339, timeRaw)
+		if err != nil {
+			log.WithError(err).Errorf("unable to parse schedule time for existing VolumeSnapshot, found: %s", timeRaw)
+			continue
+		}
+		if mostRecentTime == nil || mostRecentTime.Before(scheduledTime) {
+			mostRecentTime = &scheduledTime
+		}
+	}
+	return snaps, mostRecentTime, nil
+}
+
+func snapshotReady(snap *unstructured.Unstructured) bool {
+	ready, found, err := unstructured.NestedBool(snap.Object, "status", "readyToUse")
+	return err == nil && found && ready
+}
+
+func snapshotHasError(snap *unstructured.Unstructured) bool {
+	_, found, err := unstructured.NestedMap(snap.Object, "status", "error")
+	return err == nil && found
+}
+
+// cleanupSnapshotsWithLimit removes VolumeSnapshots ordered from oldest to
+// newest, keeping at most "limit" snapshots, mirroring cleanupJobsWithLimit.
+func (r *ReconcileVitessBackupsSchedule) cleanupSnapshotsWithLimit(ctx context.Context, snaps []*unstructured.Unstructured, limit int32) {
+	if limit == -1 {
+		return
+	}
+
+	sort.SliceStable(snaps, func(i, j int) bool {
+		ti := snaps[i].GetCreationTimestamp()
+		tj := snaps[j].GetCreationTimestamp()
+		return ti.Before(&tj)
+	})
+
+	for i, snap := range snaps {
+		if int32(i) >= int32(len(snaps))-limit {
+			break
+		}
+		if err := r.client.Delete(ctx, snap, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			log.WithError(err).Errorf("unable to delete old VolumeSnapshot: %s", snap.GetName())
+		} else {
+			log.Infof("deleted old VolumeSnapshot: %s", snap.GetName())
+		}
+	}
+}
+
+// chooseSnapshotTarget picks the tablet whose data volume should be
+// snapshotted. It prefers rdonly tablets over replicas, never picks the
+// primary, and requires the tablet's data volume to be bound. Candidates are
+// sorted so the choice is deterministic across reconciles.
+func chooseSnapshotTarget(shard *planetscalev2.VitessShard) (string, error) {
+	for _, want := range []string{"rdonly", "replica"} {
+		var candidates []string
+		for alias, tablet := range shard.Status.Tablets {
+			if tablet.Type != want {
+				continue
+			}
+			if tablet.DataVolumeBound != corev1.ConditionTrue {
+				continue
+			}
+			candidates = append(candidates, alias)
+		}
+		if len(candidates) > 0 {
+			sort.Strings(candidates)
+			return candidates[0], nil
+		}
+	}
+	return "", fmt.Errorf("no non-primary tablet with a bound data volume found in shard %s", shard.Name)
+}
+
+// createVolumeSnapshot builds a VolumeSnapshot object for the data volume of
+// one non-primary tablet in the strategy's shard. The object is built as
+// unstructured so the operator does not need to link the external-snapshotter
+// client; the snapshot.storage.k8s.io/v1 CRDs must be installed in the cluster.
+func (r *ReconcileVitessBackupsSchedule) createVolumeSnapshot(
+	ctx context.Context,
+	vbsc planetscalev2.VitessBackupSchedule,
+	strategy planetscalev2.VitessBackupScheduleStrategy,
+	meta metav1.ObjectMeta,
+) (*unstructured.Unstructured, error) {
+	shard, err := r.getShardFromKeyspace(ctx, vbsc.Namespace, vbsc.Spec.Cluster, strategy.Keyspace, strategy.Shard)
+	if err != nil {
+		return nil, err
+	}
+	targetAlias, err := chooseSnapshotTarget(&shard)
+	if err != nil {
+		return nil, err
+	}
+	tabletAlias, err := topoproto.ParseTabletAlias(targetAlias)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse tablet alias %q: %v", targetAlias, err)
+	}
+	// The tablet's data PVC shares its name with the tablet Pod.
+	pvcName := vttablet.PodName(vbsc.Spec.Cluster, *tabletAlias)
+
+	snap := &unstructured.Unstructured{}
+	snap.SetGroupVersionKind(volumeSnapshotGVK)
+	snap.SetNamespace(meta.Namespace)
+	snap.SetName(meta.Name)
+	snap.SetLabels(meta.Labels)
+	snap.SetAnnotations(meta.Annotations)
+
+	spec := map[string]interface{}{
+		"source": map[string]interface{}{
+			"persistentVolumeClaimName": pvcName,
+		},
+	}
+	if strategy.VolumeSnapshotClassName != "" {
+		spec["volumeSnapshotClassName"] = strategy.VolumeSnapshotClassName
+	}
+	snap.Object["spec"] = spec
+
+	// Unlike Jobs, VolumeSnapshots are the backups themselves, so they are
+	// deliberately NOT owned by the VitessBackupSchedule: deleting the schedule
+	// must not cascade-delete the backups. Retention is enforced by the
+	// label-based history cleanup instead. (CloudNativePG makes the same call
+	// with its snapshotOwnerReference default of "none"; making this
+	// configurable can come later.)
+	return snap, nil
+}

--- a/pkg/controller/vitessbackupschedule/volumesnapshot_backup_test.go
+++ b/pkg/controller/vitessbackupschedule/volumesnapshot_backup_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2026 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitessbackupschedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	kbatch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+)
+
+func newSnapshotScheme() *runtime.Scheme {
+	s := newScheme()
+	s.AddKnownTypeWithName(volumeSnapshotGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(volumeSnapshotListGVK, &unstructured.UnstructuredList{})
+	metav1.AddToGroupVersion(s, volumeSnapshotGVK.GroupVersion())
+	return s
+}
+
+func TestChooseSnapshotTarget(t *testing.T) {
+	tablet := func(tabletType string, volumeBound corev1.ConditionStatus) planetscalev2.VitessTabletStatus {
+		return planetscalev2.VitessTabletStatus{Type: tabletType, DataVolumeBound: volumeBound}
+	}
+
+	testCases := []struct {
+		name    string
+		tablets map[string]planetscalev2.VitessTabletStatus
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "prefers rdonly over replica",
+			tablets: map[string]planetscalev2.VitessTabletStatus{
+				"zone1-1111111111": tablet("replica", corev1.ConditionTrue),
+				"zone1-2222222222": tablet("rdonly", corev1.ConditionTrue),
+				"zone1-3333333333": tablet("primary", corev1.ConditionTrue),
+			},
+			want: "zone1-2222222222",
+		},
+		{
+			name: "falls back to replica and never picks the primary",
+			tablets: map[string]planetscalev2.VitessTabletStatus{
+				"zone1-1111111111": tablet("primary", corev1.ConditionTrue),
+				"zone1-2222222222": tablet("replica", corev1.ConditionTrue),
+			},
+			want: "zone1-2222222222",
+		},
+		{
+			name: "picks deterministically by sorted alias",
+			tablets: map[string]planetscalev2.VitessTabletStatus{
+				"zone1-2222222222": tablet("replica", corev1.ConditionTrue),
+				"zone1-1111111111": tablet("replica", corev1.ConditionTrue),
+				"zone1-3333333333": tablet("primary", corev1.ConditionTrue),
+			},
+			want: "zone1-1111111111",
+		},
+		{
+			name: "skips tablets without a bound data volume",
+			tablets: map[string]planetscalev2.VitessTabletStatus{
+				"zone1-1111111111": tablet("replica", corev1.ConditionFalse),
+				"zone1-2222222222": tablet("replica", corev1.ConditionTrue),
+			},
+			want: "zone1-2222222222",
+		},
+		{
+			name: "errors when only the primary is available",
+			tablets: map[string]planetscalev2.VitessTabletStatus{
+				"zone1-1111111111": tablet("primary", corev1.ConditionTrue),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			shard := planetscalev2.VitessShard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-commerce-x-x"},
+				Status:     planetscalev2.VitessShardStatus{Tablets: tc.tablets},
+			}
+			got, err := chooseSnapshotTarget(&shard)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestReconcileStrategy_VolumeSnapshotCreatesSnapshot(t *testing.T) {
+	scheme := newSnapshotScheme()
+
+	shard := &planetscalev2.VitessShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-commerce-x-x",
+			Namespace: "default",
+			Labels: map[string]string{
+				planetscalev2.ClusterLabel:  "test-cluster",
+				planetscalev2.KeyspaceLabel: "commerce",
+			},
+		},
+		Status: planetscalev2.VitessShardStatus{
+			Tablets: map[string]planetscalev2.VitessTabletStatus{
+				"zone1-1111111111": {Type: "primary", DataVolumeBound: corev1.ConditionTrue},
+				"zone1-2222222222": {Type: "replica", DataVolumeBound: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	r := &ReconcileVitessBackupsSchedule{
+		scheme: scheme,
+		client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(&planetscalev2.VitessShard{}, &planetscalev2.VitessBackupSchedule{}).
+			WithObjects(shard).Build(),
+	}
+
+	strategy := planetscalev2.VitessBackupScheduleStrategy{
+		Name:                    "commerce-x",
+		Scope:                   planetscalev2.BackupScopeShard,
+		Keyspace:                "commerce",
+		Shard:                   "-",
+		VolumeSnapshotClassName: "test-snapclass",
+	}
+	vbsc := planetscalev2.VitessBackupSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hourly",
+			Namespace: "default",
+			// Far enough in the past for one run to be due, close enough to
+			// stay under the missed-runs limit.
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-90 * time.Minute)),
+		},
+		Spec: planetscalev2.VitessBackupScheduleSpec{
+			Cluster: "test-cluster",
+			VitessBackupScheduleTemplate: planetscalev2.VitessBackupScheduleTemplate{
+				Schedule:     "0 * * * *",
+				BackupMethod: planetscalev2.BackupMethodVolumeSnapshot,
+				Strategy:     []planetscalev2.VitessBackupScheduleStrategy{strategy},
+			},
+		},
+		Status: planetscalev2.NewVitessBackupScheduleStatus(planetscalev2.VitessBackupScheduleStatus{}),
+	}
+
+	_, err := r.reconcileStrategy(t.Context(), strategy, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "hourly"}}, vbsc)
+	require.NoError(t, err)
+
+	snaps := &unstructured.UnstructuredList{}
+	snaps.SetGroupVersionKind(volumeSnapshotListGVK)
+	require.NoError(t, r.client.List(t.Context(), snaps, client.InNamespace("default")))
+	require.Len(t, snaps.Items, 1)
+
+	snap := snaps.Items[0]
+	require.Equal(t, string(planetscalev2.BackupMethodVolumeSnapshot), snap.GetLabels()[planetscalev2.BackupMethodLabel])
+	require.Equal(t, "hourly", snap.GetLabels()[planetscalev2.BackupScheduleLabel])
+	require.NotEmpty(t, snap.GetAnnotations()[scheduledTimeAnnotation])
+
+	// The snapshot must target the data PVC of the non-primary tablet. The PVC
+	// shares its name with the tablet Pod.
+	pvcName, found, err := unstructured.NestedString(snap.Object, "spec", "source", "persistentVolumeClaimName")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Contains(t, pvcName, "vttablet-zone1-2222222222")
+
+	className, found, err := unstructured.NestedString(snap.Object, "spec", "volumeSnapshotClassName")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "test-snapclass", className)
+
+	// The scheduled run must be recorded so the next reconcile doesn't re-fire.
+	require.Contains(t, vbsc.Status.LastScheduledTimes, strategy.Name)
+
+	// No Job must be created for the volumeSnapshot method.
+	jobs := &kbatch.JobList{}
+	require.NoError(t, r.client.List(t.Context(), jobs, client.InNamespace("default")))
+	require.Empty(t, jobs.Items, "no Jobs expected for volumeSnapshot method")
+}
+
+func TestReconcileStrategy_VolumeSnapshotSkipsWhenNoTargetAvailable(t *testing.T) {
+	scheme := newSnapshotScheme()
+
+	// Shard whose only tablet is the primary: no valid snapshot target.
+	shard := &planetscalev2.VitessShard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-commerce-x-x",
+			Namespace: "default",
+			Labels: map[string]string{
+				planetscalev2.ClusterLabel:  "test-cluster",
+				planetscalev2.KeyspaceLabel: "commerce",
+			},
+		},
+		Status: planetscalev2.VitessShardStatus{
+			Tablets: map[string]planetscalev2.VitessTabletStatus{
+				"zone1-1111111111": {Type: "primary", DataVolumeBound: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	r := &ReconcileVitessBackupsSchedule{
+		scheme: scheme,
+		client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(&planetscalev2.VitessShard{}, &planetscalev2.VitessBackupSchedule{}).
+			WithObjects(shard).Build(),
+	}
+
+	strategy := planetscalev2.VitessBackupScheduleStrategy{
+		Name:     "commerce-x",
+		Scope:    planetscalev2.BackupScopeShard,
+		Keyspace: "commerce",
+		Shard:    "-",
+	}
+	vbsc := planetscalev2.VitessBackupSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "hourly",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-90 * time.Minute)),
+		},
+		Spec: planetscalev2.VitessBackupScheduleSpec{
+			Cluster: "test-cluster",
+			VitessBackupScheduleTemplate: planetscalev2.VitessBackupScheduleTemplate{
+				Schedule:     "0 * * * *",
+				BackupMethod: planetscalev2.BackupMethodVolumeSnapshot,
+				Strategy:     []planetscalev2.VitessBackupScheduleStrategy{strategy},
+			},
+		},
+		Status: planetscalev2.NewVitessBackupScheduleStatus(planetscalev2.VitessBackupScheduleStatus{}),
+	}
+
+	// The run is skipped (no target), but the reconcile must not error out.
+	_, err := r.reconcileStrategy(t.Context(), strategy, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "hourly"}}, vbsc)
+	require.NoError(t, err)
+
+	snaps := &unstructured.UnstructuredList{}
+	snaps.SetGroupVersionKind(volumeSnapshotListGVK)
+	require.NoError(t, r.client.List(t.Context(), snaps, client.InNamespace("default")))
+	require.Empty(t, snaps.Items)
+	require.NotContains(t, vbsc.Status.LastScheduledTimes, strategy.Name)
+}

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -8597,6 +8597,16 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers


### PR DESCRIPTION
## Description

Implements the scheduled-backup slice of RFC #812: a third `BackupMethod` for `VitessBackupSchedule` that takes CSI VolumeSnapshots of tablet data volumes instead of running vtbackup/vtctldclient Jobs.

Opening as a **draft** — the API shape questions in #812 are still open, and this PR is meant to give that discussion something concrete to react to.

```yaml
spec:
  backupMethod: volumeSnapshot
  strategies:
  - name: commerce-snap
    keyspace: commerce
    shard: "-"
    volumeSnapshotClassName: my-snapclass   # optional, cluster default otherwise
```

### What it does

- At each scheduled time the controller creates a `VolumeSnapshot` of the data PVC of **one non-primary tablet** in the target shard (rdonly preferred, then replica; deterministic pick; the primary is never snapshotted). Target selection uses the observed tablet types from `VitessShard.status.tablets`.
- No Job is created. Snapshots carry the same labels and scheduled-time annotation as scheduled Jobs, and `successfulJobsHistoryLimit` / `failedJobsHistoryLimit` are applied to ready/errored snapshots (label-based cleanup, oldest first).
- If no eligible target exists at fire time (e.g. single-tablet shard), the run is skipped with a log line and retried at the next scheduled time.
- Snapshots are deliberately **not** owner-referenced to the schedule: unlike Jobs they are the backups themselves, and deleting a `VitessBackupSchedule` must not cascade-delete backups (same default CloudNativePG chose with `snapshotOwnerReference: none`). Making ownership configurable can be a follow-up (#812 open question 2).
- `VolumeSnapshot` objects are built as unstructured, so no new module dependency on external-snapshotter; the `snapshot.storage.k8s.io/v1` CRDs must be installed, and the operator ClusterRole gains `volumesnapshots` permissions (added to `deploy/role.yaml` and `operator-latest.yaml`).

### Consistency contract (documented on the API type)

The snapshot is crash-consistent, not application-consistent: restore relies on InnoDB crash recovery, which is safe only with durable settings (`sync_binlog=1`, `innodb_flush_log_at_trx_commit=1` — the Vitess defaults) and all MySQL data on a single volume. A fenced/cold mode (quiesce mysqld during the cut) is intentionally **not** in this PR — the right way to hold mysqld down needs discussion first (#812 open question 3: in-pod management restarts a cleanly shut down mysqld within seconds).

Restore needs no code at all: `dataVolumeClaimTemplate` already passes `dataSource`/`dataSourceRef` through to tablet PVCs, and vttablet treats a pre-populated data dir as a restart ("Attempting to restore, but mysqld already contains data"). Verified end to end on v2.17.0 — details in #812.

### Verification

Unit: `go test ./pkg/...` → 18 packages ok, exit 0 (3 new tests: target selection table test, snapshot creation via fake client, skip-when-no-target).

Live, on kind + csi-hostpath-driver + the example cluster (operator built from this branch):

- snapshots created each minute, targeting the non-primary replica's PVC, `readyToUse=true`, correct labels/annotations/snapshot class;
- history limit enforced ("deleted old VolumeSnapshot" after exceeding the limit, steady state at the configured count);
- no Jobs created; deleting the schedule left the snapshots in place;
- restoring one of these snapshots into a tablet PVC via `dataVolumeClaimTemplate.dataSource` produced a replica that rejoined via GTID auto-positioning and passed `CHECKSUM TABLE` against the primary.

One e2e caveat worth knowing: csi-hostpath cannot snapshot a volume with an actively-writing mysqld (`tar: file changed as we read it`), so e2e coverage for this method on kind will need a block-level test driver (e.g. topolvm) or an idle/quiesced target.

Ref: #812

Signed-off-by: Hyungmin Oh <hyungmin.oh@nhn.com>
