### PR TITLE
Make the upgrade e2e test wait for the vttablet rollout to finish

### DIFF
--- a/test/endtoend/upgrade_test.sh
+++ b/test/endtoend/upgrade_test.sh
@@ -228,7 +228,7 @@ function verifyVtgateDeploymentStrategy() {
 function upgradeToLatest() {
   echo "Upgrade Vitess Operator"
   kubectl apply -f operator-latest.yaml
-  checkPodSpecBySelectorWithTimeout default "app=vitess-operator" 1 "image: vitess-operator-pr:latest"
+  checkPodSpecBySelectorWithTimeout default "app=vitess-operator" 1 '"image":"vitess-operator-pr:latest"'
   checkPodStatusWithTimeout "vitess-operator(.*)1/1(.*)Running(.*)"
 
   echo "Upgrade Vitess binaries"
@@ -240,11 +240,17 @@ function upgradeToLatest() {
   checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
 
   # Wait for the cluster spec changes to take effect
-  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vtctld" 1 "image: vitess/lite:mysql80"
-  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vtgate" 1 "image: vitess/lite:mysql80"
-  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vtgate" 1 "--tablet-refresh-interval=10s"
-  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vtorc" 1 "image: vitess/lite:mysql80"
-  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vttablet" 12 "image: vitess/lite:mysql80"
+  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vtctld" 1 '"image":"vitess/lite:mysql80"'
+  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vtgate" 1 '"image":"vitess/lite:mysql80"'
+  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vtgate" 1 '"--tablet-refresh-interval=10s"'
+  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vtorc" 1 '"image":"vitess/lite:mysql80"'
+  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vttablet" 12 '"image":"vitess/lite:mysql80"'
+
+  # The vttablet image change is applied through a scheduled rollout that
+  # recreates the pods one at a time. Wait for it to finish before going on,
+  # otherwise the following steps race against pods being recreated.
+  waitForScheduledRolloutsToFinish example "planetscale.com/cluster=example"
+  checkPodStatusWithTimeout "example-vttablet-zone1(.*)3/3(.*)Running(.*)" 3
 
   verifyVtgateDeploymentStrategy
 
@@ -257,9 +263,9 @@ function verifyResourceSpec() {
   echo "Verifying resource spec"
 
   echo "mysqld_exporter flags:"
-  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vttablet" 3 "--no-collect.info_schema.innodb_cmpmem$"
-  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vttablet" 3 "--collect.info_schema.tables$"
-  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vttablet" 3 "--collect.info_schema.tables.databases=\*$"
+  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vttablet" 3 '"--no-collect.info_schema.innodb_cmpmem"'
+  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vttablet" 3 '"--collect.info_schema.tables"'
+  checkPodSpecBySelectorWithTimeout example "planetscale.com/component=vttablet" 3 '"--collect.info_schema.tables.databases=\*"'
 }
 
 # Test setup

--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -202,6 +202,16 @@ function verifyListBackupsOutput() {
   exit 1
 }
 
+# checkPodSpecBySelectorWithTimeout:
+# $1: namespace
+# $2: pod selector
+# $3: number of matches expected
+# $4: regex matched against the pod specs, rendered as JSON (one pod per line)
+#
+# Only the pod spec is inspected, never the whole pod object. Pod spec changes
+# that the operator has scheduled but not yet applied are stored, as YAML, in
+# the rollout.planetscale.com/scheduled annotation. Grepping the whole object
+# would count those pending changes as if they were already live.
 function checkPodSpecBySelectorWithTimeout() {
   local namespace="$1"
   local pod_selector="$2"
@@ -211,9 +221,8 @@ function checkPodSpecBySelectorWithTimeout() {
   local out pods_matched
 
   for i in {1..1200}; do
-    # YAML output is convenient to grep
-    out="$(kubectl get pods --namespace="${namespace}" --selector="${pod_selector}" --output=yaml)"
-    pods_matched="$(echo "${out}" | grep -cE -- "${spec_matcher}")"
+    out="$(kubectl get pods --namespace="${namespace}" --selector="${pod_selector}" --output=jsonpath='{range .items[*]}{.spec}{"\n"}{end}')"
+    pods_matched="$(echo "${out}" | grep -oE -- "${spec_matcher}" | wc -l)"
 
     if [[ "${pods_matched}" -eq "${matches_expected}" ]]; then
       echo "${spec_matcher} found"
@@ -226,6 +235,36 @@ function checkPodSpecBySelectorWithTimeout() {
   if echo "${pod_selector}" | grep -q "vttablet"; then
     printMysqlErrorFiles
   fi
+  exit 1
+}
+
+# waitForScheduledRolloutsToFinish:
+# $1: namespace
+# $2: pod selector
+#
+# Disruptive pod spec changes (for example a new vttablet image) are not applied
+# in place. The operator stores the desired spec in the
+# rollout.planetscale.com/scheduled annotation and recreates the pods one at a
+# time, after draining each of them. This waits until no selected pod carries
+# that annotation anymore, i.e. until the rollout is complete.
+function waitForScheduledRolloutsToFinish() {
+  local namespace="$1"
+  local pod_selector="$2"
+
+  local pending
+
+  for i in {1..1200}; do
+    pending="$(kubectl get pods --namespace="${namespace}" --selector="${pod_selector}" --output=jsonpath='{.items[*].metadata.annotations}' | grep -o '"rollout.planetscale.com/scheduled"' | wc -l)"
+
+    if [[ "${pending}" -eq 0 ]]; then
+      echo "No scheduled rollouts pending for: ${pod_selector}"
+      return
+    fi
+    sleep 1
+  done
+
+  echo "ERROR: waitForScheduledRolloutsToFinish timeout, ${pending} pod(s) still have a scheduled rollout for: ${pod_selector}"
+  kubectl get pods --namespace="${namespace}" --selector="${pod_selector}" --output=yaml
   exit 1
 }
 


### PR DESCRIPTION
## Problem

The Upgrade Test in the end-to-end workflow fails intermittently with:

```
cannot switch traffic for workflow commerce2customer at this time: could not refresh all of the tablets involved in the operation:
  failed to refresh tablet zone1-2548885007: Code: DEADLINE_EXCEEDED
rpc error: code = DeadlineExceeded desc = ... dial tcp 10.244.0.21:15999: i/o timeout
SwitchTraffic for rdonly and replica failed
```

Recent examples: [main, 2026-08-28](https://github.com/planetscale/vitess-operator/actions/runs/33205964180) and [#822](https://github.com/planetscale/vitess-operator/actions/runs/33773107495/job/100708040442).

The commerce replica tablet was being deleted and recreated by the operator at the exact moment `SwitchTraffic` tried to refresh it. The operator was still in the middle of rolling out the new vttablet image from `cluster_upgrade.yaml`, but the test had already moved on to `MoveTables`.

## Root cause

`upgradeToLatest` waits for the new image with `checkPodSpecBySelectorWithTimeout`, which greps the full YAML of the pods for `image: vitess/lite:mysql80` and expects 12 matches across the three commerce tablet pods.

The operator applies vttablet image changes through a scheduled rollout: it stores the desired spec in the `rollout.planetscale.com/scheduled` annotation and recreates the pods one at a time after draining each of them. That annotation contains the same four image lines per pod, so the count reaches 12 as soon as the rollout is scheduled, before any pod has actually been recreated. The cluster-state dump from the failed run shows the commerce primary still running `v23.0.6` with the scheduled-rollout annotation on it while the test was already running `SwitchTraffic`.

## Fix

- `checkPodSpecBySelectorWithTimeout` now renders only the pod spec, as JSON via jsonpath, and counts matcher occurrences in that. Pending rollouts stored in annotations are no longer counted. The matchers in `upgrade_test.sh` are updated to the JSON form, which also makes the argument matches exact without needing `$` anchors.
- New `waitForScheduledRolloutsToFinish` helper waits until no pod in the selector carries the `rollout.planetscale.com/scheduled` annotation.
- `upgradeToLatest` calls it, then re-checks that all three tablet pods are `3/3 Running`, before continuing.

The jsonpath rendering was verified against client-go's jsonpath package with a fake pod list: the spec renders as compact JSON (`"image":"..."`), images pending in the annotation are not counted, and args match exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cadbQ27mzMNqqKD8c4YcC
