### PR TITLE
Use the pool name when calculating the tablet UID

### DIFF
--- a/deploy/crds/planetscale.com_vitessclusters.yaml
+++ b/deploy/crds/planetscale.com_vitessclusters.yaml
@@ -2147,6 +2147,8 @@ spec:
                                             type: object
                                           name:
                                             default: ""
+                                            maxLength: 63
+                                            pattern: ^([A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?)?$
                                             type: string
                                           replicas:
                                             format: int32
@@ -2617,6 +2619,8 @@ spec:
                                           type: object
                                         name:
                                           default: ""
+                                          maxLength: 63
+                                          pattern: ^([A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?)?$
                                           type: string
                                         replicas:
                                           format: int32

--- a/deploy/crds/planetscale.com_vitesskeyspaces.yaml
+++ b/deploy/crds/planetscale.com_vitesskeyspaces.yaml
@@ -610,6 +610,8 @@ spec:
                                       type: object
                                     name:
                                       default: ""
+                                      maxLength: 63
+                                      pattern: ^([A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?)?$
                                       type: string
                                     replicas:
                                       format: int32
@@ -1080,6 +1082,8 @@ spec:
                                     type: object
                                   name:
                                     default: ""
+                                    maxLength: 63
+                                    pattern: ^([A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?)?$
                                     type: string
                                   replicas:
                                     format: int32

--- a/deploy/crds/planetscale.com_vitessshards.yaml
+++ b/deploy/crds/planetscale.com_vitessshards.yaml
@@ -593,6 +593,8 @@ spec:
                       type: object
                     name:
                       default: ""
+                      maxLength: 63
+                      pattern: ^([A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?)?$
                       type: string
                     replicas:
                       format: int32

--- a/docs/api.md
+++ b/docs/api.md
@@ -8162,10 +8162,13 @@ string
 </td>
 <td>
 <p>Name is the pool&rsquo;s unique name within the (cell,type) pair.
-This field is optional, and defaults to an empty.
-Assigning different names to this field enables the existence of multiple pools with a specific tablet type in a given cell,
-which can be beneficial for unmanaged tablets.
-Hence, you must specify ExternalDatastore when assigning a name to this field.</p>
+This field is optional, and defaults to an empty string.
+Different names allow multiple pools of the same tablet type in one cell.
+That is useful for unmanaged tablets, and for tablets that must stay on the machine holding their data.
+The name is part of the tablet UID.
+Pools within one (cell,type) therefore get distinct UIDs, Pod names and PVC names.
+Pools with no name keep the UID they have always had.
+The name is also used as a label value on the pool&rsquo;s Pods and PVCs, so it has to be a valid one.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -8164,10 +8164,13 @@ string
 </td>
 <td>
 <p>Name is the pool&rsquo;s unique name within the (cell,type) pair.
-This field is optional, and defaults to an empty.
-Assigning different names to this field enables the existence of multiple pools with a specific tablet type in a given cell,
-which can be beneficial for unmanaged tablets.
-Hence, you must specify ExternalDatastore when assigning a name to this field.</p>
+This field is optional, and defaults to an empty string.
+Different names allow multiple pools of the same tablet type in one cell.
+That is useful for unmanaged tablets, and for tablets that must stay on the machine holding their data.
+The name is part of the tablet UID.
+Pools within one (cell,type) therefore get distinct UIDs, Pod names and PVC names.
+Pools with no name keep the UID they have always had.
+The name is also used as a label value on the pool&rsquo;s Pods and PVCs, so it has to be a valid one.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/planetscale/v2/labels.go
+++ b/pkg/apis/planetscale/v2/labels.go
@@ -36,7 +36,7 @@ const (
 	// TabletTypeLabel is the key for identifying the Vitess target tablet type for a Pod.
 	TabletTypeLabel = LabelPrefix + "/" + "tablet-type"
 	// TabletPoolNameLabel is the key for identifying the Vitess target pool name within the (cell,type) pair.
-	// This label is applicable to Vitess-unmanaged keyspaces.
+	// This label is applicable to any pool that sets a name, managed or not.
 	TabletPoolNameLabel = LabelPrefix + "/" + "pool-name"
 	// TabletIndexLabel is the key for identifying the index of a Vitess tablet within its pool.
 	TabletIndexLabel = LabelPrefix + "/" + "tablet-index"

--- a/pkg/apis/planetscale/v2/vitessshard_types.go
+++ b/pkg/apis/planetscale/v2/vitessshard_types.go
@@ -172,11 +172,16 @@ type VitessShardTabletPool struct {
 	Type VitessTabletPoolType `json:"type"`
 
 	// Name is the pool's unique name within the (cell,type) pair.
-	// This field is optional, and defaults to an empty.
-	// Assigning different names to this field enables the existence of multiple pools with a specific tablet type in a given cell,
-	// which can be beneficial for unmanaged tablets.
-	// Hence, you must specify ExternalDatastore when assigning a name to this field.
+	// This field is optional, and defaults to an empty string.
+	// Different names allow multiple pools of the same tablet type in one cell.
+	// That is useful for unmanaged tablets, and for tablets that must stay on the machine holding their data.
+	// The name is part of the tablet UID.
+	// Pools within one (cell,type) therefore get distinct UIDs, Pod names and PVC names.
+	// Pools with no name keep the UID they have always had.
+	// The name is also used as a label value on the pool's Pods and PVCs, so it has to be a valid one.
 	// +kubebuilder:default=""
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=^([A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?)?$
 	Name string `json:"name,omitempty"`
 
 	// Replicas is the number of tablets to deploy in this pool.

--- a/pkg/controller/vitessshard/reconcile_tablets.go
+++ b/pkg/controller/vitessshard/reconcile_tablets.go
@@ -284,8 +284,10 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 				Uid:  vttablet.UID(pool.Cell, keyspaceName, vts.Spec.KeyRange, pool.Type, uint32(tabletIndex)),
 			}
 
-			// If TabletPools has multiple pools within the same (cell,type) pair, we need to add a pool name to the UID generator.
-			if pool.ExternalDatastore != nil && 0 < len(pool.Name) {
+			// A pool's name is part of its identity, with or without an ExternalDatastore.
+			// So add the name to the UID generator whenever the pool has one.
+			// An empty name is left out, because UIDWithPoolName hashes it differently from UID.
+			if 0 < len(pool.Name) {
 				tabletAlias.Uid = vttablet.UIDWithPoolName(pool.Cell, keyspaceName, vts.Spec.KeyRange, pool.Type, uint32(tabletIndex), pool.Name)
 			}
 
@@ -298,7 +300,7 @@ func vttabletSpecs(vts *planetscalev2.VitessShard, parentLabels map[string]strin
 			labels[planetscalev2.TabletUidLabel] = vttablet.UIDString(tabletAlias.Uid)
 			labels[planetscalev2.TabletTypeLabel] = string(pool.Type)
 			labels[planetscalev2.TabletIndexLabel] = strconv.FormatUint(uint64(tabletIndex), 10)
-			if pool.ExternalDatastore != nil {
+			if pool.ExternalDatastore != nil || 0 < len(pool.Name) {
 				labels[planetscalev2.TabletPoolNameLabel] = pool.Name
 			}
 

--- a/pkg/controller/vitessshard/reconcile_tablets_test.go
+++ b/pkg/controller/vitessshard/reconcile_tablets_test.go
@@ -86,3 +86,119 @@ func TestTabletUidLabelZeroPadded(t *testing.T) {
 		}
 	}
 }
+
+func TestNamedTabletPoolsGetDistinctUIDs(t *testing.T) {
+	// Multiple pools of one tablet type in one cell, distinguished only by name, with local MySQL
+	cluster := "default"
+	cell := "zone1"
+	keyspace := "commerce"
+	poolNames := []string{"node-a", "node-b", "node-c"}
+
+	pools := make([]planetscalev2.VitessShardTabletPool, 0, len(poolNames))
+	for _, name := range poolNames {
+		pools = append(pools, planetscalev2.VitessShardTabletPool{
+			Cell:     cell,
+			Type:     planetscalev2.ReplicaPoolType,
+			Name:     name,
+			Replicas: 1,
+		})
+	}
+	shard := newVitessShard(keyspace, pools)
+	parentLabels := map[string]string{
+		planetscalev2.ComponentLabel: planetscalev2.VttabletComponentName,
+		planetscalev2.ClusterLabel:   cluster,
+		planetscalev2.KeyspaceLabel:  keyspace,
+		planetscalev2.ShardLabel:     shard.Spec.KeyRange.SafeName(),
+	}
+
+	tablets := vttabletSpecs(shard, parentLabels)
+	if len(tablets) != len(poolNames) {
+		t.Fatalf("expected %d tablets, got %d", len(poolNames), len(tablets))
+	}
+
+	seen := make(map[uint32]string, len(tablets))
+	for i, tablet := range tablets {
+		wantUID := vttablet.UIDWithPoolName(cell, keyspace, shard.Spec.KeyRange, planetscalev2.ReplicaPoolType, uint32(tablet.Index), poolNames[i])
+		if tablet.Alias.Uid != wantUID {
+			t.Errorf("pool %q: expected uid %v, got %v", poolNames[i], wantUID, tablet.Alias.Uid)
+		}
+		if other, ok := seen[tablet.Alias.Uid]; ok {
+			t.Errorf("pool %q has the same uid as pool %q (%v), so both would produce one Pod and one PVC",
+				poolNames[i], other, tablet.Alias.Uid)
+		}
+		seen[tablet.Alias.Uid] = poolNames[i]
+
+		if got := tablet.Labels[planetscalev2.TabletPoolNameLabel]; got != poolNames[i] {
+			t.Errorf("pool %q: expected pool name label %q, got %q", poolNames[i], poolNames[i], got)
+		}
+	}
+}
+
+func TestUnnamedTabletPoolUIDIsUnchanged(t *testing.T) {
+	// A pool with no name must keep the UID it has always had
+	cluster := "default"
+	cell := "zone1"
+	keyspace := "commerce"
+
+	shard := newVitessShard(keyspace, []planetscalev2.VitessShardTabletPool{
+		{
+			Cell:     cell,
+			Type:     planetscalev2.ReplicaPoolType,
+			Replicas: 3,
+		},
+	})
+	parentLabels := map[string]string{
+		planetscalev2.ComponentLabel: planetscalev2.VttabletComponentName,
+		planetscalev2.ClusterLabel:   cluster,
+		planetscalev2.KeyspaceLabel:  keyspace,
+		planetscalev2.ShardLabel:     shard.Spec.KeyRange.SafeName(),
+	}
+
+	for _, tablet := range vttabletSpecs(shard, parentLabels) {
+		wantUID := vttablet.UID(cell, keyspace, shard.Spec.KeyRange, planetscalev2.ReplicaPoolType, uint32(tablet.Index))
+		if tablet.Alias.Uid != wantUID {
+			t.Errorf("tablet index %d: expected uid %v, got %v", tablet.Index, wantUID, tablet.Alias.Uid)
+		}
+		if _, ok := tablet.Labels[planetscalev2.TabletPoolNameLabel]; ok {
+			t.Errorf("tablet index %d: unnamed pool should not carry a pool name label", tablet.Index)
+		}
+	}
+}
+
+func TestExternalDatastorePoolUIDIsUnchanged(t *testing.T) {
+	// An ExternalDatastore pool with no name has always used the plain UID, so it has to keep using it
+	// UIDWithPoolName hashes an empty name differently, so calling it here would rename the tablet
+	cluster := "default"
+	cell := "zone1"
+	keyspace := "commerce"
+
+	shard := newVitessShard(keyspace, []planetscalev2.VitessShardTabletPool{
+		{
+			Cell:     cell,
+			Type:     planetscalev2.ExternalReplicaPoolType,
+			Replicas: 2,
+			ExternalDatastore: &planetscalev2.ExternalDatastore{
+				User:     "vitess",
+				Host:     "mysql.example.com",
+				Port:     3306,
+				Database: keyspace,
+			},
+		},
+	})
+	parentLabels := map[string]string{
+		planetscalev2.ComponentLabel: planetscalev2.VttabletComponentName,
+		planetscalev2.ClusterLabel:   cluster,
+		planetscalev2.KeyspaceLabel:  keyspace,
+		planetscalev2.ShardLabel:     shard.Spec.KeyRange.SafeName(),
+	}
+
+	for _, tablet := range vttabletSpecs(shard, parentLabels) {
+		wantUID := vttablet.UID(cell, keyspace, shard.Spec.KeyRange, planetscalev2.ExternalReplicaPoolType, uint32(tablet.Index))
+		if tablet.Alias.Uid != wantUID {
+			t.Errorf("tablet index %d: expected uid %v, got %v", tablet.Index, wantUID, tablet.Alias.Uid)
+		}
+		if got, ok := tablet.Labels[planetscalev2.TabletPoolNameLabel]; !ok || got != "" {
+			t.Errorf("tablet index %d: expected an empty pool name label, got %q (present %v)", tablet.Index, got, ok)
+		}
+	}
+}

--- a/pkg/operator/vttablet/spec.go
+++ b/pkg/operator/vttablet/spec.go
@@ -85,6 +85,11 @@ func (spec *Spec) poolLabels() map[string]string {
 	labels := spec.shardLabels()
 	labels[planetscalev2.CellLabel] = spec.Labels[planetscalev2.CellLabel]
 	labels[planetscalev2.TabletTypeLabel] = spec.Labels[planetscalev2.TabletTypeLabel]
+	// Pools that differ only by name are still different pools.
+	// An empty name is left out, so the selector for a pool without one does not change.
+	if poolName := spec.Labels[planetscalev2.TabletPoolNameLabel]; poolName != "" {
+		labels[planetscalev2.TabletPoolNameLabel] = poolName
+	}
 	return labels
 }
 

--- a/pkg/operator/vttablet/spec_test.go
+++ b/pkg/operator/vttablet/spec_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vttablet
+
+import (
+	"testing"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+)
+
+func TestPoolLabelsWithPoolName(t *testing.T) {
+	// A named pool must not select the other pools in its (cell,type) pair as if they were the same pool
+	spec := &Spec{Labels: map[string]string{
+		planetscalev2.ComponentLabel:      planetscalev2.VttabletComponentName,
+		planetscalev2.ClusterLabel:        "default",
+		planetscalev2.KeyspaceLabel:       "commerce",
+		planetscalev2.ShardLabel:          "x-x",
+		planetscalev2.CellLabel:           "zone1",
+		planetscalev2.TabletTypeLabel:     string(planetscalev2.ReplicaPoolType),
+		planetscalev2.TabletPoolNameLabel: "node-a",
+	}}
+
+	if got := spec.poolLabels()[planetscalev2.TabletPoolNameLabel]; got != "node-a" {
+		t.Errorf("expected pool name %q in the pool selector, got %q", "node-a", got)
+	}
+}
+
+func TestPoolLabelsWithoutPoolName(t *testing.T) {
+	// A pool with no name must keep the selector it has today, or its Pods are recreated on upgrade
+	// An ExternalDatastore pool with no name carries the label with an empty value, and still counts as unnamed
+	for _, labelValue := range []string{"", "unset"} {
+		spec := &Spec{Labels: map[string]string{
+			planetscalev2.ComponentLabel:  planetscalev2.VttabletComponentName,
+			planetscalev2.ClusterLabel:    "default",
+			planetscalev2.KeyspaceLabel:   "commerce",
+			planetscalev2.ShardLabel:      "x-x",
+			planetscalev2.CellLabel:       "zone1",
+			planetscalev2.TabletTypeLabel: string(planetscalev2.ReplicaPoolType),
+		}}
+		if labelValue != "unset" {
+			spec.Labels[planetscalev2.TabletPoolNameLabel] = labelValue
+		}
+
+		if _, ok := spec.poolLabels()[planetscalev2.TabletPoolNameLabel]; ok {
+			t.Errorf("pool name label %q: expected no pool name in the pool selector", labelValue)
+		}
+	}
+}


### PR DESCRIPTION
## Abstract

If a pool sets `name` but not `externalDatastore`, use `name` when calculating the tablet UID anyway. Today the name is only used when `externalDatastore` is set too, so two local-MySQL pools that differ only by name get the same UID and collapse into a single tablet. Pools with no `name` keep the UID they have today.

## Why

`spec.tabletPools` is a list. Each entry has a `type` (replica, rdonly, ...), a `cell`, and an optional `name`. The `name` is there to tell apart two entries that have the same type and cell:

```yaml
tabletPools:
  - {cell: zone1, type: replica, name: node-a, replicas: 1}
  - {cell: zone1, type: replica, name: node-b, replicas: 1}
```

The CRD accepts this: `tabletPools` is a listMapKey map on (type, cell, name). But the tablet UID only includes the name if the pool also sets `externalDatastore`.

Now:

    name set and externalDatastore set   md5(cell, keyspace, keyRange, type, index, name)
    anything else                        md5(cell, keyspace, keyRange, type, index)

After:

    name set                             md5(cell, keyspace, keyRange, type, index, name)
    name empty                           md5(cell, keyspace, keyRange, type, index)   unchanged

Both pools above use local MySQL, so both tablets get the same UID. That UID is used for the tablet alias, the Pod name and the PVC name, so the two entries produce one Pod and one PVC. One tablet is created and the other entry does nothing.

## How

One condition changes: the name is used whenever it is set, instead of only when `externalDatastore` is set too.

Pools that leave `name` empty - the default, and everything that exists today - get the same UID as before, so no tablets are renamed on upgrade. That includes `externalDatastore` pools with no name: `UIDWithPoolName` hashes an empty name differently from `UID`, so the empty case has to keep calling `UID`, and a test covers it.

Two things follow from a local pool having a name:

- The pool-name label is now set for named pools with local MySQL; it was already set for external ones. So `name` is validated as a label value, with the same `maxLength` and pattern a backup location name uses. Without that, a name like `rack/node` is accepted and then the API server refuses the Pod.
- The default pod anti-affinity selects on the pool name when there is one, so two pools that differ only by name are no longer scored as the same pool. Pools with no name keep the selector they have today.

Release note: a pool with local MySQL and a name gets a new UID, so a new Pod and PVC. The field docs said to set `name` only together with `externalDatastore`, and two such pools collide today, so this should affect nobody - but it is a rename if someone did it. A named `externalDatastore` pool keeps its UID, but its default anti-affinity changes, so its Pods are replaced on the next rolling update. Happy to gate either part behind an explicit opt-in.

## What we're trying to achieve

We're moving Vitess tablets from bare metal to Kubernetes, and we would rather use this operator than keep maintaining our own.

We have no network-attached storage. Tablets use the disks of the node they run on, so a tablet's data cannot follow its Pod - if the Pod is rescheduled, the data stays behind. So we need one tablet per named machine, which is one pool per machine: `replicas: 1`, `name` set to the machine, and a nodeAffinity pinning the Pod to it.

The rest already works. `affinity` is used as given, and `MasterEligibleTabletCount()` adds up `replicas` across all pools, so three pools of one replica count as three master-eligible tablets. The UID is the only thing missing.

## Issue

https://github.com/planetscale/vitess-operator/issues/795