### PR TITLE
Expose vtbackup metrics on the default web port

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [Overview](docs/)
 - [Getting Started on AWS](docs/aws-quickstart.md)
 - [Getting Started on GCP](docs/gcp-quickstart.md)
+- [Scheduled vtbackup metrics](docs/vtbackup-metrics.md)
 - [VitessCluster CRD API Reference](docs/api.md)
 
 ## Compatibility
@@ -68,4 +69,3 @@ make build IMAGE_NAME=your.registry/vitess/operator
 
 If you would like to contribute to this project, please refer to the
 [contributing readme](CONTRIBUTING.md)
-

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -18,6 +18,11 @@ The configuration for your Vitess cluster is recorded in a single configuration 
 
 The operator implements applied changes in the configuration file for your Vitess cluster.
 
+## Scrape metrics from scheduled vtbackup Jobs.
+
+See [Scraping scheduled vtbackup metrics](vtbackup-metrics.md) for the
+configuration and Prometheus Operator example.
+
 ## The Vitess Operator is open source.
 
 The Vitess Operator is on [GitHub](https://github.com/planetscale/vitess-operator). See the repository for information on licensing and contribution.

--- a/docs/vtbackup-metrics.md
+++ b/docs/vtbackup-metrics.md
@@ -1,0 +1,118 @@
+# Scraping scheduled vtbackup metrics
+
+Scheduled backups that use `backupMethod: vtbackup` run a short-lived
+`vtbackup` Pod. The process serves Prometheus metrics at `/metrics` through
+its HTTP server.
+
+## Configure the HTTP port
+
+The operator configures vtbackup to use the standard Vitess web port, `15000`,
+by default. Set the existing `vttablet.vtbackupExtraFlags` field on the tablet
+pool template to choose a different port:
+
+```yaml
+spec:
+  keyspaces:
+    - name: commerce
+      partitionings:
+        - equal:
+            parts: 1
+            shardTemplate:
+              tabletPools:
+                - cell: zone1
+                  type: replica
+                  vttablet:
+                    vtbackupExtraFlags:
+                      port: "18080"
+```
+
+The generated vtbackup container declares the configured value as the named
+`web` TCP port. The setting is copied to scheduled vtbackup Jobs from the
+tablet pool template used to build the backup Pod. If `port` is omitted, the
+operator uses `15000`. Set `port: "0"` explicitly to retain vtbackup's
+ephemeral behavior and omit the container-port declaration.
+
+Avoid assigning a port already used by another container in the same Pod,
+because containers share a network namespace.
+
+## Prometheus annotations
+
+`VitessBackupSchedule.spec.annotations` is copied to generated Jobs and Pod
+templates. For annotation-based Prometheus discovery, configure the schedule
+as follows:
+
+```yaml
+spec:
+  backup:
+    schedules:
+      - name: daily
+        backupMethod: vtbackup
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "15000"
+          prometheus.io/path: "/metrics"
+```
+
+The annotation port must match the `port` value passed to vtbackup.
+
+## Prometheus Operator `PodMonitor`
+
+The controller labels scheduled vtbackup Jobs and their Pod templates with
+`planetscale.com/component: vtbackup` and
+`planetscale.com/backup-method: vtbackup`. A `PodMonitor` can select those
+Pods and target the named port:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: vitess-vtbackup
+  namespace: example
+spec:
+  namespaceSelector:
+    matchNames:
+      - example
+  selector:
+    matchLabels:
+      planetscale.com/component: vtbackup
+      planetscale.com/backup-method: vtbackup
+  podMetricsEndpoints:
+    - port: web
+      path: /metrics
+      interval: 30s
+```
+
+Because backup Pods normally exit after the backup completes, a short-lived
+Pod may finish before a scrape occurs. Set `keep-alive-timeout` through the
+same existing vtbackup flag map when final metrics need to remain available:
+
+```yaml
+spec:
+  keyspaces:
+    - name: commerce
+      partitionings:
+        - equal:
+            parts: 1
+            shardTemplate:
+              tabletPools:
+                - cell: zone1
+                  type: replica
+                  vttablet:
+                    vtbackupExtraFlags:
+                      port: "15000"
+                      keep-alive-timeout: "60s"
+  backup:
+    schedules:
+      - name: daily
+        backupMethod: vtbackup
+        jobTimeoutMinute: 15
+```
+
+Choose a keep-alive duration of at least twice the Prometheus scrape interval
+when possible. The duration counts toward `jobTimeoutMinute`, and
+`keep-alive-timeout` only runs after a successful backup; failed backups exit
+without waiting for the keep-alive period.
+
+Do not set `stats_backend: prometheus` for vtbackup. That setting selects a
+push-style backend and can cause vtbackup to wait for a backend that is not
+registered. The HTTP endpoint and `/metrics` path work without it.

--- a/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
+++ b/pkg/controller/vitessbackupschedule/vitessbackupschedule_controller.go
@@ -656,6 +656,9 @@ func (r *ReconcileVitessBackupsSchedule) createJob(
 		planetscalev2.ShardLabel:          vkr.SafeName(),
 		planetscalev2.BackupMethodLabel:   string(method),
 	}
+	if method == planetscalev2.BackupMethodVtbackup {
+		labels[planetscalev2.ComponentLabel] = planetscalev2.VtbackupComponentName
+	}
 
 	meta := metav1.ObjectMeta{
 		Labels:      maps.Clone(labels),

--- a/pkg/controller/vitessbackupschedule/vtctldclient_backup_test.go
+++ b/pkg/controller/vitessbackupschedule/vtctldclient_backup_test.go
@@ -286,6 +286,8 @@ func TestCreateJob_VtctldclientMethodNoPVC(t *testing.T) {
 
 	// Verify the backup-method label is set
 	assert.Equal(t, string(planetscalev2.BackupMethodVtctldclient), job.Labels[planetscalev2.BackupMethodLabel])
+	assert.NotContains(t, job.Labels, planetscalev2.ComponentLabel)
+	assert.NotContains(t, job.Spec.Template.Labels, planetscalev2.ComponentLabel)
 
 	// Verify no PVC was created
 	pvcList := &corev1.PersistentVolumeClaimList{}
@@ -353,6 +355,9 @@ func TestCreateJob_VtbackupMethodCreatesPVC(t *testing.T) {
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
 			UID:               types.UID("test-uid"),
 			ResourceVersion:   "1",
+			Labels: map[string]string{
+				planetscalev2.ComponentLabel: "user-value",
+			},
 		},
 		Spec: planetscalev2.VitessBackupScheduleSpec{
 			Cluster: "example",
@@ -377,6 +382,8 @@ func TestCreateJob_VtbackupMethodCreatesPVC(t *testing.T) {
 
 	// Verify the backup-method label is set
 	assert.Equal(t, string(planetscalev2.BackupMethodVtbackup), job.Labels[planetscalev2.BackupMethodLabel])
+	assert.Equal(t, planetscalev2.VtbackupComponentName, job.Labels[planetscalev2.ComponentLabel])
+	assert.Equal(t, planetscalev2.VtbackupComponentName, job.Spec.Template.Labels[planetscalev2.ComponentLabel])
 
 	// Verify a PVC was created
 	pvcList := &corev1.PersistentVolumeClaimList{}
@@ -508,6 +515,8 @@ func TestCreateJob_DefaultMethodIsVtbackup(t *testing.T) {
 
 	// Should have defaulted to vtbackup
 	assert.Equal(t, string(planetscalev2.BackupMethodVtbackup), job.Labels[planetscalev2.BackupMethodLabel])
+	assert.Equal(t, planetscalev2.VtbackupComponentName, job.Labels[planetscalev2.ComponentLabel])
+	assert.Equal(t, planetscalev2.VtbackupComponentName, job.Spec.Template.Labels[planetscalev2.ComponentLabel])
 
 	// Verify a PVC was created (vtbackup behavior)
 	pvcList := &corev1.PersistentVolumeClaimList{}

--- a/pkg/operator/vttablet/backup.go
+++ b/pkg/operator/vttablet/backup.go
@@ -96,6 +96,7 @@ func init() {
 		}
 		flags := vitess.Flags{
 			"backup_engine_implementation": string(spec.BackupEngine),
+			"port":                         planetscalev2.DefaultWebPort,
 		}
 		if spec.BackupEngine == planetscalev2.VitessBackupEngineXtraBackup {
 			// A vtbackup Pod is given the same resources as the mysqld

--- a/pkg/operator/vttablet/vtbackup_pod.go
+++ b/pkg/operator/vttablet/vtbackup_pod.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vttablet
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"planetscale.dev/vitess-operator/pkg/operator/mysql"
+	"planetscale.dev/vitess-operator/pkg/operator/vitess"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
@@ -89,6 +91,26 @@ func BackupPodName(clusterName, keyspaceName string, keyRange planetscalev2.Vite
 // InitialBackupPodName returns the name of the Pod for an initial vtbackup job.
 func InitialBackupPodName(clusterName, keyspaceName string, keyRange planetscalev2.VitessKeyRange) string {
 	return names.JoinWithConstraints(names.DefaultConstraints, clusterName, keyspaceName, keyRange.SafeName(), planetscalev2.VtbackupComponentName, "init")
+}
+
+func vtbackupContainerPorts(flags vitess.Flags) []corev1.ContainerPort {
+	rawPort, ok := flags["port"]
+	if !ok {
+		return nil
+	}
+
+	port, err := strconv.ParseInt(fmt.Sprint(rawPort), 10, 32)
+	if err != nil || port < 1 || port > 65535 {
+		return nil
+	}
+
+	return []corev1.ContainerPort{
+		{
+			Name:          planetscalev2.DefaultWebPortName,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(port),
+		},
+	}
 }
 
 // BackupPodDataVolume returns the effective vtbackup data-volume mount and
@@ -178,6 +200,7 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec, mysqldImage stri
 		vtbackupAllFlags["builtinbackup-incremental-restore-path"] = vtDataRootPath
 	}
 	mysql.UpdateMySQLServerVersion(vtbackupAllFlags, mysqldImage)
+	containerPorts := vtbackupContainerPorts(vtbackupAllFlags)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   key.Namespace,
@@ -218,6 +241,7 @@ func NewBackupPod(key client.ObjectKey, backupSpec *BackupSpec, mysqldImage stri
 					ImagePullPolicy: tabletSpec.ImagePullPolicies.Mysqld,
 					Command:         []string{vtbackupCommand},
 					Args:            vtbackupAllFlags.FormatArgs(),
+					Ports:           containerPorts,
 					Resources:       containerResources,
 					SecurityContext: securityContext,
 					Env:             env,

--- a/pkg/operator/vttablet/vtbackup_pod_test.go
+++ b/pkg/operator/vttablet/vtbackup_pod_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 PlanetScale Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vttablet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	planetscalev2 "planetscale.dev/vitess-operator/pkg/apis/planetscale/v2"
+)
+
+func TestNewBackupPodContainerPorts(t *testing.T) {
+	tests := []struct {
+		name       string
+		extraFlags map[string]string
+		want       []corev1.ContainerPort
+	}{
+		{
+			name: "port not specified",
+			want: nil,
+		},
+		{
+			name:       "port specified",
+			extraFlags: map[string]string{"port": "15000"},
+			want: []corev1.ContainerPort{{
+				Name:          planetscalev2.DefaultWebPortName,
+				Protocol:      corev1.ProtocolTCP,
+				ContainerPort: 15000,
+			}},
+		},
+		{
+			name:       "custom port specified",
+			extraFlags: map[string]string{"port": "18080"},
+			want: []corev1.ContainerPort{{
+				Name:          planetscalev2.DefaultWebPortName,
+				Protocol:      corev1.ProtocolTCP,
+				ContainerPort: 18080,
+			}},
+		},
+		{
+			name:       "invalid port",
+			extraFlags: map[string]string{"port": "0"},
+			want:       nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tabletSpec := &Spec{
+				Images: planetscalev2.VitessKeyspaceImages{
+					Mysqld: &planetscalev2.MysqldImage{
+						Mysql80Compatible: "mysql:8.0.40",
+					},
+				},
+				Vttablet: &planetscalev2.VttabletSpec{
+					VtbackupExtraFlags: test.extraFlags,
+				},
+				Mysqld: &planetscalev2.MysqldSpec{},
+				BackupLocation: &planetscalev2.VitessBackupLocation{
+					Volume: &corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			}
+			pod := NewBackupPod(
+				client.ObjectKey{Namespace: "default", Name: "backup"},
+				&BackupSpec{TabletSpec: tabletSpec},
+				"mysql:8.0.40",
+			)
+
+			require.Len(t, pod.Spec.Containers, 1)
+			assert.Equal(t, test.want, pod.Spec.Containers[0].Ports)
+		})
+	}
+}

--- a/pkg/operator/vttablet/vtbackup_pod_test.go
+++ b/pkg/operator/vttablet/vtbackup_pod_test.go
@@ -29,17 +29,14 @@ import (
 
 func TestNewBackupPodContainerPorts(t *testing.T) {
 	tests := []struct {
-		name       string
-		extraFlags map[string]string
-		want       []corev1.ContainerPort
+		name        string
+		extraFlags  map[string]string
+		wantPortArg string
+		want        []corev1.ContainerPort
 	}{
 		{
-			name: "port not specified",
-			want: nil,
-		},
-		{
-			name:       "port specified",
-			extraFlags: map[string]string{"port": "15000"},
+			name:        "port defaults to web port",
+			wantPortArg: "--port=15000",
 			want: []corev1.ContainerPort{{
 				Name:          planetscalev2.DefaultWebPortName,
 				Protocol:      corev1.ProtocolTCP,
@@ -47,8 +44,19 @@ func TestNewBackupPodContainerPorts(t *testing.T) {
 			}},
 		},
 		{
-			name:       "custom port specified",
-			extraFlags: map[string]string{"port": "18080"},
+			name:        "port specified",
+			extraFlags:  map[string]string{"port": "15000"},
+			wantPortArg: "--port=15000",
+			want: []corev1.ContainerPort{{
+				Name:          planetscalev2.DefaultWebPortName,
+				Protocol:      corev1.ProtocolTCP,
+				ContainerPort: 15000,
+			}},
+		},
+		{
+			name:        "custom port specified",
+			extraFlags:  map[string]string{"port": "18080"},
+			wantPortArg: "--port=18080",
 			want: []corev1.ContainerPort{{
 				Name:          planetscalev2.DefaultWebPortName,
 				Protocol:      corev1.ProtocolTCP,
@@ -56,9 +64,10 @@ func TestNewBackupPodContainerPorts(t *testing.T) {
 			}},
 		},
 		{
-			name:       "invalid port",
-			extraFlags: map[string]string{"port": "0"},
-			want:       nil,
+			name:        "port zero disables the declared port",
+			extraFlags:  map[string]string{"port": "0"},
+			wantPortArg: "--port=0",
+			want:        nil,
 		},
 	}
 
@@ -90,6 +99,7 @@ func TestNewBackupPodContainerPorts(t *testing.T) {
 			)
 
 			require.Len(t, pod.Spec.Containers, 1)
+			assert.Contains(t, pod.Spec.Containers[0].Args, test.wantPortArg)
 			assert.Equal(t, test.want, pod.Spec.Containers[0].Ports)
 		})
 	}

--- a/pkg/operator/vttablet/vtbackup_pod_test.go
+++ b/pkg/operator/vttablet/vtbackup_pod_test.go
@@ -65,6 +65,9 @@ func TestNewBackupPodContainerPorts(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tabletSpec := &Spec{
+				Labels: map[string]string{
+					planetscalev2.ClusterLabel: "example",
+				},
 				Images: planetscalev2.VitessKeyspaceImages{
 					Mysqld: &planetscalev2.MysqldImage{
 						Mysql80Compatible: "mysql:8.0.40",


### PR DESCRIPTION
## Summary

- Configure generated `vtbackup` Pods to use the standard Vitess web port, `15000`, by default.
- Declare the effective vtbackup HTTP port as a named `web` TCP container port.
- Preserve `vttablet.vtbackupExtraFlags.port` overrides, including `port: "0"` as an explicit ephemeral-port escape hatch with no declared container port.
- Label scheduled vtbackup Jobs and Pod templates with `planetscale.com/component: vtbackup` while leaving `vtctldclient` Jobs unmarked.
- Add focused tests and a user-facing metrics guide.

## Context

Related to #825. `vtbackup` starts an HTTP server and serves Prometheus metrics at `/metrics`, but scheduled backup Pods need a predictable, declared port for Prometheus Operator named-port discovery.

The operator now passes `--port=15000` by default. Existing `vttablet.vtbackupExtraFlags.port` values override that default, including `port: "0"` for deployments that need ephemeral listening. The generated `web` container port always matches the effective vtbackup port when that port is valid.

## Behavior

- No port override: vtbackup receives `--port=15000` and the container declares `web/TCP/15000`.
- Custom override such as `port: "18080"`: vtbackup receives that value and the declared `web` port matches it.
- `port: "0"`: vtbackup uses an ephemeral port and the container does not declare a port.
- Invalid port values such as `"-1"`, `"65536"`, or `"not-a-port"` remain unchanged in vtbackup's arguments but do not produce a Kubernetes container-port declaration.
- Scheduled vtbackup Jobs and Pod templates receive `planetscale.com/component: vtbackup` after the effective backup method is resolved, including an omitted method that defaults to vtbackup. Generated labels take precedence over conflicting user labels; `vtctldclient` Jobs do not receive the controller-generated component label.

## Prometheus discovery and operations

Existing schedule annotations remain supported, and users provide their own discovery resources: the operator does not create a Service or `PodMonitor`. The documentation includes annotation-based discovery and a `PodMonitor` targeting `port: web`; applicable NetworkPolicies must allow Prometheus to reach the backup Pod on the declared port.

Scheduled vtbackup Pods are short-lived, per-Pod metric series. The guide documents `keep-alive-timeout`, which runs only after successful backups, should generally be at least twice the scrape interval, and counts toward `jobTimeoutMinute` (or use `-1` to disable the timeout when appropriate). It also covers recording rules for retaining final values, phase gauges returning to zero before successful keep-alive begins, and why `--stats-backend=prometheus` should not be configured.

The PodMonitor example selects both `planetscale.com/component: vtbackup` and `planetscale.com/backup-method: vtbackup`, avoiding initial-backup Pods. A component-only selector also matches initial-backup Pods; users can add `planetscale.com/backup-schedule: <schedule-name>` to narrow selection to one scheduled backup.

No new CRD fields, Service, operator-managed PodMonitor, or default keep-alive behavior is introduced. Full configuration is documented in [Scraping scheduled vtbackup metrics](docs/vtbackup-metrics.md).

## Testing

- `go test -count=1 ./pkg/operator/vttablet ./pkg/controller/vitessbackupschedule ./pkg/controller/vitessshard`
- Port tests cover default, custom, ephemeral, negative, out-of-range, and non-numeric values.
- CI workflows cover unit, integration, upgrade, backup schedule, backup restore, generated files, and DCO.
