### PR TITLE
Fix backup schedule timeout and scheduling state

### DIFF
--- a/deploy/crds/planetscale.com_vitessbackupschedules.yaml
+++ b/deploy/crds/planetscale.com_vitessbackupschedules.yaml
@@ -63,7 +63,7 @@ spec:
               jobTimeoutMinute:
                 default: 10
                 format: int32
-                minimum: 0
+                minimum: -1
                 type: integer
               name:
                 example: every-day

--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -189,7 +189,7 @@ spec:
                         jobTimeoutMinute:
                           default: 10
                           format: int32
-                          minimum: 0
+                          minimum: -1
                           type: integer
                         name:
                           example: every-day

--- a/docs/api.md
+++ b/docs/api.md
@@ -3065,7 +3065,7 @@ int32
 <td>
 <em>(Optional)</em>
 <p>JobTimeoutMinutes specifies how many minutes a Job may run before the operator stops and removes it.
-The timeout begins when Kubernetes sets the Job&rsquo;s status startTime.
+The timeout begins when Kubernetes sets the Job&rsquo;s status startTime. Set this field to -1 to disable the timeout.
 Default value is 10 minutes.</p>
 </td>
 </tr>

--- a/docs/api.md
+++ b/docs/api.md
@@ -3064,7 +3064,8 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>JobTimeoutMinutes defines after how many minutes a job that has not yet finished should be stopped and removed.
+<p>JobTimeoutMinutes specifies how many minutes a Job may run before the operator stops and removes it.
+The timeout begins when Kubernetes sets the Job&rsquo;s status startTime.
 Default value is 10 minutes.</p>
 </td>
 </tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -3067,7 +3067,7 @@ int32
 <td>
 <em>(Optional)</em>
 <p>JobTimeoutMinutes specifies how many minutes a Job may run before the operator stops and removes it.
-The timeout begins when Kubernetes sets the Job&rsquo;s status startTime.
+The timeout begins when Kubernetes sets the Job&rsquo;s status startTime. Set this field to -1 to disable the timeout.
 Default value is 10 minutes.</p>
 </td>
 </tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -3066,7 +3066,8 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>JobTimeoutMinutes defines after how many minutes a job that has not yet finished should be stopped and removed.
+<p>JobTimeoutMinutes specifies how many minutes a Job may run before the operator stops and removes it.
+The timeout begins when Kubernetes sets the Job&rsquo;s status startTime.
 Default value is 10 minutes.</p>
 </td>
 </tr>

--- a/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
@@ -200,10 +200,10 @@ type VitessBackupScheduleTemplate struct {
 	AllowedMissedRuns *int `json:"allowedMissedRun,omitempty"`
 
 	// JobTimeoutMinutes specifies how many minutes a Job may run before the operator stops and removes it.
-	// The timeout begins when Kubernetes sets the Job's status startTime.
+	// The timeout begins when Kubernetes sets the Job's status startTime. Set this field to -1 to disable the timeout.
 	// Default value is 10 minutes.
 	// +optional
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=-1
 	// +kubebuilder:default=10
 	JobTimeoutMinutes int32 `json:"jobTimeoutMinute,omitempty"`
 

--- a/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
+++ b/pkg/apis/planetscale/v2/vitessbackupschedule_types.go
@@ -199,7 +199,8 @@ type VitessBackupScheduleTemplate struct {
 	// +kubebuilder:validation:Minimum=0
 	AllowedMissedRuns *int `json:"allowedMissedRun,omitempty"`
 
-	// JobTimeoutMinutes defines after how many minutes a job that has not yet finished should be stopped and removed.
+	// JobTimeoutMinutes specifies how many minutes a Job may run before the operator stops and removes it.
+	// The timeout begins when Kubernetes sets the Job's status startTime.
 	// Default value is 10 minutes.
 	// +optional
 	// +kubebuilder:validation:Minimum=0

--- a/pkg/controller/vitessbackupschedule/scheduling_regression_test.go
+++ b/pkg/controller/vitessbackupschedule/scheduling_regression_test.go
@@ -34,7 +34,37 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+	"planetscale.dev/vitess-operator/pkg/operator/resync"
 )
+
+func TestReconcileSkipsStatusUpdateWhenStatusIsUnchanged(t *testing.T) {
+	vbsc := vtctldclientVBSC()
+	vbsc.Spec.Strategy = nil
+
+	statusUpdates := 0
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&planetscalev2.VitessBackupSchedule{}).
+		WithObjects(&vbsc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if subResourceName == "status" {
+					statusUpdates++
+				}
+				return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &ReconcileVitessBackupsSchedule{
+		client: k8sClient,
+		resync: resync.NewPeriodic("test-vbsc-status", time.Hour),
+	}
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&vbsc)})
+	require.NoError(t, err)
+	assert.Zero(t, statusUpdates)
+}
 
 func TestReconcileStrategyUsesStatusAfterSuccessfulJobHistoryIsRemoved(t *testing.T) {
 	now := time.Now().UTC()
@@ -179,6 +209,58 @@ func TestRemoveTimeoutJobsWaitsForJobStartTime(t *testing.T) {
 	}
 
 	require.NoError(t, r.removeTimeoutJobs(t.Context(), []*kbatch.Job{job}, "test-vbsc", 10, now))
+
+	remaining := &kbatch.Job{}
+	require.NoError(t, r.client.Get(t.Context(), client.ObjectKeyFromObject(job), remaining))
+}
+
+func TestRemoveTimeoutJobsSkipsJobAlreadyBeingDeleted(t *testing.T) {
+	now := time.Date(2026, time.August, 28, 12, 0, 0, 0, time.UTC)
+	job := timeoutTestJob(
+		"already-deleting",
+		now.Add(-30*time.Minute),
+		metav1.NewTime(now.Add(-30*time.Minute)),
+		planetscalev2.BackupMethodVtctldclient,
+	)
+	deletionTime := metav1.NewTime(now.Add(-time.Minute))
+	job.DeletionTimestamp = &deletionTime
+	job.Finalizers = []string{"test.planetscale.com/keep-job"}
+
+	jobDeletes := 0
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(job).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*kbatch.Job); ok {
+					jobDeletes++
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &ReconcileVitessBackupsSchedule{client: k8sClient}
+
+	require.NoError(t, r.removeTimeoutJobs(t.Context(), []*kbatch.Job{job}, "test-vbsc", 10, now))
+	assert.Zero(t, jobDeletes)
+}
+
+func TestRemoveTimeoutJobsAllowsDisabledTimeout(t *testing.T) {
+	now := time.Date(2026, time.August, 28, 12, 0, 0, 0, time.UTC)
+	job := timeoutTestJob(
+		"timeout-disabled",
+		now.Add(-24*time.Hour),
+		metav1.NewTime(now.Add(-24*time.Hour)),
+		planetscalev2.BackupMethodVtctldclient,
+	)
+
+	scheme := newScheme()
+	r := &ReconcileVitessBackupsSchedule{
+		client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(job).Build(),
+	}
+
+	require.NoError(t, r.removeTimeoutJobs(t.Context(), []*kbatch.Job{job}, "test-vbsc", -1, now))
 
 	remaining := &kbatch.Job{}
 	require.NoError(t, r.client.Get(t.Context(), client.ObjectKeyFromObject(job), remaining))

--- a/pkg/controller/vitessbackupschedule/scheduling_regression_test.go
+++ b/pkg/controller/vitessbackupschedule/scheduling_regression_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2026 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitessbackupschedule
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kbatch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+)
+
+func TestReconcileStrategyUsesStatusAfterSuccessfulJobHistoryIsRemoved(t *testing.T) {
+	now := time.Now().UTC()
+	lastScheduled := now.Truncate(time.Hour)
+	zero := int32(0)
+
+	vbsc := vtctldclientVBSC()
+	vbsc.CreationTimestamp = metav1.NewTime(now.Add(-2 * time.Hour))
+	vbsc.Spec.Schedule = "0 * * * *"
+	vbsc.Spec.SuccessfulJobsHistoryLimit = &zero
+	strategy := vbsc.Spec.Strategy[0]
+	vbsc.Status.LastScheduledTimes[strategy.Name] = &metav1.Time{Time: lastScheduled}
+
+	scheme := newScheme()
+	r := &ReconcileVitessBackupsSchedule{
+		client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(vtctldService(), vtctldCluster()).Build(),
+		scheme: scheme,
+	}
+
+	_, err := r.reconcileStrategy(t.Context(), strategy, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: vbsc.Namespace, Name: vbsc.Name},
+	}, vbsc)
+	require.NoError(t, err)
+
+	jobs := &kbatch.JobList{}
+	require.NoError(t, r.client.List(t.Context(), jobs, client.InNamespace(vbsc.Namespace)))
+	assert.Empty(t, jobs.Items, "the persisted scheduling cursor must prevent recreating an already-scheduled run")
+}
+
+func TestReconcileStrategyRepairsStatusFromNewerJobAnnotation(t *testing.T) {
+	now := time.Now().UTC()
+	jobScheduledTime := now.Truncate(time.Hour)
+	zero := int32(0)
+
+	vbsc := vtctldclientVBSC()
+	vbsc.CreationTimestamp = metav1.NewTime(now.Add(-2 * time.Hour))
+	vbsc.Spec.Schedule = "0 * * * *"
+	vbsc.Spec.SuccessfulJobsHistoryLimit = &zero
+	strategy := vbsc.Spec.Strategy[0]
+	vbsc.Status.LastScheduledTimes[strategy.Name] = &metav1.Time{Time: jobScheduledTime.Add(-time.Hour)}
+
+	job := &kbatch.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "existing-backup",
+		Namespace: vbsc.Namespace,
+		Labels: map[string]string{
+			planetscalev2.BackupScheduleLabel: vbsc.Name,
+			planetscalev2.ClusterLabel:        vbsc.Spec.Cluster,
+			planetscalev2.KeyspaceLabel:       strategy.Keyspace,
+			planetscalev2.ShardLabel:          "x-x",
+			planetscalev2.BackupMethodLabel:   string(planetscalev2.BackupMethodVtctldclient),
+		},
+		Annotations: map[string]string{
+			scheduledTimeAnnotation: jobScheduledTime.Format(time.RFC3339),
+		},
+	}, Status: kbatch.JobStatus{Conditions: []kbatch.JobCondition{{
+		Type:   kbatch.JobComplete,
+		Status: corev1.ConditionTrue,
+	}}}}
+
+	scheme := newScheme()
+	r := &ReconcileVitessBackupsSchedule{
+		client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(job).Build(),
+		scheme: scheme,
+	}
+
+	_, err := r.reconcileStrategy(t.Context(), strategy, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: vbsc.Namespace, Name: vbsc.Name},
+	}, vbsc)
+	require.NoError(t, err)
+	require.NotNil(t, vbsc.Status.LastScheduledTimes[strategy.Name])
+	assert.Equal(t, jobScheduledTime, vbsc.Status.LastScheduledTimes[strategy.Name].Time)
+	require.NoError(t, r.client.Get(t.Context(), client.ObjectKeyFromObject(job), &kbatch.Job{}),
+		"the Job must remain until the repaired status has been persisted")
+}
+
+func TestRemoveTimeoutJobsUsesJobStartTime(t *testing.T) {
+	now := time.Date(2026, time.August, 28, 12, 0, 0, 0, time.UTC)
+	job := timeoutTestJob(
+		"recently-started",
+		now.Add(-2*time.Hour),
+		metav1.NewTime(now.Add(-5*time.Minute)),
+		planetscalev2.BackupMethodVtctldclient,
+	)
+
+	scheme := newScheme()
+	r := &ReconcileVitessBackupsSchedule{
+		client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(job).Build(),
+	}
+
+	require.NoError(t, r.removeTimeoutJobs(t.Context(), []*kbatch.Job{job}, "test-vbsc", 10, now))
+
+	remaining := &kbatch.Job{}
+	require.NoError(t, r.client.Get(t.Context(), client.ObjectKeyFromObject(job), remaining))
+}
+
+func TestRemoveTimeoutJobsDeletesJobAfterStartTimeTimeout(t *testing.T) {
+	now := time.Date(2026, time.August, 28, 12, 0, 0, 0, time.UTC)
+	job := timeoutTestJob(
+		"timed-out",
+		now.Add(-5*time.Minute),
+		metav1.NewTime(now.Add(-30*time.Minute)),
+		planetscalev2.BackupMethodVtctldclient,
+	)
+
+	var propagationPolicy *metav1.DeletionPropagation
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(job).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*kbatch.Job); ok {
+					propagationPolicy = (&client.DeleteOptions{}).ApplyOptions(opts).PropagationPolicy
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &ReconcileVitessBackupsSchedule{client: k8sClient}
+
+	require.NoError(t, r.removeTimeoutJobs(t.Context(), []*kbatch.Job{job}, "test-vbsc", 10, now))
+
+	err := r.client.Get(t.Context(), client.ObjectKeyFromObject(job), &kbatch.Job{})
+	assert.True(t, apierrors.IsNotFound(err), "expected timed-out Job to be deleted, got: %v", err)
+	require.NotNil(t, propagationPolicy)
+	assert.Equal(t, metav1.DeletePropagationForeground, *propagationPolicy)
+}
+
+func TestRemoveTimeoutJobsWaitsForJobStartTime(t *testing.T) {
+	now := time.Date(2026, time.August, 28, 12, 0, 0, 0, time.UTC)
+	job := timeoutTestJob(
+		"not-started",
+		now.Add(-2*time.Hour),
+		metav1.Time{},
+		planetscalev2.BackupMethodVtctldclient,
+	)
+	job.Status.StartTime = nil
+
+	scheme := newScheme()
+	r := &ReconcileVitessBackupsSchedule{
+		client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(job).Build(),
+	}
+
+	require.NoError(t, r.removeTimeoutJobs(t.Context(), []*kbatch.Job{job}, "test-vbsc", 10, now))
+
+	remaining := &kbatch.Job{}
+	require.NoError(t, r.client.Get(t.Context(), client.ObjectKeyFromObject(job), remaining))
+}
+
+func TestRemoveTimeoutJobsPreservesPVCWhenJobDeletionFails(t *testing.T) {
+	now := time.Date(2026, time.August, 28, 12, 0, 0, 0, time.UTC)
+	job := timeoutTestJob(
+		"delete-fails",
+		now.Add(-30*time.Minute),
+		metav1.NewTime(now.Add(-30*time.Minute)),
+		planetscalev2.BackupMethodVtbackup,
+	)
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Name:      job.Name,
+		Namespace: job.Namespace,
+	}}
+
+	pvcDeleteCalled := false
+	scheme := newScheme()
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(job, pvc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				switch obj.(type) {
+				case *kbatch.Job:
+					return apierrors.NewServiceUnavailable("Job deletion unavailable")
+				case *corev1.PersistentVolumeClaim:
+					pvcDeleteCalled = true
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &ReconcileVitessBackupsSchedule{client: k8sClient}
+
+	err := r.removeTimeoutJobs(t.Context(), []*kbatch.Job{job}, "test-vbsc", 10, now)
+	require.ErrorContains(t, err, "Job deletion unavailable")
+	assert.False(t, pvcDeleteCalled)
+	require.NoError(t, r.client.Get(t.Context(), client.ObjectKeyFromObject(pvc), &corev1.PersistentVolumeClaim{}))
+}
+
+func timeoutTestJob(name string, scheduledTime time.Time, startTime metav1.Time, method planetscalev2.BackupMethod) *kbatch.Job {
+	return &kbatch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				planetscalev2.BackupMethodLabel: string(method),
+			},
+			Annotations: map[string]string{
+				scheduledTimeAnnotation: scheduledTime.Format(time.RFC3339),
+			},
+		},
+		Status: kbatch.JobStatus{StartTime: &startTime},
+	}
+}

--- a/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
+++ b/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
@@ -201,7 +201,7 @@ func (r *ReconcileVitessBackupsSchedule) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, nil
 	}
 
-	oldStatus := vbsc.DeepCopy()
+	oldStatus := vbsc.Status.DeepCopy()
 	vbsc.Status = planetscalev2.NewVitessBackupScheduleStatus(vbsc.Status)
 
 	// Register this reconciling attempt no matter if we fail or succeed.
@@ -212,7 +212,7 @@ func (r *ReconcileVitessBackupsSchedule) Reconcile(ctx context.Context, req ctrl
 	resultBuilder := &results.Builder{}
 	_, _ = resultBuilder.Merge(r.reconcileStrategies(ctx, req, vbsc))
 
-	if !apiequality.Semantic.DeepEqual(&vbsc.Status, &oldStatus) {
+	if !apiequality.Semantic.DeepEqual(&vbsc.Status, oldStatus) {
 		if err := r.client.Status().Update(ctx, &vbsc); err != nil {
 			if !apierrors.IsConflict(err) {
 				log.WithError(err).Error("unable to update VitessBackupSchedule status")
@@ -573,6 +573,9 @@ func (r *ReconcileVitessBackupsSchedule) removeTimeoutJobs(ctx context.Context, 
 		return nil
 	}
 	for _, job := range jobs {
+		if job.DeletionTimestamp != nil {
+			continue
+		}
 		if job.Status.StartTime == nil {
 			continue
 		}

--- a/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
+++ b/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
@@ -300,6 +300,7 @@ func (r *ReconcileVitessBackupsSchedule) reconcileStrategy(
 	vbsc planetscalev2.VitessBackupSchedule,
 ) (reconcile.Result, error) {
 	resultBuilder := &results.Builder{}
+	now := time.Now()
 
 	start, end, ok := strings.Cut(strategy.Shard, "-")
 	if !ok {
@@ -314,13 +315,32 @@ func (r *ReconcileVitessBackupsSchedule) reconcileStrategy(
 		// We had an error reading the jobs, we can requeue.
 		return resultBuilder.Error(err)
 	}
+	lastScheduledTime := vbsc.Status.LastScheduledTimes[strategy.Name]
+	repairedLastScheduledTime := false
+	if mostRecentTime != nil && (lastScheduledTime == nil || lastScheduledTime.Time.Before(*mostRecentTime)) {
+		// Repair status from the Job annotation if Job creation succeeded but the
+		// status update did not.
+		lastScheduledTime = &metav1.Time{Time: *mostRecentTime}
+		vbsc.Status.LastScheduledTimes[strategy.Name] = lastScheduledTime
+		repairedLastScheduledTime = true
+	}
+	if lastScheduledTime != nil && (mostRecentTime == nil || mostRecentTime.Before(lastScheduledTime.Time)) {
+		// Keep a copy so getNextSchedule can clamp the value to StartingDeadlineSeconds
+		// without mutating the persisted status entry.
+		statusTime := lastScheduledTime.Time
+		mostRecentTime = &statusTime
+	}
 
 	// We must clean up old jobs to not overcrowd the number of Pods and Jobs in the cluster.
 	// This will be done according to both failedJobsHistoryLimit and successfulJobsHistoryLimit fields.
-	r.cleanupJobsWithLimit(ctx, jobs.failed, vbsc.GetFailedJobsLimit())
-	r.cleanupJobsWithLimit(ctx, jobs.successful, vbsc.GetSuccessfulJobsLimit())
+	// Keep the Jobs for one more reconcile when an annotation repaired the status, so a
+	// conflicting status update cannot remove the only durable record of the scheduled run.
+	if !repairedLastScheduledTime {
+		r.cleanupJobsWithLimit(ctx, jobs.failed, vbsc.GetFailedJobsLimit())
+		r.cleanupJobsWithLimit(ctx, jobs.successful, vbsc.GetSuccessfulJobsLimit())
+	}
 
-	err = r.removeTimeoutJobs(ctx, jobs.active, vbsc.Name, vbsc.Spec.JobTimeoutMinutes)
+	err = r.removeTimeoutJobs(ctx, jobs.active, vbsc.Name, vbsc.Spec.JobTimeoutMinutes, now)
 	if err != nil {
 		// We had an error while removing timed out jobs, we can requeue
 		return resultBuilder.Error(err)
@@ -343,7 +363,7 @@ func (r *ReconcileVitessBackupsSchedule) reconcileStrategy(
 		delete(vbsc.Status.GeneratedSchedules, strategy.Name)
 	}
 
-	missedRun, nextRun, err := getNextSchedule(effectiveSchedule, vbsc, time.Now(), mostRecentTime)
+	missedRun, nextRun, err := getNextSchedule(effectiveSchedule, vbsc, now, mostRecentTime)
 	if err != nil {
 		log.Error(err, "unable to figure out VitessBackupSchedule schedule")
 		// Re-queuing here does not make sense as we have an error with the schedule and the user needs to fix it first.
@@ -357,14 +377,14 @@ func (r *ReconcileVitessBackupsSchedule) reconcileStrategy(
 	}
 
 	// Keep track of when we need to requeue this job
-	requeueAfter := nextRun.Sub(time.Now())
+	requeueAfter := nextRun.Sub(now)
 	_, _ = resultBuilder.RequeueAfter(requeueAfter)
 
 	// Check whether we are too late to create this Job or not. The startingDeadlineSeconds field will help us
 	// schedule Jobs that are late.
 	tooLate := false
 	if vbsc.Spec.StartingDeadlineSeconds != nil {
-		tooLate = missedRun.Add(time.Duration(*vbsc.Spec.StartingDeadlineSeconds) * time.Second).Before(time.Now())
+		tooLate = missedRun.Add(time.Duration(*vbsc.Spec.StartingDeadlineSeconds) * time.Second).Before(now)
 	}
 	if tooLate {
 		log.Infof("missed starting deadline for latest run; skipping; next run is scheduled for: %s", nextRun.Format(time.RFC3339))
@@ -548,42 +568,42 @@ func (r *ReconcileVitessBackupsSchedule) cleanupJobsWithLimit(ctx context.Contex
 	}
 }
 
-func (r *ReconcileVitessBackupsSchedule) removeTimeoutJobs(ctx context.Context, jobs []*kbatch.Job, vbscName string, timeout int32) error {
+func (r *ReconcileVitessBackupsSchedule) removeTimeoutJobs(ctx context.Context, jobs []*kbatch.Job, vbscName string, timeout int32, now time.Time) error {
 	if timeout == -1 {
 		return nil
 	}
 	for _, job := range jobs {
-		jobStartTime, err := getScheduledTimeForJob(job)
-		if err != nil {
-			return err
+		if job.Status.StartTime == nil {
+			continue
 		}
-		if jobStartTime.Add(time.Minute * time.Duration(timeout)).Before(time.Now()) {
-			if err = r.client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); (err) != nil {
-				log.WithError(err).Errorf("unable to delete timed out job: %s", job.Name)
-			} else {
-				log.Infof("deleted timed out job: %s", job.Name)
-			}
-			timeoutJobsCount.WithLabelValues(vbscName, metrics.Result(err)).Inc()
+		if !job.Status.StartTime.Add(time.Minute * time.Duration(timeout)).Before(now) {
+			continue
+		}
 
-			// vtctldclient jobs don't have PVCs, so skip PVC cleanup for them.
-			if job.Labels[planetscalev2.BackupMethodLabel] == string(planetscalev2.BackupMethodVtctldclient) {
+		err := r.client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground))
+		timeoutJobsCount.WithLabelValues(vbscName, metrics.Result(err)).Inc()
+		if err != nil {
+			return fmt.Errorf("unable to delete timed out job %s: %w", job.Name, err)
+		}
+		log.Infof("deleted timed out job: %s", job.Name)
+
+		// vtctldclient jobs don't have PVCs, so skip PVC cleanup for them.
+		if job.Labels[planetscalev2.BackupMethodLabel] == string(planetscalev2.BackupMethodVtctldclient) {
+			continue
+		}
+
+		pvc := &corev1.PersistentVolumeClaim{}
+		err = r.client.Get(ctx, client.ObjectKey{Namespace: job.Namespace, Name: job.Name}, pvc)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
-
-			pvc := &corev1.PersistentVolumeClaim{}
-			err := r.client.Get(ctx, client.ObjectKey{Namespace: job.Namespace, Name: job.Name}, pvc)
-			if err != nil {
-				log.WithError(err).Errorf("unable to get PVC for timed out job: %s", job.Name)
-				if apierrors.IsNotFound(err) {
-					continue
-				}
-			}
-			if err := r.client.Delete(ctx, pvc, client.PropagationPolicy(metav1.DeletePropagationBackground)); (err) != nil {
-				log.WithError(err).Errorf("unable to delete old PVC for timed out job: %s", job.Name)
-			} else {
-				log.Infof("deleted old PVC for timed out job: %s", job.Name)
-			}
+			return fmt.Errorf("unable to get PVC for timed out job %s: %w", job.Name, err)
 		}
+		if err := r.client.Delete(ctx, pvc, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			return fmt.Errorf("unable to delete PVC for timed out job %s: %w", job.Name, err)
+		}
+		log.Infof("deleted PVC for timed out job: %s", job.Name)
 	}
 	return nil
 }

--- a/pkg/controller/vitessbackupschedule/vtctldclient_backup_test.go
+++ b/pkg/controller/vitessbackupschedule/vtctldclient_backup_test.go
@@ -600,7 +600,8 @@ func TestCleanupJobsWithLimit_SkipsPVCForVtctldclientJobs(t *testing.T) {
 }
 
 func TestRemoveTimeoutJobs_SkipsPVCForVtctldclientJobs(t *testing.T) {
-	scheduledAt := time.Now().Add(-30 * time.Minute)
+	now := time.Now()
+	scheduledAt := now.Add(-30 * time.Minute)
 	vtctldJob := &kbatch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vtctldclient-timeout",
@@ -623,7 +624,7 @@ func TestRemoveTimeoutJobs_SkipsPVCForVtctldclientJobs(t *testing.T) {
 	}
 
 	// A 10-minute timeout removes the Job 30 minutes after it started.
-	err := r.removeTimeoutJobs(t.Context(), []*kbatch.Job{vtctldJob}, "test-vbsc", 10, time.Now())
+	err := r.removeTimeoutJobs(t.Context(), []*kbatch.Job{vtctldJob}, "test-vbsc", 10, now)
 	require.NoError(t, err)
 
 	// The job should be deleted

--- a/pkg/controller/vitessbackupschedule/vtctldclient_backup_test.go
+++ b/pkg/controller/vitessbackupschedule/vtctldclient_backup_test.go
@@ -612,6 +612,9 @@ func TestRemoveTimeoutJobs_SkipsPVCForVtctldclientJobs(t *testing.T) {
 				scheduledTimeAnnotation: scheduledAt.Format(time.RFC3339),
 			},
 		},
+		Status: kbatch.JobStatus{
+			StartTime: &metav1.Time{Time: scheduledAt},
+		},
 	}
 
 	scheme := newScheme()
@@ -619,8 +622,8 @@ func TestRemoveTimeoutJobs_SkipsPVCForVtctldclientJobs(t *testing.T) {
 		client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(vtctldJob).Build(),
 	}
 
-	// Timeout of 10 minutes — the job scheduled 30min ago should be timed out
-	err := r.removeTimeoutJobs(t.Context(), []*kbatch.Job{vtctldJob}, "test-vbsc", 10)
+	// A 10-minute timeout removes the Job 30 minutes after it started.
+	err := r.removeTimeoutJobs(t.Context(), []*kbatch.Job{vtctldJob}, "test-vbsc", 10, time.Now())
 	require.NoError(t, err)
 
 	// The job should be deleted

--- a/test/endtoend/operator/operator-latest.yaml
+++ b/test/endtoend/operator/operator-latest.yaml
@@ -458,7 +458,7 @@ spec:
               jobTimeoutMinute:
                 default: 10
                 format: int32
-                minimum: 0
+                minimum: -1
                 type: integer
               name:
                 example: every-day
@@ -2167,7 +2167,7 @@ spec:
                         jobTimeoutMinute:
                           default: 10
                           format: int32
-                          minimum: 0
+                          minimum: -1
                           type: integer
                         name:
                           example: every-day


### PR DESCRIPTION
## Summary

Fixes #817

Fix backup-schedule create/delete loops caused by stale cron timestamps and lost Job history. The controller now uses persisted per-strategy status as its scheduling cursor and measures timeouts from the actual Job start time.

This prevents completed or timed-out Jobs from resetting scheduling state, including when `successfulJobsHistoryLimit: 0` or the operator catches up a missed cron slot after downtime.

## Changes

- Use `status.lastScheduledTimes` as the durable scheduling cursor.
- Repair stale status from newer Job annotations before cleaning up Job history.
- Measure `jobTimeoutMinute` from `Job.status.startTime`; Jobs that have not started cannot time out.
- Support `jobTimeoutMinute: -1` to disable timeout cleanup. The default remains 10 minutes.
- Delete timed-out Jobs with foreground propagation. Under `concurrencyPolicy: Forbid`, a terminating Job remains active until Kubernetes removes its Pods, blocking a replacement.
- Preserve vtbackup PVCs when Job deletion fails.
- Skip repeated timeout cleanup for Jobs already being deleted.
- Update `VitessBackupSchedule` status only when it changes.